### PR TITLE
Upload to pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  build:
     # Nox probably does what we need
 #    strategy:
 #      matrix: { products: [ "jobmon-core", "jobmon-server", "jobmon-client" ] }
@@ -27,10 +27,17 @@ jobs:
         python -m pip install --upgrade pip
         pip install build nox
     - name: Build package
+      #ToDo Restrict to Jobmon-client?
       run: nox -s build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: dist
+  publish:
+      needs: ['build']
+      environment: 'deploy''
+      name: upload release to PyPI
+      runs-on: ubuntu-latest
+      permissions:
+        id-token: write
+      steps:
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages_dir: artifact/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,12 +1,4 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
+name: Build & Upload Python Package
 
 on:
   release:
@@ -17,6 +9,8 @@ permissions:
 
 jobs:
   deploy:
+    strategy:
+      matrix: { products: [ "jobmon-core", "jobmon-server", "jobmon-client" ] }
 
     runs-on: ubuntu-latest
 
@@ -25,12 +19,14 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
     - name: Build package
+      with:
+        working-directory: ${{ matrix.products }}
       run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install build nox
     - name: Build package
       run: nox -s build
     - name: Publish package

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     environment: 'deploy'
     runs-on: ubuntu-latest
+    # Advice on security best practice is to have two jobs, one for building and one for deploying to pypi.
+    # Only the deploying one has the write permissions. But splitting meant that the second job can't find the
+    # dist directory.
     permissions:
       id-token: write
     steps:
@@ -23,11 +26,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build nox setuptools wheel
+        pip install build nox
     - name: Build package
-      run: |
-        python -m build --sdist --wheel --outdir dist/ jobmon_client  
-        ls
-        ls -l dist
+      run: nox -s build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,9 @@ permissions:
 
 jobs:
   deploy:
-    strategy:
-      matrix: { products: [ "jobmon-core", "jobmon-server", "jobmon-client" ] }
+    # Nox probably does what we need
+#    strategy:
+#      matrix: { products: [ "jobmon-core", "jobmon-server", "jobmon-client" ] }
 
     runs-on: ubuntu-latest
 
@@ -19,17 +20,16 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.12'
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
     - name: Build package
-      with:
-        working-directory: ${{ matrix.products }}
-      run: python -m build
+      run: nox -s build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: dist

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: artifact/
+          packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build package
       #ToDo Restrict to Jobmon-client?
       run: |
-        nox -s build
+        python -m build --outdir dist --sdist --wheel jobmon_client  
         ls
         ls -l dist
   publish:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,5 +42,3 @@ jobs:
       steps:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   build:
+    environment: 'deploy'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -22,18 +25,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install build nox setuptools wheel
     - name: Build package
-      #ToDo Restrict to Jobmon-client?
       run: |
         python -m build --sdist --wheel --outdir dist/ jobmon_client  
         ls
         ls -l dist
-  publish:
-      needs: ['build']
-      environment: 'deploy'
-      name: upload release to PyPI
-      runs-on: ubuntu-latest
-      permissions:
-        id-token: write
-      steps:
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,3 +31,5 @@ jobs:
       run: nox -s build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,10 @@ jobs:
         pip install build nox
     - name: Build package
       #ToDo Restrict to Jobmon-client?
-      run: nox -s build
+      run: |
+        nox -s build
+        ls
+        ls -l dist
   publish:
       needs: ['build']
       environment: 'deploy'
@@ -40,4 +43,4 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: jobmon/dist/
+          packages-dir: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: dist/
+          packages-dir: jobmon/dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,12 +10,7 @@ permissions:
 
 jobs:
   build:
-    # Nox probably does what we need
-#    strategy:
-#      matrix: { products: [ "jobmon-core", "jobmon-server", "jobmon-client" ] }
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -29,7 +24,7 @@ jobs:
     - name: Build package
       #ToDo Restrict to Jobmon-client?
       run: |
-        python -m build --outdir dist --sdist --wheel jobmon_client  
+        python -m build --sdist --wheel --outdir dist/ jobmon_client  
         ls
         ls -l dist
   publish:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build nox
+        pip install build nox setuptools wheel
     - name: Build package
       #ToDo Restrict to Jobmon-client?
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,7 +31,7 @@ jobs:
       run: nox -s build
   publish:
       needs: ['build']
-      environment: 'deploy''
+      environment: 'deploy'
       name: upload release to PyPI
       runs-on: ubuntu-latest
       permissions:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,6 +3,7 @@ name: Build & Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/jobmon_client/README.md
+++ b/jobmon_client/README.md
@@ -1,0 +1,13 @@
+# JobMon Client
+
+## Introduction
+
+JobMon is a Python package developed by IHME's Scientific Computing team,
+designed to simplify and standardize the process of job monitoring and
+workflow management in computational projects.
+It facilitates the tracking of job statuses, manages dependencies,
+and streamlines the execution of complex workflows across various computing environments.
+
+This package is imported into the customer's codebase and used to interact with the JobMon server. 
+
+See also the main documentation at [readthedocs](https://jobmon.readthedocs.io/en/latest/#).

--- a/jobmon_client/pyproject.toml
+++ b/jobmon_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jobmon_client"
-description="A dependency management utility for batch computation."
+description="A dependency management utility with retires and resource management for HPC computation."
 readme="README.md"
 requires-python = ">=3.9"
 classifiers = [

--- a/jobmon_client/pyproject.toml
+++ b/jobmon_client/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jobmon_client"
 description="A dependency management utility for batch computation."
+readme="README.md"
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3.9",

--- a/jobmon_core/README.md
+++ b/jobmon_core/README.md
@@ -1,0 +1,14 @@
+# JobMon Core
+
+## Introduction
+
+JobMon is a Python package developed by IHME's Scientific Computing team,
+designed to simplify and standardize the process of job monitoring and
+workflow management in computational projects.
+It facilitates the tracking of job statuses, manages dependencies,
+and streamlines the execution of complex workflows across various computing environments.
+
+This package contains the code that it is shared between the client and the server, and
+is deployed to the customer's worked node. 
+
+See also the main documentation at [readthedocs](https://jobmon.readthedocs.io/en/latest/#).

--- a/jobmon_core/pyproject.toml
+++ b/jobmon_core/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jobmon_core"
 description="Shared functionality for Jobmon Namespace Packages"
-readme="../README.md"
+readme="README.md"
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3.9",

--- a/jobmon_core/pyproject.toml
+++ b/jobmon_core/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jobmon_core"
 description="Shared functionality for Jobmon Namespace Packages"
+readme="../README.md"
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3.9",

--- a/jobmon_server/README.md
+++ b/jobmon_server/README.md
@@ -1,0 +1,13 @@
+# JobMon Server
+
+## Introduction
+
+JobMon is a Python package developed by IHME's Scientific Computing team,
+designed to simplify and standardize the process of job monitoring and
+workflow management in computational projects.
+It facilitates the tracking of job statuses, manages dependencies,
+and streamlines the execution of complex workflows across various computing environments.
+
+This package contains the code that executes as a central server, typically containerized. 
+
+See also the main documentation at [readthedocs](https://jobmon.readthedocs.io/en/latest/#).

--- a/jobmon_server/pyproject.toml
+++ b/jobmon_server/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jobmon_server"
 description = "Web Service and Model for Jobmon"
+readme="README.md"
 requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3.9",

--- a/noxfile.py
+++ b/noxfile.py
@@ -114,7 +114,7 @@ def build(session: Session) -> None:
 
     for src_dir in args:
         namespace_dir = str(Path(src_dir).parent)
-        session.run("python", "-m", "build", "--sdist", "--wheel", "--outdir", "dist", namespace_dir)
+        session.run("python", "-m", "build", "--outdir", "dist", namespace_dir)
 
 
 @nox.session(python=python, venv_backend="conda")

--- a/noxfile.py
+++ b/noxfile.py
@@ -114,7 +114,7 @@ def build(session: Session) -> None:
 
     for src_dir in args:
         namespace_dir = str(Path(src_dir).parent)
-        session.run("python", "-m", "build", "--outdir", "dist", namespace_dir)
+        session.run("python", "-m", "build", "--sdist", "--wheel", "--outdir", "dist", namespace_dir)
 
 
 @nox.session(python=python, venv_backend="conda")


### PR DESCRIPTION
Modified the python-publish.yml workflow to use "trusted publisher" to publish to pypi.org.  Lots of configuration in pypi.org to support this. Also created a new environment in github actions: pypi-prod.