### PR TITLE
Tooltips and cursor as pointer for applicable info icons

### DIFF
--- a/jobmon_gui/src/components/task_details/TaskInstanceTable.tsx
+++ b/jobmon_gui/src/components/task_details/TaskInstanceTable.tsx
@@ -1,10 +1,12 @@
 import React, {useState} from 'react';
 import {HiInformationCircle} from "react-icons/hi";
+import {HtmlTooltip} from "@jobmon_gui/components/HtmlToolTip";
 import CustomModal from '@jobmon_gui/components/Modal';
 import {formatBytes} from "@jobmon_gui/utils/formatters";
 import humanizeDuration from 'humanize-duration';
 import {MaterialReactTable} from "material-react-table";
 import {Box} from "@mui/material";
+import IconButton from "@mui/material/IconButton";
 
 
 export default function TaskInstanceTable({taskInstanceData}) {
@@ -103,7 +105,24 @@ export default function TaskInstanceTable({taskInstanceData}) {
                     <p className='color-dark'>
                         Task Instances&nbsp;
                         <span>
-                            <HiInformationCircle onClick={() => showModal("status")}/>
+                            <HtmlTooltip
+                                title="Task Instance Statuses"
+                                arrow={true}
+                                placement={"right"} 
+                            >
+                                <IconButton
+                                    color="inherit"
+                                    sx={{
+                                        padding: 0,
+                                        fontSize: 'inherit',
+                                    }}
+                                >
+                                    <HiInformationCircle
+                                        style={{cursor: 'pointer'}}
+                                        onClick={() => showModal("status")}
+                                    />
+                                </IconButton>
+                            </HtmlTooltip>
                         </span>
                     </p>
                 </header>

--- a/jobmon_gui/src/components/workflow_details/WorkflowHeader.tsx
+++ b/jobmon_gui/src/components/workflow_details/WorkflowHeader.tsx
@@ -8,6 +8,8 @@ import {TbHandStop} from "react-icons/tb";
 import {HiRocketLaunch} from "react-icons/hi2";
 import {HiInformationCircle} from "react-icons/hi";
 import React, {useState} from "react";
+import IconButton from "@mui/material/IconButton";
+import {HtmlTooltip} from "@jobmon_gui/components/HtmlToolTip";
 import CustomModal from '@jobmon_gui/components/Modal';
 
 export default function WorkflowHeader({
@@ -46,7 +48,24 @@ export default function WorkflowHeader({
                     {wf_id} - {wf_name}
                 </p>
                 <span style={{transform: 'translateY(-5px)', paddingLeft: '10px'}}>
-                    <HiInformationCircle onClick={() => setShowWFInfo(true)}/>
+                    <HtmlTooltip
+                        title="Workflow Information"
+                        arrow={true}
+                        placement={"right"} 
+                    >
+                        <IconButton
+                            color="inherit"
+                            sx={{
+                                padding: 0,
+                                fontSize: 'inherit',
+                            }}
+                        >
+                            <HiInformationCircle
+                                style={{cursor: 'pointer'}}
+                                onClick={() => setShowWFInfo(true)}
+                            />
+                        </IconButton>
+                    </HtmlTooltip>
                 </span>
             </div>
             <div>

--- a/jobmon_gui/src/screens/TaskDetails.tsx
+++ b/jobmon_gui/src/screens/TaskDetails.tsx
@@ -7,7 +7,9 @@ import NodeLists from '@jobmon_gui/components/task_details/NodeLists';
 import TaskFSM from '@jobmon_gui/components/task_details/TaskFSM';
 import {convertDatePST} from '@jobmon_gui/utils/formatters'
 import {HiInformationCircle} from "react-icons/hi";
+import {HtmlTooltip} from "@jobmon_gui/components/HtmlToolTip";
 import CustomModal from '@jobmon_gui/components/Modal';
+import IconButton from "@mui/material/IconButton";
 
 function getTaskDetails(setTaskStatus, setWorkflowId, setTaskName, setTaskCommand, setTaskStatusDate, taskId) {
     // Returns task status and workflow ID
@@ -134,13 +136,47 @@ export default function TaskDetails() {
                     <p className='color-dark'>
                         Task Name: {task_name}&nbsp;
                         <span>
-                            <HiInformationCircle onClick={() => setShowTaskInfo(true)}/>
+                            <HtmlTooltip
+                                title="Task Information"
+                                arrow={true}
+                                placement={"right"} 
+                            >
+                                <IconButton
+                                    color="inherit"
+                                    sx={{
+                                        padding: 0,
+                                        fontSize: 'inherit',
+                                    }}
+                                >
+                                    <HiInformationCircle
+                                        style={{cursor: 'pointer'}}
+                                        onClick={() => setShowTaskInfo(true)}
+                                    />
+                                </IconButton>
+                            </HtmlTooltip>
                         </span>
                     </p>
                     <p className="color-dark">
                         Task Finite State Machine&nbsp;
                         <span>
-                            <HiInformationCircle onClick={() => setShowTaskFSM(true)}/>
+                        <HtmlTooltip
+                                title="Task Finite State Machine"
+                                arrow={true}
+                                placement={"right"} 
+                            >
+                                <IconButton
+                                    color="inherit"
+                                    sx={{
+                                        padding: 0,
+                                        fontSize: 'inherit',
+                                    }}
+                                >
+                                    <HiInformationCircle
+                                        style={{cursor: 'pointer'}}
+                                        onClick={() => setShowTaskFSM(true)}
+                                    />
+                                </IconButton>
+                            </HtmlTooltip>
                         </span>
                     </p>
                 </header>


### PR DESCRIPTION
## Description

Sets `cursor: 'pointer'` for hover of (i) info icons if/when it is the type where user needs to click in order to see info (e.g. info is hidden in modal) so that user immediately intuits that a click is required to display the information. Also decided to add tooltips (using our custom `HtmlTooltip` component to wrap) for each of these.

## Type of Change

Minor GUI update

## Changes Made

- Adds `cursor: 'pointer'` style to `HiInformationCircle` info icons where user needs to click in order to see info
- Adds `HtmlTooltip` wrap to these icons with appropriate titles

## Screenshots


https://github.com/user-attachments/assets/9ae060e3-7e60-46b4-aaa3-86e845b36dd0



## Additional Notes

Unlike [this concurrent branch](https://github.com/ihmeuw-scicomp/jobmon/tree/feat/GBDSCI-6554_task-instance-table-clickability), I have not made a `common` component (e.g. with props for tooltip text, `onClick` event) to avoid repetative code. But we could make like a `HtmlTooltipIconButton` or something. Please let me know if the DRYer approach would be preferable.