### PR TITLE
Gbdsci 5460 task groups

### DIFF
--- a/jobmon_client/src/jobmon/client/task.py
+++ b/jobmon_client/src/jobmon/client/task.py
@@ -344,6 +344,16 @@ class Task:
             )
         return self._workflow
 
+    @property
+    def labels(self) -> Dict[str, Any]:
+        """Return the label map for the Task."""
+        return dict(
+            **self.task_attributes,
+            **self.task_args,
+            **self.node.node_args,
+            task_template_name=self.node.task_template_version.task_template.template_name,
+        )
+
     @workflow.setter
     def workflow(self, val: Workflow) -> None:
         self._workflow = val

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -166,7 +166,7 @@ class TaskGroup:
             for key, upstream_key in dependency_specification.items():
                 if key in task.labels:
                     label_value = task.labels[key]
-                    matches.intersection(upstream_label_map[upstream_key][label_value])
+                    matches.intersection_update(upstream_label_map[upstream_key][label_value])
             task.add_upstreams(list(matches))
 
     def interleave_downstream(

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -2,31 +2,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Union
-
-
-class Task:
-
-    def __init__(self, labels: Dict):
-        self.labels = labels
-        self.upstream_tasks: Set[Task] = set()
-        self.dowstream_tasks: Set[Task] = set()
-
-    def add_label(self, label_name, label_value):
-        self.labels[label_name] = label_value
-
-    def add_upstream(self, task: Task):
-        self.upstream_tasks.add(task)
-
-    def add_upstreams(self, tasks: List[Task]):
-        for task in tasks:
-            self.add_upstream(task)
-
-    def add_downstream(self, task: Task):
-        self.dowstream_tasks.add(task)
-
-    def add_downstreams(self, tasks: List[Task]):
-        for task in tasks:
-            self.add_downstream(task)
+from jobmon.client.task import Task
 
 
 def get_label_map(

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -84,10 +84,12 @@ class TaskGroup:
     def add_labels(self, label_dict: Dict, subsetter: Optional[Dict] = None):
         if subsetter is not None:
             tasks = self.get_subset(**subsetter)
+            if not tasks:
+                raise ValueError("No matching tasks in this TaskGroup.")
         else:
             tasks = self.tasks
         for label_name, label_value in label_dict.items():
-            [task.add_label(label_name, label_value) for task in tasks]
+            [task.add_attribute(label_name, label_value) for task in tasks]
 
     def union(self, other: TaskGroup, new_name: str = "") -> TaskGroup:
         """Combine two task groups."""

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -40,8 +40,10 @@ def subset_by_label(
         # convert it to a list with a single element
         if isinstance(values, str):
             iter_values: List[Union[str, int]] = [values]
-        if not isinstance(values, Iterable):
+        elif not isinstance(values, Iterable):
             iter_values = [values]
+        else:
+            iter_values = list(values)
 
         if label in label_map:
             # Iterate over all values and increment the number of matches for matching tasks

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -119,7 +119,10 @@ class TaskGroup:
         """
         tasks = list(self.get_subset(**kwargs))
 
-        if len(tasks) != 1:
+        if len(tasks) == 0:
+            raise ValueError("No matching tasks in this TaskGroup.")
+
+        if len(tasks) > 1:
             raise ValueError("Provided labels do not uniquely identify a task.")
 
         return tasks[0]

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -15,8 +15,9 @@ def get_label_map(
 
     for task in tasks:
         for label in labels:
-            val = task.labels[label]
-            label_map[label][val].add(task)
+            if label in task.labels:
+                val = task.labels[label]
+                label_map[label][val].add(task)
 
     return dict(label_map)
 
@@ -41,10 +42,11 @@ def subset_by_label(
         if not isinstance(values, Iterable):
             iter_values = [values]
 
-        # Iterate over all values and increment the number of matches for matching tasks
-        for val in iter_values:
-            for match in label_map[label][val]:
-                num_matches[match] += 1
+        if label in label_map:
+            # Iterate over all values and increment the number of matches for matching tasks
+            for val in iter_values:
+                for match in label_map[label][val]:
+                    num_matches[match] += 1
 
     # Create a set of all tasks that have a number of matches equal to the number of labels in
     # the subsetter
@@ -162,8 +164,9 @@ class TaskGroup:
         for task in tasks:
             matches = upstream_tasks.copy()
             for key, upstream_key in dependency_specification.items():
-                label_value = task.labels[key]
-                matches.intersection(upstream_label_map[upstream_key][label_value])
+                if key in task.labels:
+                    label_value = task.labels[key]
+                    matches.intersection(upstream_label_map[upstream_key][label_value])
             task.add_upstreams(list(matches))
 
     def interleave_downstream(

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -177,6 +177,8 @@ class TaskGroup:
                     matches.intersection_update(
                         upstream_label_map[upstream_key][label_value]
                     )
+                else:
+                    matches = set()
             if matches:
                 matched_upstreams.update(matches)
                 matched_downstreams.add(task)

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+from collections import defaultdict
+
+from typing import Dict, Iterable, Iterator, List, Optional, Set, Union
+
+
+class Task:
+
+    def __init__(self, labels: Dict):
+        self.labels = labels
+        self.upstream_tasks: Set[Task] = set()
+        self.dowstream_tasks: Set[Task] = set()
+
+    def add_label(self, label_name, label_value):
+        self.labels[label_name] = label_value
+
+    def add_upstream(self, task: Task):
+        self.upstream_tasks.add(task)
+
+    def add_upstreams(self, tasks: List[Task]):
+        for task in tasks:
+            self.add_upstream(task)
+
+    def add_downstream(self, task: Task):
+        self.dowstream_tasks.add(task)
+
+    def add_downstreams(self, tasks: List[Task]):
+        for task in tasks:
+            self.add_downstream(task)
+
+
+def get_label_map(
+    tasks: Set[Task],
+    labels: List[str]
+) -> Dict[str, Dict[Union[str, int], Set[Task]]]:
+    """Build up a mapping of tasks by label."""
+    label_map: Dict[str, Dict[Union[str, int], Set[Task]]] \
+        = defaultdict(lambda: defaultdict(set))
+
+    for task in tasks:
+        for label in labels:
+            val = task.labels[label]
+            label_map[label][val].add(task)
+
+    return dict(label_map)
+
+
+def subset_by_label(
+    label_map: Dict[str, Dict[Union[str, int], Set[Task]]],
+    subsetter: Dict[str, Union[str, int, List[Union[str, int]]]],
+) -> Set[Task]:
+    # Create a dictionary to keep track of the number of matches for each task
+    num_matches: Dict[Task, int] = {
+        value: 0
+        for val_dict in label_map.values()
+        for task_set in val_dict.values()
+        for value in task_set
+    }
+
+    # Iterate over all labels and values in the subsetter
+    for label, values in subsetter.items():
+        # convert it to a list with a single element
+        if isinstance(values, str):
+            iter_values: List[Union[str, int]] = [values]
+        if not isinstance(values, Iterable):
+            iter_values = [values]
+
+        # Iterate over all values and increment the number of matches for matching tasks
+        for val in iter_values:
+            for match in label_map[label][val]:
+                num_matches[match] += 1
+
+    # Create a set of all tasks that have a number of matches equal to the number of labels in
+    # the subsetter
+    all_matches = set(
+        task for task, matches in num_matches.items()
+        if matches == len(subsetter.keys())
+    )
+    return all_matches
+
+
+# Stubs
+class TaskGroup:
+    """TaskGroup stub."""
+
+    tasks: Set[Task]
+    name: str
+
+    def __init__(self, tasks: Iterable[Task], name: str = ""):
+        self.tasks = set(tasks)
+        self.name = name
+
+    def add_task(self, task: Task):
+        """Adds a task to the group."""
+        self.tasks.add(task)
+
+    def add_tasks(self, tasks: Iterable[Task]):
+        """Adds multiple tasks to the group."""
+        for task in tasks:
+            self.add_task(task)
+
+    def add_labels(self, label_dict: Dict, subsetter: Optional[Dict] = None):
+        if subsetter is not None:
+            tasks = self.get_subset(**subsetter)
+        else:
+            tasks = self.tasks
+        for label_name, label_value in label_dict.items():
+            [task.add_label(label_name, label_value) for task in tasks]
+
+    def union(self, other: TaskGroup, new_name: str = "") -> TaskGroup:
+        """Combine two task groups."""
+        return TaskGroup(self.tasks | other.tasks, new_name)
+
+    def get_subset(self, **kwargs) -> Set[Task]:
+        # build up a mapping of tasks by label
+        label_map = get_label_map(self.tasks, list(kwargs.keys()))
+        return subset_by_label(label_map, kwargs)
+
+    def get_subgroup(
+        self,
+        empty_okay: bool = False,
+        new_name: str = "",
+        **kwargs
+    ) -> TaskGroup:
+        """probably the same implementation details as workflow.get_tasks_by_node_args
+
+        kwargs can be task arguments or attributes.
+
+        raises an error if the group is empty and empty_okay is False.
+        """
+        tasks = self.get_subset(**kwargs)
+
+        if not tasks and not empty_okay:
+            raise ValueError("No matching tasks in this TaskGroup.")
+
+        return TaskGroup(tasks, new_name)
+
+    def get_task(self, **kwargs) -> Task:
+        """Raises an error if it doesn't uniquely identify a task.
+
+        kwargs can be task arguments or attributes.
+        """
+        tasks = list(self.get_subset(**kwargs))
+
+        if len(tasks) != 1:
+            raise ValueError("Provided labels do not uniquely identify a task.")
+
+        return tasks[0]
+
+    def interleave_upstream(
+        self,
+        upstream_group: TaskGroup,
+        dependency_specification: Dict[str, str],
+        subsetter: Optional[Dict] = None,
+        upstream_subsetter: Optional[Dict] = None,
+    ):
+        """Set interleaving dependencies between TaskGroups via label value matching.
+
+        Dependencies are set between tasks where the values in all the specified labels match
+        and the interleaved tasks fulfill any specified subset criteria.
+
+        Args:
+            upstream_group: The task group to interleave dependencies from.
+            dependency_specification: A dictionary mapping label names between groups. Keys
+                are labels on tasks in this group, and values are labels in tasks in the
+                upstream_group.
+            subsetter: A dictionary used to subset the tasks of the current TaskGroup by
+                filtering label keys and values based on the supplied dict.
+            upstream_subsetter: A dictionary used to subset the tasks of the upstream TaskGroup
+                by filtering label keys and values based on the supplied dict.
+        """
+
+        # get the set of tasks for this TaskGroup based on the provided subsetter
+        if subsetter is not None:
+            tasks = self.get_subset(**subsetter)
+        else:
+            tasks = self.tasks
+
+        # get the set of tasks for this TaskGroup based on the provided subsetter
+        if upstream_subsetter is not None:
+            upstream_tasks = upstream_group.get_subset(**upstream_subsetter)
+        else:
+            upstream_tasks = upstream_group.tasks
+        upstream_label_map = get_label_map(
+            upstream_tasks, list(dependency_specification.values())
+        )
+
+        for task in tasks:
+            matches = upstream_tasks.copy()
+            for key, upstream_key in dependency_specification.items():
+                label_value = task.labels[key]
+                matches.intersection(upstream_label_map[upstream_key][label_value])
+            task.add_upstreams(list(matches))
+
+    def interleave_downstream(
+        self,
+        upstream_group: TaskGroup,
+        dependency_specification: Dict[str, str],
+        subsetter: Optional[Dict] = None,
+        upstream_subsetter: Optional[Dict] = None,
+    ):
+        pass
+
+    def __iter__(self) -> Iterator[Task]:
+        for task in self.tasks:
+            yield task
+
+    def __or__(self, other_group: TaskGroup) -> TaskGroup:
+        """Combine two groups."""
+        return self.union(other_group)
+
+    def __len__(self) -> int:
+        return len(self.tasks)

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -6,12 +6,12 @@ from jobmon.client.task import Task
 
 
 def get_label_map(
-    tasks: Set[Task],
-    labels: List[str]
+    tasks: Set[Task], labels: List[str]
 ) -> Dict[str, Dict[Union[str, int], Set[Task]]]:
     """Build up a mapping of tasks by label."""
-    label_map: Dict[str, Dict[Union[str, int], Set[Task]]] \
-        = defaultdict(lambda: defaultdict(set))
+    label_map: Dict[str, Dict[Union[str, int], Set[Task]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
 
     for task in tasks:
         for label in labels:
@@ -49,7 +49,8 @@ def subset_by_label(
     # Create a set of all tasks that have a number of matches equal to the number of labels in
     # the subsetter
     all_matches = set(
-        task for task, matches in num_matches.items()
+        task
+        for task, matches in num_matches.items()
         if matches == len(subsetter.keys())
     )
     return all_matches
@@ -93,10 +94,7 @@ class TaskGroup:
         return subset_by_label(label_map, kwargs)
 
     def get_subgroup(
-        self,
-        empty_okay: bool = False,
-        new_name: str = "",
-        **kwargs
+        self, empty_okay: bool = False, new_name: str = "", **kwargs
     ) -> TaskGroup:
         """probably the same implementation details as workflow.get_tasks_by_node_args
 

--- a/jobmon_client/src/jobmon/client/task_group.py
+++ b/jobmon_client/src/jobmon/client/task_group.py
@@ -89,7 +89,8 @@ class TaskGroup:
         else:
             tasks = self.tasks
         for label_name, label_value in label_dict.items():
-            [task.add_attribute(label_name, label_value) for task in tasks]
+            for task in tasks:
+                task.add_attribute(label_name, label_value)
 
     def union(self, other: TaskGroup, new_name: str = "") -> TaskGroup:
         """Combine two task groups."""

--- a/jobmon_gui/src/task_details_page/task_instance_table.tsx
+++ b/jobmon_gui/src/task_details_page/task_instance_table.tsx
@@ -130,15 +130,6 @@ export default function TaskInstanceTable({ taskInstanceData }) {
             sort: true,
             sortCaret: customCaret,
             style: { overflowWrap: 'break-word' },
-        },
-        {
-            dataField: "ti_error_log_description",
-            text: "Error Log",
-            sort: true,
-            sortCaret: customCaret,
-            style: { overflowWrap: 'break-word' },
-            headerStyle: { width: "30%" },
-
         }
     ]
 

--- a/tests/client/test_task.py
+++ b/tests/client/test_task.py
@@ -429,3 +429,24 @@ def test_default_max_attemps(db_engine, client_env, tool):
     # test wf always have a default max attempts so existing code works
     wf5 = tool.create_workflow(default_max_attempts=None)
     assert wf5.default_max_attempts == tool.default_max_attempts is not None
+
+
+def test_labels(tool):
+    """Assert that labels contains all node args, task args and attributes."""
+    tt = tool.get_task_template(
+        template_name="test_tt1",
+        command_template="true|| abc {arg1} {arg2}",
+        node_args=["arg1"],
+        task_args=["arg2"],
+    )
+
+    task = tt.create_task(
+        name="task1",
+        arg1="arg1_1",
+        arg2="arg2_1",
+    )
+    task.add_attribute("attribute", "value")
+
+    expected_labels = {"arg1": "arg1_1", "arg2": "arg2_1", "attribute": "value"}
+
+    assert task.labels == expected_labels

--- a/tests/client/test_task_group.py
+++ b/tests/client/test_task_group.py
@@ -218,6 +218,15 @@ class TestGetFunctions:
         group = TaskGroup(all_tasks, "group")
         assert set(all_tasks[:2]) == group.get_subgroup(group="in").tasks
 
+    def test_subgroup_multiple_values(self, template1):
+        """Get a subgroup with multiple values for a label."""
+        in_tasks = template1.create_tasks(arg1=[1, 2], arg2=[1, 2])
+        out_tasks = template1.create_tasks(arg1=[3], arg2=[1, 2])
+
+        group = TaskGroup(in_tasks + out_tasks)
+
+        assert set(in_tasks) == group.get_subgroup(arg1=[1, 2]).tasks
+
     def test_subgroup_args_and_attributes(self, template1, template2):
         """Get a subgroup with a mix of args and attributes specified."""
         tasks_1 = template1.create_tasks(

--- a/tests/client/test_task_group.py
+++ b/tests/client/test_task_group.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List
 import uuid
+import warnings
 
 from jobmon.client.task_group import TaskGroup
 from jobmon.client.tool import Tool
@@ -744,6 +745,20 @@ class TestDependencyIncomplete:
         )
 
         with pytest.raises(ValueError):
+            group2.interleave_upstream(
+                group1, dependency_specification={"stage2_arg": "stage1_arg"}
+            )
+
+    def test_no_warning(sefl, template1, template2):
+        """Double check that warning doesn't get raised if it shouldn't."""
+        group1 = TaskGroup(
+            template1.create_tasks(stage1_arg=["val1", "val2"]), "group1"
+        )
+        group2 = TaskGroup(
+            template2.create_tasks(stage2_arg=["val1", "val2"]), "group2"
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             group2.interleave_upstream(
                 group1, dependency_specification={"stage2_arg": "stage1_arg"}
             )

--- a/tests/client/test_task_group.py
+++ b/tests/client/test_task_group.py
@@ -354,6 +354,34 @@ class TestGetFunctions:
         in_group = task_group.get_subgroup(arg1=[1,2], group="in")
         assert in_group.tasks == set(in_tasks)
 
+    @pytest.mark.parametrize(
+        "subsetter", 
+        [{"arg1": 1}, {"arg1": [1,2], "arg2": 1}]
+    )
+    def test_add_label(self, subsetter, template1):
+        group = TaskGroup(template1.create_tasks(arg1=[1, 2], arg2=[1, 2]))
+        group.add_labels({"new_label": "value"}, subsetter)
+
+        expected = group.get_subgroup(**subsetter).tasks
+        actual = group.get_subgroup(new_label="value").tasks
+
+        assert expected == actual
+
+    def test_add_label_all(self, template1):
+        """Adds the label to all tasks."""
+        group = TaskGroup(template1.create_tasks(arg1=[1, 2], arg2=[1, 2]))
+        group.add_labels({"new_label": "value"})
+
+        for task in group:
+            assert task.labels["new_label"] == "value"
+
+    def test_add_label_bad_subsetter(self, template1):
+        """Assert an error gets raised if the subsetter doesn't describe any tasks."""
+        group = TaskGroup(template1.create_tasks(arg1=[1, 2], arg2=[1, 2]))
+        with pytest.raises(Exception):
+            group.add_labels({"new_label": "value"}, {"bad": "terrible"})
+
+
 class TestDependencyHomogeneous:
     """The tests here revolve around setting dependencies between two groups of homogenous
     tasks, parallelized across two variables.

--- a/tests/client/test_task_group.py
+++ b/tests/client/test_task_group.py
@@ -351,13 +351,10 @@ class TestGetFunctions:
 
         task_group = TaskGroup(in_tasks + out_tasks)
 
-        in_group = task_group.get_subgroup(arg1=[1,2], group="in")
+        in_group = task_group.get_subgroup(arg1=[1, 2], group="in")
         assert in_group.tasks == set(in_tasks)
 
-    @pytest.mark.parametrize(
-        "subsetter", 
-        [{"arg1": 1}, {"arg1": [1,2], "arg2": 1}]
-    )
+    @pytest.mark.parametrize("subsetter", [{"arg1": 1}, {"arg1": [1, 2], "arg2": 1}])
     def test_add_label(self, subsetter, template1):
         group = TaskGroup(template1.create_tasks(arg1=[1, 2], arg2=[1, 2]))
         group.add_labels({"new_label": "value"}, subsetter)
@@ -517,9 +514,9 @@ class TestDependencyHomogeneous:
     ):
         """Assert that we can set dependencies on only the upstream subset."""
         template2_group.interleave_upstream(
-            template1_group, 
-            dependency_specification = {"stage2_arg1": "stage1_arg1"}, 
-            upstream_subsetter = {"stage1_arg2": "val3"},
+            template1_group,
+            dependency_specification={"stage2_arg1": "stage1_arg1"},
+            upstream_subsetter={"stage1_arg2": "val3"},
         )
         arg1_vals = ["val1", "val2"]
         for arg1_val in arg1_vals:
@@ -532,9 +529,9 @@ class TestDependencyHomogeneous:
     ):
         """Assert that we can set dependencies on only the downstream subset."""
         template2_group.interleave_upstream(
-            template1_group, 
-            dependency_specification = {"stage2_arg1": "stage1_arg1"}, 
-            subsetter = {"stage2_arg2": "val3"},
+            template1_group,
+            dependency_specification={"stage2_arg1": "stage1_arg1"},
+            subsetter={"stage2_arg2": "val3"},
         )
         arg1_vals = ["val1", "val2"]
         for arg1_val in arg1_vals:
@@ -547,20 +544,19 @@ class TestDependencyHomogeneous:
     def test_upstream_and_downstream_subsetter(
         self, template1_group: TaskGroup, template2_group: TaskGroup
     ):
-        """Assert that we can set dependencies on only a downstream and an upstream subset."""        
+        """Assert that we can set dependencies on only a downstream and an upstream subset."""
         template2_group.interleave_upstream(
-            template1_group, 
-            dependency_specification = {"stage2_arg1": "stage1_arg1"}, 
-            subsetter = {"stage2_arg2": "val3"},
-            upstream_subsetter = {"stage1_arg2": "val4"},
+            template1_group,
+            dependency_specification={"stage2_arg1": "stage1_arg1"},
+            subsetter={"stage2_arg2": "val3"},
+            upstream_subsetter={"stage1_arg2": "val4"},
         )
         arg1_vals = ["val1", "val2"]
         for arg1_val in arg1_vals:
             task1 = template1_group.get_task(stage1_arg1=arg1_val, stage1_arg2="val4")
             task2 = template2_group.get_task(stage2_arg1=arg1_val, stage2_arg2="val3")
             assert task2.upstream_tasks == {task1}
-        
-        
+
 
 class TestDependencyHeterogeneous:
     """These are test of setting dependency structures on groups containing multiple different
@@ -892,10 +888,7 @@ class TestDependencyIncomplete:
         task_2_2 = template2.create_task(stage2_arg="val4")
         group2 = TaskGroup([task_2_1, task_2_2])
 
-        group2.interleave_upstream(
-            group1, dependency_specification={"group":"group"}
-        )
+        group2.interleave_upstream(group1, dependency_specification={"group": "group"})
 
         assert task_2_1.upstream_tasks == {task_1_1}
         assert task_2_2.upstream_tasks == set()
-

--- a/tests/client/test_task_group.py
+++ b/tests/client/test_task_group.py
@@ -1,0 +1,801 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, Iterator, List, Optional, Set
+from jobmon.client.api import Tool
+from jobmon.client.task import Task
+
+import pytest
+import itertools
+
+# Stubs
+class TaskGroup:
+    """TaskGroup stub."""
+
+    tasks: Set[Task]
+    name: str
+
+    def __init__(self, tasks: Iterable[Task], name: str):
+        pass
+
+    def add_task(self, task: Task):
+        """Adds a task to the group."""
+        pass
+
+    def add_tasks(self, tasks: Iterable[Task]):
+        """Adds multiple tasks to the group."""
+        pass
+
+    def union(self, other: TaskGroup, new_name: Optional[str] = None) -> TaskGroup:
+        """Combine two task groups."""
+
+    def get_subgroup(
+        self,
+        task_template_name: Optional[str],
+        empty_okay: bool = False,
+        new_name: Optional[str] = None,
+        **kwargs
+    ) -> TaskGroup:
+        """probably the same implementation details as workflow.get_tasks_by_node_args
+        
+        kwargs can be task arguments or attributes.
+
+        raises an error if the group is empty and empty_okay is False.
+        """
+        pass
+
+    def get_task(self, task_template_name: Optional[str], **kwargs) -> Task:
+        """Raises an error if it doesn't uniquely identify a task.
+        
+        kwargs can be task arguments or attributes.
+        """
+        pass
+
+    def add_upstream(
+        self,
+        upstream_group: TaskGroup,
+        dependency_specification: Dict[str, str],
+        my_template: Optional[str] = None,
+        upstream_template: Optional[str] = None,
+    ):
+        """`dependency_specification` is a dictionary mapping argument or attribute names. Keys
+        are argument or attribute names in tasks in this group, and values are argument or 
+        attribute names in tasks in the upstream group. Dependencies are set between tasks 
+        where the values in all the specified arguments/attributes match, and they fit 
+        `my_template`/`upstream_template` if supplied.
+        """
+        pass
+
+    def __iter__(self) -> Iterator[Task]:
+        pass
+
+    def __or__(self, other_group: TaskGroup) -> TaskGroup:
+        """Combine two groups."""
+
+    def __len__(self) -> int:
+        pass
+
+
+tool = Tool("test_tool")
+
+
+@pytest.mark.skip
+class TestUtils:
+    """Test dunder methods and other simple utils."""
+
+    template = tool.get_task_template(
+        template_name="template",
+        command_template="script {arg}",
+        node_args=["arg"],
+        task_args=[],
+        op_args=[],
+    )
+
+    def test_iter(self):
+        """Test that the TaskGroup is iterable."""
+        task_list = self.template.create_tasks(arg=[1, 2])
+        task_group = TaskGroup(task_list, name="")
+        task_set = set(task_group)  # set() just iterates through the argument provided.
+
+        assert set(task_list) == task_set
+
+    def test_tasks(self):
+        """Test that the .tasks attribute is a set of all the contained tasks."""
+        task_list = self.template.create_tasks(arg=[1, 2])
+        task_group = TaskGroup(task_list, name="")
+
+        assert set(task_group) == task_group.tasks
+
+    def test_union(self):
+        """Test that TaskGroups can be combined together."""
+        list1 = self.template.create_tasks(arg=[1, 2])
+        list2 = self.template.create_tasks(arg=[3, 4])
+
+        group1 = TaskGroup(list1, name="1")
+        group2 = TaskGroup(list2, name="2")
+
+        combined_group = group1.union(group2)
+
+        assert set(combined_group) == set(list1 + list2)
+
+    def test_union_name(self):
+        """Test that the new group has the requested name."""
+        list1 = self.template.create_tasks(arg=[1, 2])
+        list2 = self.template.create_tasks(arg=[3, 4])
+
+        group1 = TaskGroup(list1, name="1")
+        group2 = TaskGroup(list2, name="2")
+
+        new_name = "new_name"
+        combined_group = group1.union(group2, new_name)
+
+        assert combined_group.name == new_name
+
+    def test_or(self):
+        """Test that `|` works like union."""
+        list1 = self.template.create_tasks(arg=[1, 2])
+        list2 = self.template.create_tasks(arg=[3, 4])
+
+        group1 = TaskGroup(list1, "1")
+        group2 = TaskGroup(list2, "2")
+
+        combined_group = group1 | group2
+
+        assert set(combined_group) == set(list1 + list2)
+
+    @pytest.mark.parameterize(
+        ["args", "expected_len"], [[[], 0], [[1], 1], [[1, 2, 3], 3]]
+    )
+    def test_len(self, args: List[int], expected_len: int):
+        """Test that len works as expected."""
+        tasks = self.template.create_tasks(arg=args)
+        group = TaskGroup(tasks)
+
+        assert len(group) == expected_len
+
+    def test_uniqueness(self):
+        """Assert that the same task can only get added once."""
+        task_list = self.template.create_tasks(arg=[1, 2])
+        group = TaskGroup(task_list * 2)
+
+        assert len(group) == len(task_list)
+
+
+@pytest.mark.skip
+class TestAddTasks:
+    """Test adding tasks to the current workflow."""
+
+    template = tool.get_task_template(
+        template_name="template",
+        command_template="script {arg}",
+        node_args=["arg"],
+        task_args=[],
+        op_args=[],
+    )
+
+    def test_add_task(self):
+        """Test that it adds a task to a TaskGroup"""
+        group = TaskGroup(self.template.create_tasks(arg=[1, 2]), "name")
+        new_task = self.template.create_task(arg=3)
+
+        group.add_task(new_task)
+
+        assert new_task in group
+
+    def test_add_uniqueness(self):
+        """Test that if I add a task twice nothing happens."""
+        task = self.template.create_task(arg=1)
+        group = TaskGroup([task], "name")
+
+        group.add_task(task)
+
+        assert len(group) == 1
+
+    def test_add_tasks(self):
+        """Test that it adds multiple tasks to the TaskGroup"""
+        group = TaskGroup(self.template.create_tasks(arg=[1, 2]), "name")
+        new_tasks = self.template.create_tasks(arg=[3, 4])
+
+        group.add_tasks(new_tasks)
+
+        for task in new_tasks:
+            assert task in group
+
+
+@pytest.mark.skip
+class TestGetFunctions:
+    """Tests for get_subgroup and get_task"""
+
+    template1 = tool.get_task_template(
+        template_name="template1",
+        command_template="script {arg1} {arg2}",
+        node_args=["arg1", "arg2"],
+        task_args=[],
+        op_args=[],
+    )
+    template2 = tool.get_task_template(
+        template_name="template2",
+        command_template="script {arg1} {arg2}",
+        node_args=["arg1", "arg2"],
+        task_args=[],
+        op_args=[],
+    )
+
+    def test_subgroup_homogenous(self):
+        """Get a subset from a group with all one template."""
+        in_group = TaskGroup(
+            self.template1.create_tasks(arg1=[1], arg2=[1, 2]), "in_group"
+        )
+        out_group = TaskGroup(
+            self.template1.create_tasks(arg1=[2], arg2=[1, 2]), "out_group"
+        )
+        big_group = in_group | out_group
+
+        assert in_group.tasks == big_group.get_subgroup(arg1=1).tasks
+
+    def test_subgroup_with_template(self):
+        """Get a subset using only one template in the group."""
+        in_group = TaskGroup(
+            self.template1.create_tasks(arg1=[1], arg2=[1, 2]), "in_group"
+        )
+        out_group1 = TaskGroup(
+            self.template1.create_tasks(arg1=[2], arg2=[1, 2]), "out_group1"
+        )
+        out_group2 = TaskGroup(
+            self.template2.create_tasks(arg1=[1, 2], arg2=[1, 2]), "out_group2"
+        )
+        big_group = in_group | out_group1 | out_group2
+
+        assert (
+            in_group.tasks
+            == big_group.get_subgroup(task_template_name="template1", arg1=1).tasks
+        )
+
+    def test_subgroup_multiple_templates(self):
+        """Get a subgroup that has multiple templates which have a matching argument."""
+        in_group1 = TaskGroup(
+            self.template1.create_tasks(arg1=[1], arg2=[1, 2]), "in_group1"
+        )
+        out_group1 = TaskGroup(
+            self.template1.create_tasks(arg1=[2], arg2=[1, 2]), "out_group2"
+        )
+        in_group2 = TaskGroup(
+            self.template2.create_tasks(arg1=[1], arg2=[1, 2]), "in_group2"
+        )
+        out_group2 = TaskGroup(
+            self.template2.create_tasks(arg1=[2], arg2=[1, 2]), "out_group2"
+        )
+        big_group = in_group1 | out_group1 | in_group2 | out_group2
+
+        assert (in_group1 | in_group2).tasks == big_group.get_subgroup(arg1=1).tasks
+
+    def test_subgroup_attributes(self):
+        """Get a subgroup based on attributes."""
+        all_tasks = self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2])
+        for task in all_tasks[:2]:
+            task.add_attribute("group", "in")
+        for task in all_tasks[3:]:
+            task.add_attribute("group", "out")
+
+        group = TaskGroup(all_tasks, "group")
+        assert set(all_tasks[:2]) == group.get_subgroup(group="in").tasks
+
+    def test_subgroup_args_and_attributes(self):
+        """Get a subgroup with a mix of args and attributes specified."""
+        tasks_1 = self.template1.create_tasks(arg1=[1,], arg2=[1, 2, 3])
+        tasks_2 = self.template2.create_tasks(arg1=[2, 3], arg1=[1, 2, 3])
+        for task in tasks_1[:2] + tasks_2[:2]:
+            task.add_attribute("group", "in")
+        for task in tasks_1[3:] + tasks_2[3:]:
+            task.add_attribute("group", "out")
+
+        group = TaskGroup(tasks_1 + tasks_2, "group")
+        subgroup = group.get_subgroup(group="in", arg2=2)
+
+        for task in subgroup:
+            assert task.node.node_args["arg2"] == 2
+            assert task.task_attributes["group"] == "in"
+
+    def test_get_empty_subgroup(self):
+        """Assert an error is thrown if attempting to get an empty subgroup.
+
+        Not entirely sure this is the behavior we want, but it does seem broadly safer than
+        returning an empty group.
+        """
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "group"
+        )
+        with pytest.raises(KeyError):
+            group.get_subgroup(arg1=3)
+
+    def test_get_empty_subgroup_empty_okay(self):
+        """Assert an error isn't thrown if attempting to get an empty subgroup and empty_okay
+        is true.
+        """
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "group"
+        )
+        subgroup = group.get_subgroup(arg1=3, empty_okay=True)
+
+        assert len(subgroup) == 0
+
+    def test_get_subgroup_new_name(self):
+        """Get subgroup with a new name."""
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "group"
+        )
+
+        new_name = "new_name"
+        sub_group = group.get_subgroup(arg1=1, new_name=new_name)
+
+        assert sub_group.name == new_name
+
+    def test_task_homogenous(self):
+        """Get a task from a group with all one template."""
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "group"
+        )
+        task = group.get_task(arg1=1, arg2=1)
+
+        assert task.node.node_args["arg1"] == 1
+        assert task.node.node_args["arg2"] == 2
+
+    def test_task_with_template(self):
+        """Get a task using a specified template."""
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "part1"
+        ) | TaskGroup(self.template2.create_tasks(arg1=[1, 2], arg2=[1, 2]), "part2")
+        task = group.get_task(task_template_name="template1", arg1=1, arg2=2)
+
+        assert (
+            task.node.task_template_version.task_template.template_name == "template1"
+        )
+        assert task.node.node_args["arg1"] == 1
+        assert task.node.node_args["arg2"] == 2
+
+    def test_task_multiple_possible_templates(self):
+        """Get a single task where multiple possible templates *could* match the arguments,
+        but only one does.
+        """
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "part1"
+        ) | TaskGroup(self.template2.create_tasks(arg1=[2], arg2=[1, 2]), "part2")
+        task = group.get_task(arg1=1, arg2=2)
+
+        assert (
+            task.node.task_template_version.task_template.template_name == "template1"
+        )
+        assert task.node.node_args["arg1"] == 1
+        assert task.node.node_args["arg2"] == 2
+
+    def test_task_attributes(self):
+        """Get a task based on attributes."""
+        all_tasks = self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2])
+        for task in all_tasks[:1]:
+            task.add_attribute("group", "in")
+        for task in all_tasks[2:]:
+            task.add_attribute("group", "out")
+
+        group = TaskGroup(all_tasks, "group")
+        task = group.get_task(group="in")
+
+        assert task.task_attributes["group"] == "in"
+
+    def test_get_non_existent_task(self):
+        """Assert an error is thrown if attempting to get a non-existent task."""
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "group"
+        )
+        with pytest.raises(KeyError):
+            group.get_task(arg1=3, arg2=1)
+
+    def test_get_multiple_tasks(self):
+        """Assert an error is thrown if specification doesn't match only one task."""
+        group = TaskGroup(
+            self.template1.create_tasks(arg1=[1, 2], arg2=[1, 2]), "group"
+        )
+        with pytest.raises(KeyError):
+            group.get_task(arg1=1)
+
+
+@pytest.mark.skip
+class TestDependencyHomogonous:
+    """The tests here revolve around setting dependencies between two groups of homogenous
+    tasks, parallelized across two variables.
+    """
+
+    # Templates
+    template1 = tool.get_task_template(
+        template_name="template1",
+        command_template="script1 {stage1_arg1} {stage1_arg2}",
+        node_args=["stage1_arg1", "stage1_arg2"],
+        task_args=[],
+        op_args=[],
+    )
+    template2 = tool.get_task_template(
+        template_name="template2",
+        command_template="script2 {stage2_arg1} {stage2_arg2}",
+        node_args=["stage2_arg1", "stage2_arg2"],
+        task_args=[],
+        op_args=[],
+    )
+
+    @pytest.fixture
+    def template1_group(self) -> TaskGroup:
+        arg1 = ["val1", "val2"]
+        arg2 = ["val3", "val4"]
+
+        return TaskGroup(
+            self.template1.create_tasks(stage1_arg1=arg1, stage1_arg2=arg2), "group1"
+        )
+
+    @pytest.fixture
+    def template2_group(self) -> TaskGroup:
+        arg1 = ["val1", "val2"]
+        arg2 = ["val3", "val4"]
+
+        return TaskGroup(
+            self.template2.create_tasks(stage1_arg1=arg1, stage1_arg2=arg2), "group2"
+        )
+
+    def test_all_to_all(self, template1_group: TaskGroup, template2_group: TaskGroup):
+        """Test all-to-all dependency-relationship"""
+        template2_group.add_upstream(template1_group, dependency_specification={})
+
+        for task1 in template1_group:
+            for task2 in template2_group:
+                assert task1 in task2.upstream_tasks
+
+    def test_one_to_one_match(
+        self, template1_group: TaskGroup, template2_group: TaskGroup
+    ):
+        """Tasks depend on tasks that match them in both arg1 and arg2."""
+        template2_group.add_upstream(
+            template1_group,
+            dependency_specification={
+                "stage2_arg1": "stage1_arg1",
+                "stage2_arg2": "stage1_arg2",
+            },
+        )
+
+        arg1_vals = ["val1", "val2"]
+        arg2_vals = ["val3", "val4"]
+        for arg1_val, arg2_val in itertools.product(arg1_vals, arg2_vals):
+            task1 = template1_group.get_task(
+                "template1", stage1_arg1=arg1_val, stage1_arg2=arg2_val
+            )
+            task2 = template2_group.get_task(
+                "template2", stage2_arg1=arg1_val, stage1_arg2=arg2_val
+            )
+
+            assert {task1} == task2.upstream_tasks
+
+    def test_multiple_to_multiple(
+        self, template1_group: TaskGroup, template2_group: TaskGroup
+    ):
+        """Each task in group 1 has 2 downstreams, each task in group 2 has 2 upstreams."""
+        template2_group.add_upstream(
+            template1_group, dependency_specification={"stage2_arg1": "stage1_arg1"}
+        )
+
+        arg1_vals = ["val1", "val2"]
+        for arg1_val in arg1_vals:
+            for task2 in template2_group.get_subgroup(stage2_arg1=arg1_val):
+                assert (
+                    set(template1_group.get_subgroup(stage1_arg1=arg1_val))
+                    == task2.upstream_tasks
+                )
+
+    def test_multiple_to_1(
+        self, template1_group: TaskGroup, template2_group: TaskGroup
+    ):
+        """Each task in group 1 has 2 downstreams, each task in group 2 has 1 upstream."""
+        template1_subgroup = template1_group.get_subgroup(arg2="val3")
+
+        template2_group.add_upstream(
+            template1_subgroup, dependency_specification={"stage2_arg1": "stage1_arg1"}
+        )
+        arg1_vals = ["val1", "val2"]
+        for arg1_val in arg1_vals:
+            task1 = template1_subgroup.get_task(stage1_arg1=arg1_val)
+            for task2 in template2_group.get_subgroup(stage2_arg1=arg1_val):
+                assert {task2} == task1.upstream_tasks
+
+    def test_1_to_multiple(
+        self, template1_group: TaskGroup, template2_group: TaskGroup
+    ):
+        """Each task in group 1 has 1 downstream, each task in group 2 has 2 uptreams."""
+        template2_subgroup = template2_group.get_subgroup(arg2="val3")
+
+        template2_subgroup.add_upstream(
+            template1_group, dependency_specification={"stage1_arg1": "stage2_arg1"}
+        )
+        arg1_vals = ["val1", "val2"]
+        for arg1_val in arg1_vals:
+            task2 = template1_group.get_task(stage2_arg1=arg1_val)
+            assert (
+                set(template1_group.get_subgroup(stage1_arg1=arg1_val))
+                == task2.upstream_tasks
+            )
+
+
+@pytest.mark.skip
+class TestDependencyHeterogenous:
+    """These are test of setting dependency structures on groups containing multiple different
+    task templates.
+    """
+
+    def test_downstream_with_aggregator(self):
+        """Here we're operating across one variable.
+
+        The upstream group is homogenous.
+
+        The downstream group has a parallelized step, dependent 1:1 on the upstream group, and
+        a second aggregation step, that occurs after the parallelized step.
+        """
+        # Set up templates
+        template1 = tool.get_task_template(
+            template_name="template1",
+            command_template="script1 {stage1_arg1}",
+            node_args=["stage1_arg1"],
+            task_args=[],
+            op_args=[],
+        )
+        template2 = tool.get_task_template(
+            template_name="template2",
+            command_template="script2 {stage2_arg1}",
+            node_args=["stage2_arg1"],
+            task_args=[],
+            op_args=[],
+        )
+        template_agg = tool.get_task_template(
+            template_name="template_agg",
+            command_template="script_agg {task_arg}",
+            node_args=[],
+            task_args=["task_arg"],
+            op_args=[],
+        )
+
+        # Set up groups
+        arg1_vals = ["val1", "val2"]
+
+        group1 = TaskGroup(template1.create_tasks(stage1_arg1=arg1_vals), "group1")
+
+        template2_tasks = template2.create_tasks(stage2_arg1=arg1_vals)
+        agg_task = template_agg.create_task(task_arg="foo")
+        agg_task.add_upstreams(template2_tasks)
+        group2 = TaskGroup(template2_tasks | [agg_task], "group2")
+
+        # Exercise
+        group2.add_upstream(
+            group1,
+            my_template="template2",
+            dependency_specification={"stage2_arg1": "stage1_arg1"},
+        )
+
+        # Verify group2 internals
+        assert agg_task.upstream_tasks == set(template2_tasks)
+
+        # Verify inter-group structure
+        for arg1_val in arg1_vals:
+            task1 = group1.get_task(stage1_arg1=arg1_val)
+            task2 = group2.get_task(template="template2", stage2_arg1=arg1_val)
+            assert task2.upstream_tasks == {task1}
+
+    def test_both_groups_aggregate(self):
+        """Here we're operating across two variables.
+
+        The upstream group has a first step parallelized over both variables. It has a second
+        aggregation step parallelized over the first variable (combining results along the
+        second variable.)
+
+        The downstream group has a first step parallelized over one variable, dependent 1:1 on
+        the aggregation step of the first group. It has a final aggregation step.
+        """
+        # Set up templates
+        template1 = tool.get_task_template(
+            template_name="template1",
+            command_template="script1 {stage1_arg1} {stage1_arg2}",
+            node_args=["stage1_arg1", "stage1_arg2"],
+            task_args=[],
+            op_args=[],
+        )
+        template1_agg = tool.get_task_template(
+            template_name="template1_agg",
+            command_template="script1_agg {stage1_agg_arg1}",
+            node_args=["stage1_agg_arg1"],
+            task_args=[],
+            op_args=[],
+        )
+        template2 = tool.get_task_template(
+            template_name="template2",
+            command_template="script2 {stage2_arg1}",
+            node_args=["stage2_arg1",],
+            task_args=[],
+            op_args=[],
+        )
+        template2_agg = tool.get_task_template(
+            template_name="template2_agg",
+            command_template="script2_agg {task_arg}",
+            node_args=[],
+            task_args=["task_arg"],
+            op_args=[],
+        )
+
+        # Set up groups
+        arg1_vals = ["val1", "val2"]
+        arg2_vals = ["val3", "val4"]
+
+        template1_tasks = TaskGroup(
+            template1.create_tasks(stage1_arg1=arg1_vals, stage1_arg2=arg2_vals),
+            "stage1_compute",
+        )
+        template1_agg_tasks = TaskGroup(
+            template1_agg.create_tasks(stage1_arg1=arg1_vals), "stage1_agg"
+        )
+        template1_agg_tasks.add_upstream(
+            template1_tasks, {"stage1_agg_arg1": "stage1_arg1"}
+        )
+        group1 = template1_tasks | template1_agg_tasks
+
+        template2_tasks = template2.create_tasks(stage2_arg1=arg1_vals)
+        template2_agg_task = template2_agg.create_task(task_arg="foo")
+        template2_agg_task.add_upstreams(template2_tasks)
+        group2 = TaskGroup(template2_tasks + [template2_agg_task], "stage2")
+
+        # Exercise
+        group2.add_upstream(
+            group1,
+            my_template="template2",
+            upstream_template="template1_agg",
+            dependency_specification={"stage2_arg1": "stage1_arg1"},
+        )
+
+        # Verify group 2 internal structure
+        assert template2_agg_task.upstream_tasks == set(template2_tasks)
+
+        for arg1_val in arg1_vals:
+            task1_agg = group1.get_task(stage1_agg_arg1=arg1_val)
+            # Verify group 1 internal structure
+            assert task1_agg.upstreams == set(
+                template1_tasks.get_subgroup(stage1_arg1=arg1_val)
+            )
+
+            # Verify inter-group structure
+            task2 = group2.get_task(template="template2", stage2_arg1=arg1_val)
+            assert task2.upstream_tasks == {task1_agg}
+
+    def test_hierarchy(self):
+        """Here we're testing an arbitrary hierarchy encoded using attributes.
+        
+        We're simulating the process of aggregating up a hierarchy, such that parents require
+        all of their children to complete before they do (sorta the opposite of typical DAG 
+        notation).
+        """
+        # Set up templates
+        child_template = tool.get_task_template(
+            template_name="child_template",
+            command_template="calculate_child {child_entity}",
+            node_args=["child_entity"],
+            task_args=[],
+            op_args=[],
+        )
+        parent_template = tool.get_task_template(
+            template_name="parent_template",
+            command_template="calculate_parent {parent_entity}",
+            node_args=["parent_entity"],
+            task_args=[],
+            op_args=[],
+        )
+
+        # Set up groups
+        entity_hierarchy = {
+            "parent1": ["child1", "child2"],
+            "parent2": ["child3", "child4"],
+        }
+
+        child_tasks = []
+        for parent, children in entity_hierarchy:
+            for child in children:
+                task = child_template.create_task(child_entity=child)
+                task.add_attribute("parent", parent)
+                child_tasks.append(task)
+        child_group = TaskGroup(child_tasks, "child")
+
+        parent_group = TaskGroup(
+            parent_template.create_tasks(parent_entity=entity_hierarchy.keys()),
+            "parent",
+        )
+
+        # Exercise
+        parent_group.add_upstream(child_group, {"parent_entity": "parent_entity"})
+
+        # Verify
+        for parent, children in entity_hierarchy:
+            parent_task = parent_group.get_task(parent_entity=parent)
+            child_tasks = {
+                child_group.get_task(child_entity=child) for child in children
+            }
+
+            assert parent_task.upstream_tasks == child_tasks
+
+
+@pytest.mark.skip
+class TestDependencyIncomplete:
+    """Tests for cases where a dependency spec might leave off some tasks."""
+
+    template1 = tool.get_task_template(
+        template_name="template1",
+        command_template="script1 {stage1_arg}",
+        node_args=["stage1_arg"],
+        task_args=[],
+        op_args=[],
+    )
+    template2 = tool.get_task_template(
+        template_name="template2",
+        command_template="stage2 {stage2_arg}",
+        node_args=["script2_arg"],
+        task_args=[],
+        op_args=[],
+    )
+
+    def test_extra_upstreams(self):
+        """Test the 1:1 matching where the upstream has values not included in the downstreams.
+
+        We expect a warning, and to set the right upstreams.
+        """
+        group1 = TaskGroup(
+            self.template1.create_tasks(stage1_arg=["val1", "val2", "val3"]), "group1"
+        )
+        group2 = TaskGroup(
+            self.template2.create_tasks(stage2_arg=["val1", "val2"]), "group2"
+        )
+
+        with pytest.warns(Warning):
+            group2.add_upstream(
+                group1, dependency_specification={"stage2_arg": "stage1_arg"}
+            )
+
+        for val in ["val1", "val2"]:
+            task1 = group1.get_task(stage1_arg=val)
+            task2 = group2.get_task(stage2_arg=val)
+            assert task2.upstream_tasks == {task1}
+
+    def test_extra_downstreams(self):
+        """Test the 1:1 matching where the downstream has values not included in the upstreams.
+
+        We expect a warning, and to set the right upstreams.
+        """
+        group1 = TaskGroup(
+            self.template1.create_tasks(stage1_arg=["val1", "val2"]), "group1"
+        )
+        group2 = TaskGroup(
+            self.template2.create_tasks(stage2_arg=["val1", "val2", "val3"]), "group2"
+        )
+
+        with pytest.warns(Warning):
+            group2.add_upstream(
+                group1, dependency_specification={"stage2_arg": "stage1_arg"}
+            )
+
+        for val in ["val1", "val2"]:
+            task1 = group1.get_task(stage1_arg=val)
+            task2 = group2.get_task(stage2_arg=val)
+            assert task2.upstream_tasks == {task1}
+
+        assert group2.get_task(stage2_arg="val3").upstream_tasks == {}
+
+    def test_no_matches(self):
+        """Test that an error is thrown when setting an upstream group would result in not
+        actually setting any tasks' upstreams.
+        """
+        group1 = TaskGroup(
+            self.template1.create_tasks(stage1_arg=["val1", "val2"]), "group1"
+        )
+        group2 = TaskGroup(
+            self.template2.create_tasks(stage2_arg=["val3", "val4"]), "group2"
+        )
+
+        with pytest.raises(ValueError):
+            group2.add_upstream(
+                group1, dependency_specification={"stage2_arg": "stage1_arg"}
+            )


### PR DESCRIPTION
As far as I can tell this is a fully-functioning client-side implementation of TaskGroups!

I had a thought while working on it, which is that it might be better to have the `dependency_specification` parameter in `interleave_upstream` be a list of tuples (of length two) instead of a dictionary. A practical reason for this is that one could conceive of wanting to map a single downstream label to two different upstream labels, which you can't do in a dictionary. Additionally, it just *feels* a little closer to the underlying model; the upstream and downstream labels are the same *kind* of thing, where a dictionary implies that keys and values are different types of things. It might make `interleave_downstream` feel a little more intuitive as well