### PR TITLE
Bugfix/gbdsci 6490 wrong time in task table

### DIFF
--- a/jobmon_gui/src/components/workflow_details/TaskTable.tsx
+++ b/jobmon_gui/src/components/workflow_details/TaskTable.tsx
@@ -109,7 +109,7 @@ export default function TaskTable({taskTemplateName, workflowId}: TaskTableProps
             header: "Status Date",
             accessorKey: "task_status_date",
             Cell: ({renderedCellValue}) => (
-                convertDatePST(convertDate(renderedCellValue).toISOString())
+                convertDatePST(renderedCellValue)
             )
         },
     ];


### PR DESCRIPTION
Status date in task table on workflow details page was showing in UTC instead of PDT/PST
