### PR TITLE
Gbdsci 5052/expire inactive task instances

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/fsm/distributor_instance.py
+++ b/jobmon_server/src/jobmon/server/web/routes/fsm/distributor_instance.py
@@ -7,7 +7,6 @@ from flask import jsonify, request
 from sqlalchemy import func, select
 import structlog
 
-from jobmon.core.constants import WorkflowRunStatus
 from jobmon.server.web.models.api import (
     Batch,
     DistributorInstance,

--- a/tests/distributor/conftest.py
+++ b/tests/distributor/conftest.py
@@ -113,10 +113,10 @@ def distributor_crud(db_engine):
 @pytest.fixture
 def initialize_distributor(requester_no_retry):
 
-    def _initialize(distributor_id):
+    def _initialize(distributor_id, cluster='dummy'):
         # Initialize a distributor object
 
-        distributor = ClientDistributor(cluster_name='dummy', requester=requester_no_retry,
+        distributor = ClientDistributor(cluster_name=cluster, requester=requester_no_retry,
                                         raise_on_error=True)
         distributor._distributor_instance_id = distributor_id
 

--- a/tests/distributor/test_synchronization.py
+++ b/tests/distributor/test_synchronization.py
@@ -125,3 +125,9 @@ def test_expiring_workflow_runs(requester_in_memory, requester_no_retry,
     assert len(distributor._batches) == 1
     assert len(distributor._task_instances) == 1
     assert len(distributor._task_instance_status_map[TaskInstanceStatus.QUEUED]) == 1
+
+    # Check that a subsequent sync call does not reload the expired instances
+    distributor.refresh_status_from_db(TaskInstanceStatus.QUEUED)
+    assert len(distributor._batches) == 1
+    assert len(distributor._task_instances) == 1
+    assert len(distributor._task_instance_status_map[TaskInstanceStatus.QUEUED]) == 1


### PR DESCRIPTION
The distributor should not consider task instances belonging to inactive workflow runs for any monitoring or launching work. This PR adds an endpoint to return registered batches associated with inactive workflow runs, and purge the distributor's memory space. 