### PR TITLE
Add missing dependencies to gui test environment setup

### DIFF
--- a/jobmon_core/pyproject.toml
+++ b/jobmon_core/pyproject.toml
@@ -31,9 +31,7 @@ otlp = [
     'opentelemetry-api',
     'opentelemetry-sdk',
     'opentelemetry-instrumentation',
-    'opentelemetry-instrumentation-flask',
     'opentelemetry-instrumentation-requests',
-    'opentelemetry-instrumentation-sqlalchemy',
     'opentelemetry-exporter-otlp'
 ]
 

--- a/jobmon_core/pyproject.toml
+++ b/jobmon_core/pyproject.toml
@@ -31,7 +31,9 @@ otlp = [
     'opentelemetry-api',
     'opentelemetry-sdk',
     'opentelemetry-instrumentation',
+    'opentelemetry-instrumentation-flask',
     'opentelemetry-instrumentation-requests',
+    'opentelemetry-instrumentation-sqlalchemy',
     'opentelemetry-exporter-otlp'
 ]
 

--- a/jobmon_gui/README.md
+++ b/jobmon_gui/README.md
@@ -18,7 +18,7 @@ To deploy the Flask app locally:
 2. Make a conda environment and activate it
 3. Navigate to the top of the Jobmon repository
 4. Run `nox -s launch_gui_test_server`
-5. Run `python jobmon_gui/local_testing/jobmon_gui/testing_servers/functionaltest_server.py`
+5. Run `.nox/launch_gui_test_server/bin/python jobmon_gui/local_testing/jobmon_gui/testing_servers/functionaltest_server.py`
     - This command will spin up a local version of the Flask backend, running on 127.0.0.1:8070 by default. You can then configure the React app to point to this URL for testing purposes.
 
 ### Deploying the React App Locally

--- a/noxfile.py
+++ b/noxfile.py
@@ -200,7 +200,7 @@ def launch_gui_test_server(session: Session) -> None:
     session.conda_install("mysqlclient")
     if os.path.exists("/tmp/tests.sqlite"):
         os.remove("/tmp/tests.sqlite")
-    session.install("-e", "./jobmon_core[otlp]")
+    session.install("-e", "./jobmon_core")
     session.install("-e", "./jobmon_client")
-    session.install("-e", "./jobmon_server")
+    session.install("-e", "./jobmon_server[otlp]")
     session.run("python", "jobmon_gui/local_testing/jobmon_gui/testing_servers/_create_sqlite_db.py")

--- a/noxfile.py
+++ b/noxfile.py
@@ -200,7 +200,7 @@ def launch_gui_test_server(session: Session) -> None:
     session.conda_install("mysqlclient")
     if os.path.exists("/tmp/tests.sqlite"):
         os.remove("/tmp/tests.sqlite")
-    session.install("-e", "./jobmon_core")
+    session.install("-e", "./jobmon_core[otlp]")
     session.install("-e", "./jobmon_client")
     session.install("-e", "./jobmon_server")
     session.run("python", "jobmon_gui/local_testing/jobmon_gui/testing_servers/_create_sqlite_db.py")


### PR DESCRIPTION
I'm working through the setup for the gui developer environment and running into bugs.  PRing fixes as I find them.

Two changes here:
- It seems some telemetry was added to jobmon core, but some of the telemetery dependencies were not put into the pyproject.toml for jobmon_core.  So this adds those in and then updates the noxfile to make sure the extra telemetry dependencies get installed in the development environment (otherwise the `functionaltest_server.py` fails on import errors).
- Update the readme to use the python created by nox to run the test server.  