### PR TITLE
Prequery for initial task id

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/fsm/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/routes/fsm/workflow.py
@@ -401,6 +401,16 @@ def get_tasks_from_workflow(workflow_id: int) -> Any:
 
     session = SessionLocal()
 
+    if max_task_id == 0:
+        # Performance suffers heavily if we do a search with WHERE task.id > 0
+        # Therefore, select the smallest task ID in the workflow and use that as the initial
+        # floor.
+        with session.begin():
+            min_task_id = session.execute(
+                select(func.min(Task.id)).where(Task.workflow_id == workflow_id)
+            ).scalar()
+            max_task_id = min_task_id - 1
+
     with session.begin():
         # Query task table
         query = (


### PR DESCRIPTION
~Still need to test - nox tests do not work for me anymore, I think the web service utilites were never updated with the configuration updates.~ 

Prequery the initial ID for performance reasons. The cli/test_status_commands::test-resume_workflow_from_cli and the swarm/test_build_swarm_from_workflow_id tests both pass. 