### PR TITLE
Re-add .flake8 config file to Jobmon

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,52 @@
+[flake8]
+# ANN   : flake8-annotations warnings
+# B,B9  : flake8-bugbear
+# BLK   : black
+# C     : mccabe checks code complexity
+# D     : flake8-docstrings warnings
+# DAR   : darglint warnings
+# F     : pyflakes errors
+# I     : import-order warnings
+# W,E   : pycodestyle (pep8) warnings and errors
+select = ANN,B,B9,BLK,I,C,D,DAR,E,F,W
+max-complexity = 10
+ignore =
+    # Missing type annotation for self
+    ANN101,
+    # Dynamically typed expressions (typing.Any) are disallowed
+    ANN401,
+    # Function is too complex, this will eventually go away
+    C901,
+    # Missing docstring in public module
+    D100,
+    # Missing docstring in public package
+    D104,
+    # Line break before binary operator, ignore 503 and use 504
+    W503,
+    D101,
+    D102
+extend-ignore =
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203
+
+per-file-ignores =
+    jobmon_client/src/jobmon/_client_version.py:BLK100
+    jobmon_client/src/jobmon/client/api.py:F401
+    jobmon_core/src/jobmon/_core_version.py:BLK100
+    jobmon_core/src/jobmon/distributor/api.py:F401
+    jobmon_server/src/jobmon/_server_version.py:BLK100
+    jobmon_server/src/jobmon/server/workflow_reaper/api.py:F401
+    jobmon_server/src/jobmon/server/web/routes/cli/__init__.py:F401, E402
+    jobmon_server/src/jobmon/server/web/routes/fsm/__init__.py:F401, E402, I202
+    jobmon_server/src/jobmon/server/web/routes/reaper/__init__.py:F401, E402
+
+max-line-length = 95
+
+# import order
+import-order-style = google
+
+# docstrings
+docstring-convention = google
+
+# local
+application-import-names = jobmon

--- a/jobmon_server/src/jobmon/server/web/routes/cli/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/cli/task.py
@@ -246,17 +246,25 @@ def get_task_dependencies(task_id: int) -> Any:
         up_nodes = _get_node_dependencies({node_id}, dag_id, session, Direction.UP)
         down_nodes = _get_node_dependencies({node_id}, dag_id, session, Direction.DOWN)
         up_task_dict = _get_tasks_from_nodes(workflow_id, list(up_nodes), [], session)
-        down_task_dict = _get_tasks_from_nodes(workflow_id, list(down_nodes), [], session)
+        down_task_dict = _get_tasks_from_nodes(
+            workflow_id, list(down_nodes), [], session
+        )
     # return a "standard" json format so that it can be reused by future GUI
     up = (
         []
         if up_task_dict is None or len(up_task_dict) == 0
-        else [[{"id": k, "status": up_task_dict[k][0], "name": up_task_dict[k][1]}] for k in up_task_dict]
+        else [
+            [{"id": k, "status": up_task_dict[k][0], "name": up_task_dict[k][1]}]
+            for k in up_task_dict
+        ]
     )
     down = (
         []
         if down_task_dict is None or len(down_task_dict) == 0
-        else [[{"id": k, "status": down_task_dict[k][0], "name": down_task_dict[k][1]}] for k in down_task_dict]
+        else [
+            [{"id": k, "status": down_task_dict[k][0], "name": down_task_dict[k][1]}]
+            for k in down_task_dict
+        ]
     )
     resp = jsonify({"up": up, "down": down})
     resp.status_code = 200
@@ -491,23 +499,27 @@ def get_task_details(task_id: int) -> Any:
     """Get information about TaskInstances associated with specific Task ID."""
     session = SessionLocal()
     with session.begin():
-        query = select(
-            TaskInstance.id,
-            TaskInstanceStatus.label,
-            TaskInstance.stdout,
-            TaskInstance.stderr,
-            TaskInstance.stdout_log,
-            TaskInstance.stderr_log,
-            TaskInstance.distributor_id,
-            TaskInstance.nodename,
-            TaskInstanceErrorLog.description,
-        ).outerjoin_from(
-            TaskInstance,
-            TaskInstanceErrorLog,
-            TaskInstance.id == TaskInstanceErrorLog.task_instance_id,
-        ).where(
-            TaskInstance.task_id == task_id,
-            TaskInstance.status == TaskInstanceStatus.id,
+        query = (
+            select(
+                TaskInstance.id,
+                TaskInstanceStatus.label,
+                TaskInstance.stdout,
+                TaskInstance.stderr,
+                TaskInstance.stdout_log,
+                TaskInstance.stderr_log,
+                TaskInstance.distributor_id,
+                TaskInstance.nodename,
+                TaskInstanceErrorLog.description,
+            )
+            .outerjoin_from(
+                TaskInstance,
+                TaskInstanceErrorLog,
+                TaskInstance.id == TaskInstanceErrorLog.task_instance_id,
+            )
+            .where(
+                TaskInstance.task_id == task_id,
+                TaskInstance.status == TaskInstanceStatus.id,
+            )
         )
         rows = session.execute(query).all()
 
@@ -520,7 +532,7 @@ def get_task_details(task_id: int) -> Any:
         "ti_stderr_log",
         "ti_distributor_id",
         "ti_nodename",
-        "ti_error_log_description"
+        "ti_error_log_description",
     )
     result = [dict(zip(column_names, row)) for row in rows]
     resp = jsonify(taskinstances=result)

--- a/jobmon_server/src/jobmon/server/web/routes/cli/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/routes/cli/workflow.py
@@ -8,7 +8,6 @@ import pandas as pd
 from sqlalchemy import func, select, text, update
 import structlog
 
-from jobmon.core.constants import TaskStatus as TStatus
 from jobmon.core.constants import WorkflowStatus as Statuses
 from jobmon.server.web.models.node import Node
 from jobmon.server.web.models.task import Task


### PR DESCRIPTION
A while back Adam mentioned that there were a couple of thousand linting errors in Jobmon. I realized when I was working in onemod that Jobmon was probably missing it's .flake8 config (lost in the migration to GitHub).

I re-added the config file and then fixed the handful of legitimate linting errors. Jobmon linting is now passing.
<img width="775" alt="Screenshot 2023-05-25 at 11 07 49 AM" src="https://github.com/ihmeuw-scicomp/jobmon/assets/53873394/958945ec-f460-4289-8a3a-4e66e5b757d9">
