### PR TITLE
Fix bug in errors tab

### DIFF
--- a/jobmon_gui/src/workflow_details_page/errors.tsx
+++ b/jobmon_gui/src/workflow_details_page/errors.tsx
@@ -50,7 +50,9 @@ export default function Errors({ errorLogs, tt_name, loading, apm }) {
                     "task_instance_id": e.task_instance_id,
                     "brief": error_display,
                     "date": date_display,
-                    "time": e.error_time
+                    "time": e.error_time,
+                    "error": e.error,
+                    "task_instance_stderr_log": e.task_instance_stderr_log
                 })
             }
         }
@@ -111,9 +113,8 @@ export default function Errors({ errorLogs, tt_name, loading, apm }) {
             },
             events: {
                 onClick: (e, column, columnIndex, row, rowIndex) => {
-                    console.log(rowIndex);
                     setShowModal(true)
-                    setErrorDetail(errorLogs[rowIndex]);
+                    setErrorDetail(row);
                 }
             }
         }

--- a/jobmon_gui/src/workflow_overview_page/workflow_overview.tsx
+++ b/jobmon_gui/src/workflow_overview_page/workflow_overview.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useForm } from "react-hook-form";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -75,9 +74,6 @@ function App() {
     params.append("wf_args", wf_args)
     params.append("date_submitted", date_submitted)
     params.append("status", status)
-    const request = {
-      params: params,
-    };
     let workflow_status_url = process.env.REACT_APP_BASE_URL + "/workflow_overview_viz";
     const workflow_status_renders = {
       "PENDING": (<div>< label className="label-middle" > <FaCircle className="bar-pp" /> </label><label className="label-left font-weight-300">PENDING  </label></div >),
@@ -126,7 +122,7 @@ function App() {
   });
 
   const handleClear = handleSubmit((d) => {
-    navigate('/?user=' + "&tool=" + "&wf_name=" + "&wf_args=" + "&date_submitted=" + "&status=");
+    navigate("/?user=&tool=&wf_name=&wf_args=&date_submitted=&status=");
     navigate(0)
   });
   //********************html page*************************************


### PR DESCRIPTION
Took awhile to figure out what the problem was for this one, but it ended up being an easy fix. 

Adam submitted this ticket: https://help.ihme.washington.edu/projects/SCICOMP/queues/custom/164/SCICOMP-811
TLDR: the pop up modal for error logs on the WorkflowDetails page were showing the wrong error message and task IDs

Fundamentally was a pagination problem. Previously, we sent row index to the modal so it would know what information to show. This would work if there was only page of pagination. The problem happened when there were multiple pages. The reason for this was the the table component would have the row index be for the specific page not the overall data for the table. e.g. would have and index of 8 instead of 18. So when it was queried it would always populate with error logs from the first page.

Fixed it by passing the row instead of the row index.

To see how this worked, if you go to https://jobmon-gui.ihme.washington.edu/#/workflow/148665/errors, click on "round_shifter" task template, and go to the second page of errors. If you click the errors modal associated with TaskInstance 50877793 it shows TaskID of 48874202  instead of the proper 48874207, and shows the error of 'KeyError: "not all values found in index 'acause'"" instead of "RuntimeError: There are Infs/Nans after transformation!".

This is fixed at https://jobmon-gui-christina.dev.scicomp.ihme.washington.edu/#/workflow/148665/errors

Also fixed some ESLint errors