### PR TITLE
Adds timeout to resume CLI.

### DIFF
--- a/jobmon_client/src/jobmon/client/cli.py
+++ b/jobmon_client/src/jobmon/client/cli.py
@@ -224,6 +224,7 @@ class ClientCLI(CLI):
             workflow_id=args.workflow_id,
             cluster_name=args.cluster_name,
             reset_if_running=args.reset_running_jobs,
+            timeout=args.timeout,
         )
 
     @staticmethod
@@ -592,6 +593,13 @@ class ClientCLI(CLI):
             help="whether to reset running jobs or not",
             required=False,
             action="store_true",
+        )
+        workflow_resume_parser.add_argument(
+            "-t",
+            "--timeout",
+            help="timeout for resume command",
+            required=False,
+            default=180,
         )
 
 

--- a/jobmon_client/src/jobmon/client/status_commands.py
+++ b/jobmon_client/src/jobmon/client/status_commands.py
@@ -605,7 +605,11 @@ def get_filepaths(
 
 
 def resume_workflow_from_id(
-    workflow_id: int, cluster_name: str, reset_if_running: bool = True, log: bool = True
+    workflow_id: int,
+    cluster_name: str,
+    reset_if_running: bool = True,
+    log: bool = True,
+    timeout: int = 180,
 ) -> None:
     """Given a workflow ID, resume the workflow.
 
@@ -631,7 +635,7 @@ def resume_workflow_from_id(
     swarm.from_workflow_id(workflow_id)
 
     with DistributorContext(
-        workflow_run_id=new_wfr.workflow_run_id, cluster_name=cluster_name, timeout=180
+        workflow_run_id=new_wfr.workflow_run_id, cluster_name=cluster_name, timeout=timeout
     ) as distributor:
         swarm.run(distributor_alive_callable=distributor.alive)
 


### PR DESCRIPTION
For large pipeline resumes, we needed access to the resume timeout.
This PR exposes that to the CLI so we don't need to hack our install.