### PR TITLE
add necessary reaper config key, specify otlp optional dependency

### DIFF
--- a/jobmon_core/src/jobmon/core/defaults.yaml
+++ b/jobmon_core/src/jobmon/core/defaults.yaml
@@ -12,6 +12,9 @@ heartbeat:
   report_by_buffer: 3.1
   task_instance_interval: 90
 
+reaper:
+  poll_interval_minutes = 5
+
 distributor:
   poll_interval: 10
 

--- a/jobmon_server/pyproject.toml
+++ b/jobmon_server/pyproject.toml
@@ -30,6 +30,7 @@ jobmon_server = "jobmon.server.cli:main"
 
 [project.optional-dependencies]
 otlp = [
+    'jobmon_core[otlp]',
     'opentelemetry-instrumentation-flask',
     'opentelemetry-instrumentation-sqlalchemy',
 ]


### PR DESCRIPTION
Adds a dependency on core[otlp] in the server and adds a required reaper: poll_interval_minutes key in the defaults file