### PR TITLE
Otlp client

### DIFF
--- a/jobmon_core/pyproject.toml
+++ b/jobmon_core/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     'requests',
     'tenacity>=8.1',
     'typing_extensions; python_version<"3.8"',
-    'proplot',
+    'proplot'
 ]
 dynamic = ["version"]
 

--- a/jobmon_core/pyproject.toml
+++ b/jobmon_core/pyproject.toml
@@ -19,16 +19,6 @@ dependencies = [
     'tenacity>=8.1',
     'typing_extensions; python_version<"3.8"',
     'proplot',
-    'opentelemetry-api',
-    'opentelemetry-sdk',
-    'opentelemetry-exporter-otlp',
-    'opentelemetry-distro',
-    'opentelemetry-instrumentation',
-    'opentelemetry-instrumentation-requests',
-    'opentelemetry-instrumentation-flask',
-    'opentelemetry-instrumentation-logging',
-    'opentelemetry-instrumentation-sqlalchemy',
-    'opentelemetry-instrumentation-asyncio',
 ]
 dynamic = ["version"]
 

--- a/jobmon_core/src/jobmon/core/otlp.py
+++ b/jobmon_core/src/jobmon/core/otlp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import getpass
 import logging
+import logging.config
 import os
 import socket
 import sys


### PR DESCRIPTION
"import loggin.config" seems to fix the "logging.config" not found issue.

Revert the openelementry install.