### PR TITLE
handle key errors in partial swarm case

### DIFF
--- a/jobmon_client/src/jobmon/client/swarm/workflow_run.py
+++ b/jobmon_client/src/jobmon/client/swarm/workflow_run.py
@@ -855,6 +855,7 @@ class WorkflowRun:
 
         new_status_tasks: Set[SwarmTask] = set()
         for current_status, task_ids in response["tasks_by_status"].items():
+            task_ids = set(task_ids).intersection(self.tasks)
             for task_id in task_ids:
                 task = self.tasks[task_id]
                 if current_status != task.status:

--- a/tests/swarm/test_swarm.py
+++ b/tests/swarm/test_swarm.py
@@ -507,7 +507,7 @@ def test_swarm_terminate(tool):
     assert len(swarm.ready_to_run) == 0
 
 
-def test_resume_from_workflow_id(tool, task_template):
+def test_build_swarm_from_workflow_id(tool, task_template):
     workflow = tool.create_workflow()
 
     # Create a small example DAG.
@@ -574,3 +574,6 @@ def test_resume_from_workflow_id(tool, task_template):
     resume_swarm.set_initial_fringe()
     assert len(resume_swarm.ready_to_run) == 1
     assert resume_swarm.ready_to_run[0] == st3
+
+    # Run a full sync, test that no keyerrors are raised
+    resume_swarm._task_status_updates(full_sync=True)


### PR DESCRIPTION
Dead simple PR to prevent keyerrors in the resume from workflow path.

In summary, the errors are raised since a swarm created from the command line only builds a partial DAG, excluding tasks that are in "D" state. The full sync server path, however, returns statuses for all tasks bound to the workflow including done tasks. When full_sync is False, there is no error because those "D" tasks will have a status date prior to the swarm's last_sync timestamp. The expedient solution is just to do a set intersection between tasks in memory and tasks in the server response. 

There might be some inefficiency since the server will be serializing a large number of task IDs that the swarm does not need, but considering that full syncs are relatively infrequent it probably isn't a serious runtime concern. A more thorough solution might involve including the swarm's known task IDs to the server like in `queue_task_batch`, happy to hear if mimicking that path is desired. 