### PR TITLE
Add DB API info to docs

### DIFF
--- a/docsource/monitoring_debugging.rst
+++ b/docsource/monitoring_debugging.rst
@@ -96,6 +96,100 @@ By default the query returns 5 results but you can always increase the limit usi
 Jobmon Database
 ###############
 
+Jobmon Database API
+*******************
+
+This API allows users to query the database for detailed resource usage information. There are currently two routes:
+    1. **/wf_resource_usage** - which allows users to query resource usage by Workflow ID.
+    2. **/tool_resource_usage** - which allows users to query resource usage by Tool name.
+
+Base URL
+--------
+
+All API requests should be made to the base URL provided on the **"Jobmon at IHME"** page, accessible through
+the Jobmon GUI.
+
+Authentication
+--------------
+
+Currently, the Database API does not require authentication. In future releases, this may be updated, so check this
+section for any changes.
+
+Resource Usage by Workflow ID
+-----------------------------
+**Endpoint:** `GET <base_url>/workflow/<workflow_id>/wf_resource_usage`
+
+**Parameters:**
+    - Workflow ID
+
+**Description**: Gets the resource usage for all TaskInstances associated with a provided workflow ID.
+
+**Example Response**
+    - **Status Code:** `200 OK`
+    - **Content-Type:** `application/json`
+    - **Body:**
+
+      .. code-block::
+
+          [
+              {
+                  "task_id": 6213741,
+                  "task_name": "random_task_name",
+                  "task_status": "D",
+                  "task_num_attempts": 2,
+                  "task_instance_id": 91823412,
+                  "ti_usage_str": "wallclock=8 cpu=1, mem=7 GBs, io=5 GB",
+                  "ti_wallclock": 8,
+                  "ti_maxrss": 7,
+                  "ti_maxpss": 5,
+                  "ti_cpu": 1,
+                  "ti_io": 5,
+                  "ti_status": "D"
+              }
+          ]
+
+
+
+Resource Usage by Tool Name
+-----------------------------------
+**Endpoint:** `GET <base_url>/tool/<tool_name>/tool_resource_usage?start_date=<YYYY-MM-DD>&end_date=<YYYY-MM-DD>`
+
+**Parameters:**
+    - Tool name
+    - Start date
+    - End date
+
+**Description**: Pass a tool name to the route and it will return the requested resources, utilized resources and
+node_args for TaskInstances associated with that tool. NOTE: it is required to pass a start and end date.
+
+**Example Response**
+    - **Status Code:** `200 OK`
+    - **Content-Type:** `application/json`
+    - **Body:**
+
+      .. code-block::
+
+        [
+            {
+                "node_arg_val": "--provenance True",
+                "ti_id": 12345677,
+                "ti_maxrss": 50844672,
+                "ti_requested_resources": {"runtime": 21600, "memory": 10},
+                "ti_wallclock": 20
+            },
+            {
+                "node_arg_val": "--intrinsic False",
+                "ti_id": 12345678,
+                "ti_maxrss": 43960320,
+                "ti_requested_resources": {"runtime": 21600, "memory": 10},
+                "ti_wallclock": 22
+            }
+        ]
+
+Additional Routes
+-----------------
+If there are any other routes or features you would like to see in the API, please let the SciComp team know.
+
 Running Queries
 ***************
 If the command line status commands do not provide the information you need,

--- a/jobmon_gui/src/assets/content/JobmonAtIhme.md
+++ b/jobmon_gui/src/assets/content/JobmonAtIhme.md
@@ -84,6 +84,13 @@ Port: {{JOBMON_DB_PORT}}
 
 Please note to access the Jobmon database you need to switch your VPN to "All Internet Traffic" in your Big-IP Edge Client.
 
+## Jobmon Database API
+The base URL for the Jobmon Database API is:
+
+```shell
+{{JOBMON_BASE_URL}}
+```
+
 ### Jobmon ERD
 
 ![Jobmon ERD](jobmon_erd.svg)

--- a/jobmon_gui/src/screens/JobmonAtIhme.tsx
+++ b/jobmon_gui/src/screens/JobmonAtIhme.tsx
@@ -10,6 +10,7 @@ const templateData = {
     JOBMON_DB_PASSWORD: import.meta.env.VITE_APP_DOCS_DB_PASSWORD,
     JOBMON_DB_DATABASE: import.meta.env.VITE_APP_DOCS_DB_DATABASE,
     JOBMON_DB_PORT: import.meta.env.VITE_APP_DOCS_DB_PORT,
+    JOBMON_BASE_URL: import.meta.env.VITE_APP_BASE_URL,
 };
 
 export default function JobmonAtIHME() {


### PR DESCRIPTION
You can see the changes displayed here: https://jobmon.readthedocs.io/en/feat-gbdsci-6565-add-db-api-functionality-to-docs/monitoring_debugging.html#jobmon-database-api
