### PR TITLE
Task Generator Round 3 Part 1

### DIFF
--- a/jobmon_core/src/jobmon/core/task_generator.py
+++ b/jobmon_core/src/jobmon/core/task_generator.py
@@ -217,7 +217,10 @@ class TaskGenerator:
                 serializer, which converts an object of the type to a string. And the second is
                 a deserializer, which converts a string to an object of the type.
             tool_name: A jobmon tool name for generating tasks.
-            naming_args: A list of arguments to use in the task name. If not provided, uses all
+            naming_args: A list of arguments to use in the task name. If not provided (or
+                ``None``), it uses all the arguments. If ``[]`` is provided, it uses no naming
+                arguments, and the name of the task will just be the name of the task function.
+            max_attempts: The max number of attempts jobmon will make on the tasks
             max_attempts: The max number of attempts jobmon will make on the tasks
             module_source_path: The path to the module source code. If not provided,
                                 the module is assumed to be installed in the system.
@@ -236,9 +239,7 @@ class TaskGenerator:
                 self.task_function
             ).parameters.items()
         }
-        self._naming_args = (
-            naming_args if naming_args is not None else self.params.keys()
-        )
+        self._naming_args = naming_args if naming_args is not None else self.params.keys()
 
         self._validate_task_function()
 
@@ -536,10 +537,8 @@ class TaskGenerator:
             if value == SERIALIZED_EMPTY_STRING:
                 kwargs_for_name[key] = ""
 
-        name = (
-            self.name
-            + ":"
-            + ":".join(f"{name}={value}" for name, value in kwargs_for_name.items())
+        name = ":".join(
+            [self.name] + [f"{name}={value}" for name, value in kwargs_for_name.items()]
         )
         # trim ending :
         if name[-1] == ":":

--- a/jobmon_core/src/jobmon/core/task_generator.py
+++ b/jobmon_core/src/jobmon/core/task_generator.py
@@ -239,11 +239,13 @@ class TaskGenerator:
                 self.task_function
             ).parameters.items()
         }
-        self._naming_args = naming_args if naming_args is not None else self.params.keys()
+        self._naming_args = (
+            naming_args if naming_args is not None else self.params.keys()
+        )
 
         self._validate_task_function()
 
-        self._generate_task_template()
+        self._task_template = None
 
     def _validate_task_function(self) -> None:
         """Check that a task can be generated from the task_function.
@@ -507,6 +509,8 @@ class TaskGenerator:
 
     def create_task(self, compute_resources: Dict, **kwargs: Any) -> Task:
         """Create a task for the task_function with the given kwargs."""
+        if self._task_template is None:
+            self._generate_task_template()
         executable_path = _find_executable_path(executable_name=TASK_RUNNER_NAME)
         # Serialize the kwargs
         serialized_kwargs = {
@@ -557,6 +561,8 @@ class TaskGenerator:
 
     def create_tasks(self, compute_resources: Dict, **kwargs: Any) -> List[Task]:
         """Create a task array for the task_function with the given kwargs."""
+        if self._task_template is None:
+            self._generate_task_template()
         executable_path = _find_executable_path(executable_name=TASK_RUNNER_NAME)
         # Serialize the kwargs
         serialized_kwargs = {
@@ -760,6 +766,8 @@ def get_tasks_by_node_args(
         result = []
 
     if not result and error_on_empty:
-        raise ValueError(f"There were no tasks in the workflow that matched {node_args_dict}")
+        raise ValueError(
+            f"There were no tasks in the workflow that matched {node_args_dict}"
+        )
 
     return result

--- a/jobmon_core/src/jobmon/core/task_generator.py
+++ b/jobmon_core/src/jobmon/core/task_generator.py
@@ -549,7 +549,7 @@ class TaskGenerator:
             name = name[:-1]
 
         # Create the task
-        task = self._task_template.create_task(
+        task = self._task_template.create_task(  # type: ignore
             name=name,
             compute_resources=compute_resources,
             max_attempts=self.max_attempts,
@@ -584,7 +584,7 @@ class TaskGenerator:
         # name is auto for array
 
         # Create the task
-        tasks = self._task_template.create_tasks(
+        tasks = self._task_template.create_tasks(  # type: ignore
             compute_resources=compute_resources,
             max_attempts=self.max_attempts,
             executable=executable_path,

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,7 @@ def typecheck(session: Session) -> None:
     args = session.posargs or src_locations
     session.install("mypy", "types-Flask", "types-requests", "types-PyMySQL", "types-filelock",
                     "types-PyYAML", "types-tabulate", "types-psutil", "types-Flask-Cors",
-                    "types-sqlalchemy-utils", "types-pkg-resources", "types-mysqlclient")
+                    "types-sqlalchemy-utils", "types-setuptools", "types-mysqlclient")
     session.install("-e", "./jobmon_core", "-e", "./jobmon_client", "-e", "./jobmon_server")
 
     session.run("mypy", "--explicit-package-bases", *args)

--- a/tests/worker_node/test_task_generator.py
+++ b/tests/worker_node/test_task_generator.py
@@ -956,7 +956,7 @@ def test_fhs_task(client_env, monkeypatch) -> None:
     assert tasks[1].command == expected_command2
 
 
-def test_task_template_only_generated_once(client_env, monkeypatch) -> None:
+def test_task_template_not_generated_when_instance_only_generated_once(client_env, monkeypatch) -> None:
     """Test the self._task_template only gererate once."""
     # Set up function
     monkeypatch.setattr(
@@ -974,19 +974,19 @@ def test_task_template_only_generated_once(client_env, monkeypatch) -> None:
         serializers={},
         tool_name="test_tool"
     )
-    assert tg._task_template is not None
-    tg_task_template = tg._task_template
-    tg_task_template_id = tg_task_template.id
+    # test
+    assert tg._task_template is None
 
     # create a task
     tg.create_task(compute_resources={}, foo=1)
     # verify the task_template is the same
-    assert tg._task_template is tg_task_template
-    assert tg_task_template_id == tg._task_template.id
-    # create a taskn
+    tt = tg._task_template
+    assert tt is not None
+    tg_task_template_id = tt.id
+    # create another task
     tg.create_task(compute_resources={}, foo=2)
     # verify the task_template is the same
-    assert tg._task_template is tg_task_template
+    assert tg._task_template is tt
     assert tg_task_template_id == tg._task_template.id
 
 


### PR DESCRIPTION
This PR is trying to fix these three issues:

1. GBDSCI-6420 - No naming args support
There is no actual function change, and it seems the previous rounds had already include this with test case, but I modified the code slightly to match the latest version of FHS.

2. GBDSCI-6419 - add task template deferral
There is function change to move the task template creation to when the first task creation, and added a few test cases. 

3. GBDSCI-6421 - Modify get_tasks_with_node_args to support object input
There is actual code change for this one. I have no idea why I had the serializer removed from get_tasks_with_node_args in previous rounds, which doesn't make any sense. My best guess is I might remove it for debugging, but forgot to add it back, so added a few test cases for this one too.