### PR TITLE
Change to no limit

### DIFF
--- a/jobmon_gui/src/progress_bar.tsx
+++ b/jobmon_gui/src/progress_bar.tsx
@@ -9,6 +9,10 @@ export default function JobmonProgressBar({tasks, pending, scheduled, running, d
     num_attempts_avg = parseFloat(num_attempts_avg).toFixed(1);
     // style can be striped or animated; others will be treated as default
     // FIXME: reduce code duplication through better use of variables with flow control
+    const INT_32_MAX = 2147483647
+    if (maxc === INT_32_MAX) {
+        maxc = "No Limit"
+    }
     if (style === "striped") {
         return (
             <OverlayTrigger


### PR DESCRIPTION
Change the pop up to say "No Limit" instead of 2147483647 for max concurrency limit. After vs before screen shots.

<img width="253" alt="Screenshot 2023-05-03 at 2 44 19 PM" src="https://user-images.githubusercontent.com/53873394/236057137-aa5802fc-6f73-485f-b7fa-c038068cb4a2.png">

<img width="273" alt="Screenshot 2023-05-03 at 2 44 00 PM" src="https://user-images.githubusercontent.com/53873394/236057159-1f1171e8-92cd-485f-a6fd-bb752d0aa037.png">
