### PR TITLE
Fix bug where only 10 errors were showing in clustered errors

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v2/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v2/cli/task_template.py
@@ -610,9 +610,10 @@ def get_tt_error_log_viz(tt_id: int, wf_id: int, ti_id: Optional[int]) -> Any:
             )
             .where(*where_conditions)
             .order_by(TaskInstanceErrorLog.id.desc())
-            .offset(offset)
-            .limit(page_size)
         )
+
+        if not output_clustered_errors:
+            sql = sql.offset(offset).limit(page_size)
 
         rows = session.execute(sql).all()
         session.commit()


### PR DESCRIPTION
WHAT:
Clustered errors were only showing a max of 10 errors each time do to a logic error with server side pagination.