### PR TITLE
Gbdsci 5360/reset wfr status

### DIFF
--- a/jobmon_client/src/jobmon/client/cli.py
+++ b/jobmon_client/src/jobmon/client/cli.py
@@ -179,7 +179,9 @@ class ClientCLI(CLI):
         """Manually reset a workflow."""
         from jobmon.client.status_commands import workflow_reset
 
-        response = workflow_reset(args.workflow_id)
+        response = workflow_reset(
+            workflow_id=args.workflow_id,
+            partial_reset=args.partial_reset)
         print(f"Response is: {response}")
 
     @staticmethod
@@ -453,6 +455,14 @@ class ClientCLI(CLI):
         workflow_reset_parser.set_defaults(func=self.workflow_reset)
         workflow_reset_parser.add_argument(
             "-w", "--workflow_id", help="workflow_id to reset", required=True, type=int
+        )
+        workflow_reset_parser.add_argument(
+            "-p",
+            "--partial_reset",
+            help="Set to indicate Done tasks will not be reset",
+            type=bool,
+            required=False,
+            action="store_true",
         )
 
     def _add_create_resource_yaml_subparser(self) -> None:

--- a/jobmon_client/src/jobmon/client/cli.py
+++ b/jobmon_client/src/jobmon/client/cli.py
@@ -460,7 +460,6 @@ class ClientCLI(CLI):
             "-p",
             "--partial_reset",
             help="Set to indicate Done tasks will not be reset",
-            type=bool,
             required=False,
             action="store_true",
         )

--- a/jobmon_client/src/jobmon/client/status_commands.py
+++ b/jobmon_client/src/jobmon/client/status_commands.py
@@ -416,7 +416,11 @@ def get_task_dependencies(task_id: int, requester: Optional[Requester] = None) -
     return res
 
 
-def workflow_reset(workflow_id: int, requester: Optional[Requester] = None) -> str:
+def workflow_reset(
+    workflow_id: int,
+    partial_reset: bool = False,
+    requester: Optional[Requester] = None
+) -> str:
     """Workflow reset.
 
     Return:
@@ -424,6 +428,7 @@ def workflow_reset(workflow_id: int, requester: Optional[Requester] = None) -> s
 
     Args:
         workflow_id: the workflow id to be reset.
+        partial_reset: if False, tasks in D state will be reset as well
         requester: http server interface.
     """
     if requester is None:
@@ -436,16 +441,14 @@ def workflow_reset(workflow_id: int, requester: Optional[Requester] = None) -> s
         message={},
         request_type="get",
     )
-    if rc != 200:
-        raise AssertionError(f"Server return HTTP error code: {rc}")
     if res["workflow_run_id"]:
+
+        # Terminate a workflow's active workflowruns. Should go to a terminated state
         rc, _ = requester.send_request(
             app_route=f"/workflow/{workflow_id}/reset",
-            message={},
+            message={'partial_reset': partial_reset},
             request_type="put",
         )
-        if rc != 200:
-            raise AssertionError(f"Server return HTTP error code: {rc}")
         wr_return = f"Workflow {workflow_id} has been reset."
     else:
         wr_return = (

--- a/jobmon_client/src/jobmon/client/workflow_run.py
+++ b/jobmon_client/src/jobmon/client/workflow_run.py
@@ -88,10 +88,19 @@ class WorkflowRunFactory:
             request_type="post",
         )
 
-    def create_workflow_run(self) -> WorkflowRun:
+    def create_workflow_run(
+        self,
+        workflow_run_heartbeat_interval: Optional[int] = None,
+        heartbeat_report_by_buffer: Optional[float] = None
+    ) -> WorkflowRun:
         """Workflow should at least have signalled for a resume at this point."""
         # create workflow run
-        client_wfr = WorkflowRun(workflow_id=self.workflow_id, requester=self.requester)
+        client_wfr = WorkflowRun(
+            workflow_id=self.workflow_id,
+            requester=self.requester,
+            workflow_run_heartbeat_interval=workflow_run_heartbeat_interval,
+            heartbeat_report_by_buffer=heartbeat_report_by_buffer
+        )
         client_wfr.bind()
 
         return client_wfr

--- a/jobmon_server/src/jobmon/server/web/models/workflow_run.py
+++ b/jobmon_server/src/jobmon/server/web/models/workflow_run.py
@@ -1,4 +1,5 @@
 """Workflow run database table."""
+import datetime
 
 from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import relationship
@@ -119,6 +120,17 @@ class WorkflowRun(Base):
     def is_active(self) -> bool:
         """Statuses where Workflow Run is active (bound or running)."""
         return self.status in [WorkflowRunStatus.BOUND, WorkflowRunStatus.RUNNING]
+
+    def terminable(self, current_time: datetime.datetime) -> bool:
+        """Whether a workflowrun can be terminated.
+
+        A workflowrun can be terminated if it is in Cold/Hot resume state and has missed
+        the last reporting heartbeat.
+        """
+        return (
+            (self.heartbeat_date <= current_time) and
+            (self.status in (WorkflowRunStatus.COLD_RESUME, WorkflowRunStatus.HOT_RESUME))
+        )
 
     def heartbeat(
         self,

--- a/jobmon_server/src/jobmon/server/web/routes/cli/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/routes/cli/workflow.py
@@ -183,8 +183,9 @@ def get_workflow_run_for_workflow_reset(workflow_id: int, username: str) -> Any:
     with session.begin():
         query_filter = [
             WorkflowRun.workflow_id == workflow_id,
+            WorkflowRun.status == "E",
         ]
-        sql = (select(WorkflowRun).where(*query_filter)).order_by(
+        sql = (select(WorkflowRun.id, WorkflowRun.user).where(*query_filter)).order_by(
             WorkflowRun.created_date.desc()
         )
         rows = session.execute(sql).all()


### PR DESCRIPTION
Fixes a bug where workflow reset doesn't reset workflowrun statuses, meaning if the most recent workflowrun is in cold resume and the reaper is behind or inactive the user cannot set a resumable state on the workflow. 

As a small enhancement added a flag for users to indicate whether a full or partial reset should be performed, defaulting to full. A full reset sets "D" tasks to registering, whereas a partial reset does not. The former is desired if a user wants to use the same DAG to regenerate an existing results set, whereas the latter is for setting a workflow in a weird state into a resumable state. 

