### PR TITLE
Remove invalid date from workflow information modal

### DIFF
--- a/jobmon_gui/src/components/workflow_overview/WorkflowList.tsx
+++ b/jobmon_gui/src/components/workflow_overview/WorkflowList.tsx
@@ -242,10 +242,6 @@ export default function WorkflowList() {
                             <Typography
                                 sx={modalValuesStyles}>{convertDatePST(workflowDetails.wf_submitted_date)}</Typography>
                         </Grid>
-                        <Grid item xs={8}>
-                            <Typography
-                                sx={modalValuesStyles}>{convertDatePST(workflowDetails.wf_submitted_date_end)}</Typography>
-                        </Grid>
                         <Grid item xs={4}>
                             <Typography sx={modalTitleStyles}>Status Date:</Typography>
                         </Grid>


### PR DESCRIPTION
WHAT:
The workflow information modal was showing INVALID DATE. There was a parameter that was being displayed that we didn't need that was invalid, I deleted it.