### PR TITLE
Add second error log

### DIFF
--- a/jobmon_gui/src/task_details_page/task_instance_table.tsx
+++ b/jobmon_gui/src/task_details_page/task_instance_table.tsx
@@ -19,10 +19,11 @@ export default function TaskInstanceTable({ taskInstanceData }) {
     const [showStdoutModal, setShowStdoutModal] = useState(false)
     const [showStderrModal, setShowStderrModal] = useState(false)
 
+    // ti_stderr_log is pulled from task_instance.stderr_log, ti_error_log_description is pulled from task_instance_error_log.description
     const [rowDetail, setRowDetail] = useState({
         'ti_id': '', 'ti_status': '', 'ti_stdout': '',
         'ti_stderr': '', 'ti_stdout_log': '', 'ti_stderr_log': '',
-        'ti_distributor_id': '', 'ti_nodename': '',
+        'ti_distributor_id': '', 'ti_nodename': '', 'ti_error_log_description': '',
     });
 
     const htmlFormatter = cell => {
@@ -59,7 +60,8 @@ export default function TaskInstanceTable({ taskInstanceData }) {
                 "ti_distributor_id": e.ti_distributor_id,
                 "ti_nodename": e.ti_nodename,
                 "ti_stdout_log": e.ti_stdout_log,
-                "ti_stderr_log": e.ti_stderr_log
+                "ti_stderr_log": e.ti_stderr_log,
+                "ti_error_log_description": e.ti_error_log_description
             })
 
         }
@@ -210,7 +212,9 @@ export default function TaskInstanceTable({ taskInstanceData }) {
                         {rowDetail.ti_stderr}<br></br>
                         <br></br>
                         <b>Standard Error Log:</b> <br></br>
-                        {rowDetail.ti_stderr_log}
+                        {rowDetail.ti_stderr_log}<br></br>
+                        <br></br>
+                        {rowDetail.ti_error_log_description}
                     </p>
                 }
                 showModal={showStderrModal}

--- a/jobmon_server/src/jobmon/server/web/routes/cli/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/cli/task.py
@@ -500,6 +500,11 @@ def get_task_details(task_id: int) -> Any:
             TaskInstance.stderr_log,
             TaskInstance.distributor_id,
             TaskInstance.nodename,
+            TaskInstanceErrorLog.description,
+        ).outerjoin_from(
+            TaskInstance,
+            TaskInstanceErrorLog,
+            TaskInstance.id == TaskInstanceErrorLog.task_instance_id,
         ).where(
             TaskInstance.task_id == task_id,
             TaskInstance.status == TaskInstanceStatus.id,
@@ -515,6 +520,7 @@ def get_task_details(task_id: int) -> Any:
         "ti_stderr_log",
         "ti_distributor_id",
         "ti_nodename",
+        "ti_error_log_description"
     )
     result = [dict(zip(column_names, row)) for row in rows]
     resp = jsonify(taskinstances=result)


### PR DESCRIPTION
We  have error logs in two places task_instance_error_log.description and task_instance.stderr_log. We currently display both in the error logs pop up modal but only one in the TaskInstance table pop up modal. So added the second location there.