### PR TITLE
Remove Landing Page Auto-Filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist
 .coverage
 .coverage.*
 .test_report.xml
+jobmon.db
 
 # ignore cache directories
 *__pycache__*

--- a/jobmon_gui/src/components/workflow_overview/WorkflowFilters.tsx
+++ b/jobmon_gui/src/components/workflow_overview/WorkflowFilters.tsx
@@ -2,7 +2,7 @@ import {Button, FormControl, Grid, InputLabel, MenuItem, Select, TextField} from
 import {DatePicker, LocalizationProvider} from "@mui/x-date-pickers";
 import {AdapterDayjs} from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {useWorkflowSearchSettings} from "@jobmon_gui/stores/workflow_settings";
 import {useSearchParams} from "react-router-dom";
 import {useQueryClient} from "@tanstack/react-query";
@@ -11,22 +11,76 @@ import Box from "@mui/material/Box";
 export default function WorkflowFilters() {
     const queryClient = useQueryClient()
     const workflowSettings = useWorkflowSearchSettings()
-    const [searchParams, setSearchParams] = useSearchParams();
+    const [searchParams] = useSearchParams();
 
+    const [localFilters, setLocalFilters] = useState({
+        user: "",
+        wf_args: "",
+        wf_attribute_key: "",
+        wf_attribute_value: "",
+        tool: "",
+        date_submitted: null,
+        date_submitted_end: null,
+        wf_name: "",
+        status: "",
+        wf_id: ""
+    });
 
-    useEffect(() => workflowSettings.loadValuesFromSearchParams(searchParams), [])
+    useEffect(() => {
+        workflowSettings.loadValuesFromSearchParams(searchParams);
+        setLocalFilters({
+            user: workflowSettings.get().user,
+            wf_args: workflowSettings.get().wf_args,
+            wf_attribute_key: workflowSettings.get().wf_attribute_key,
+            wf_attribute_value: workflowSettings.get().wf_attribute_value,
+            tool: workflowSettings.get().tool,
+            date_submitted: workflowSettings.get().date_submitted,
+            date_submitted_end: workflowSettings.get().date_submitted_end,
+            wf_name: workflowSettings.get().wf_name,
+            status: workflowSettings.get().status,
+            wf_id: workflowSettings.get().wf_id
+        });
+    }, []);
 
     const handleClear = () => {
-        void queryClient.invalidateQueries({queryKey: ["workflow_overview", "workflows"]})
-        workflowSettings.clear()
-        workflowSettings.triggerDataRefresh()
-    }
+        workflowSettings.clear();
+        setLocalFilters({
+            user: "",
+            wf_args: "",
+            wf_attribute_key: "",
+            wf_attribute_value: "",
+            tool: "",
+            date_submitted: null,
+            date_submitted_end: null,
+            wf_name: "",
+            status: "",
+            wf_id: ""
+        });
+        workflowSettings.triggerDataRefresh();
+        void queryClient.invalidateQueries({ queryKey: ["workflow_overview", "workflows"] });
+    };
 
     const handleSubmit = (event) => {
-        void queryClient.invalidateQueries({queryKey: ["workflow_overview", "workflows"]})
-        workflowSettings.triggerDataRefresh()
         event.preventDefault();
-    }
+        workflowSettings.set({
+            user: localFilters.user,
+            wf_args: localFilters.wf_args,
+            wf_attribute_key: localFilters.wf_attribute_key,
+            wf_attribute_value: localFilters.wf_attribute_value,
+            tool: localFilters.tool,
+            date_submitted: localFilters.date_submitted,
+            date_submitted_end: localFilters.date_submitted_end,
+            wf_name: localFilters.wf_name,
+            status: localFilters.status,
+            wf_id: localFilters.wf_id
+        });
+        workflowSettings.triggerDataRefresh();
+        void queryClient.invalidateQueries({ queryKey: ["workflow_overview", "workflows"] });
+    };
+
+    const handleInputChange = (key, value) => {
+        setLocalFilters((prev) => ({ ...prev, [key]: value }));
+    };
 
     return (<Box className="div-level-2">
         <form onSubmit={handleSubmit}>
@@ -34,43 +88,42 @@ export default function WorkflowFilters() {
                 <Grid item xs={3}>
                     <TextField label="Username"
                                fullWidth={true}
-                               value={workflowSettings.get().user}
-                               onChange={(e) => workflowSettings.setUser(e.target.value)}/>
+                               value={localFilters.user}
+                               onChange={(e) => handleInputChange("user", e.target.value)}/>
                 </Grid>
                 <Grid item xs={3}>
                     <TextField label="Workflow Args"
                                fullWidth={true}
-                               value={workflowSettings.get().wf_args}
-                               onChange={(e) => workflowSettings.setWfArgs(e.target.value)}/>
+                               value={localFilters.wf_args}
+                               onChange={(e) => handleInputChange("wf_args", e.target.value)}/>
                 </Grid>
                 <Grid item xs={1.5}>
                     <TextField label="WF Attribute Key"
                                fullWidth={true}
-                               value={workflowSettings.get().wf_attribute_key}
-                               onChange={(e) => workflowSettings.setWfAttributeKey(e.target.value)}/>
+                               value={localFilters.wf_attribute_key}
+                               onChange={(e) => handleInputChange("wf_attribute_key", e.target.value)}/>
 
                 </Grid>
                 <Grid item xs={1.5}>
                     <TextField label="WF Attribute Value" fullWidth={true}
-                               value={workflowSettings.get().wf_attribute_value}
-                               onChange={(e) => workflowSettings.setWfAttributeValue(e.target.value)}/>
+                               value={localFilters.wf_attribute_value}
+                               onChange={(e) => handleInputChange("wf_attribute_value", e.target.value)}/>
 
                 </Grid>
                 <Grid item xs={3}>
                     <TextField label="Tool"
                                fullWidth={true}
-                               value={workflowSettings.get().tool}
-                               onChange={(e) => workflowSettings.setTool(e.target.value)}/>
+                               value={localFilters.tool}
+                               onChange={(e) => handleInputChange("tool", e.target.value)}/>
 
                 </Grid>
                 <Grid item xs={1.5}>
                     <LocalizationProvider dateAdapter={AdapterDayjs}>
                         <DatePicker
                             label={"Submitted Date Start"}
-                            value={dayjs(workflowSettings.get().date_submitted) || dayjs("1970-01-01")}
-                            onChange={(value) => workflowSettings.setDateSubmitted(value)}
+                            value={localFilters.date_submitted ? dayjs(localFilters.date_submitted) : dayjs("1970-01-01")}
+                            onChange={(value) => handleInputChange("date_submitted", value)}
                             sx={{width: "100%"}}
-
                         />
                     </LocalizationProvider>
 
@@ -79,10 +132,9 @@ export default function WorkflowFilters() {
                     <LocalizationProvider dateAdapter={AdapterDayjs}>
                         <DatePicker
                             label={"Submitted Date End"}
-                            value={dayjs(workflowSettings.get().date_submitted_end) || dayjs("1970-01-01")}
-                            onChange={(value) => workflowSettings.setDateSubmittedEnd(value)}
+                            value={localFilters.date_submitted ? dayjs(localFilters.date_submitted_end) : dayjs("1970-01-01")}
+                            onChange={(value) => handleInputChange("date_submitted_end", value)}
                             sx={{width: "100%"}}
-
                         />
                     </LocalizationProvider>
 
@@ -90,8 +142,8 @@ export default function WorkflowFilters() {
                 <Grid item xs={3}>
                     <TextField label="Workflow Name"
                                fullWidth={true}
-                               value={workflowSettings.get().wf_name}
-                               onChange={(e) => workflowSettings.setWfName(e.target.value)}/>
+                               value={localFilters.wf_name}
+                               onChange={(e) => handleInputChange("wf_name", e.target.value)}/>
 
                 </Grid>
                 <Grid item xs={3}>
@@ -101,8 +153,8 @@ export default function WorkflowFilters() {
 
                                 label="Workflow Status"
                                 id={"SELECT-workflow-status"}
-                                onChange={(e) => workflowSettings.setStatus(e.target.value)}
-                                value={workflowSettings.get().status}
+                                onChange={(e) => handleInputChange("status", e.target.value)}
+                                value={localFilters.status}
                                 fullWidth={true}>
                             <MenuItem>{undefined}</MenuItem>
                             <MenuItem value="A">Aborted</MenuItem>
@@ -119,8 +171,8 @@ export default function WorkflowFilters() {
                 </Grid>
                 <Grid item xs={3}>
                     <TextField label="Workflow ID" fullWidth={true}
-                               value={workflowSettings.get().wf_id}
-                               onChange={(e) => workflowSettings.setWfId(e.target.value)}/>
+                               value={localFilters.wf_id}
+                               onChange={(e) => handleInputChange("wf_id", e.target.value)}/>
 
                 </Grid>
                 <Grid item xs={12}>
@@ -132,9 +184,8 @@ export default function WorkflowFilters() {
                             </Button>
                         </Grid>
                         <Grid item xs={2}>
-
-                            <Button variant="contained" onClick={() => handleClear()}>Clear
-                                All
+                            <Button variant="contained" onClick={handleClear}>
+                                Clear All
                             </Button>
                         </Grid>
                         <Grid item xs={4}/>

--- a/jobmon_gui/src/components/workflow_overview/WorkflowFilters.tsx
+++ b/jobmon_gui/src/components/workflow_overview/WorkflowFilters.tsx
@@ -4,17 +4,15 @@ import {AdapterDayjs} from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import React, {useEffect} from "react";
 import {useWorkflowSearchSettings} from "@jobmon_gui/stores/workflow_settings";
-import {useSearchParams} from "react-router-dom";
 import {useQueryClient} from "@tanstack/react-query";
 import Box from "@mui/material/Box";
 
 export default function WorkflowFilters() {
     const queryClient = useQueryClient()
     const workflowSettings = useWorkflowSearchSettings()
-    const [searchParams] = useSearchParams();
 
     useEffect(() => {
-        workflowSettings.loadValuesFromSearchParams(searchParams);
+        workflowSettings.loadValuesFromSearchParams(new URLSearchParams(window.location.search));
     }, []);
 
     const handleClear = () => {
@@ -40,25 +38,25 @@ export default function WorkflowFilters() {
                 <Grid item xs={3}>
                     <TextField
                         label="Username"
+                        fullWidth={true}
                         value={workflowSettings.getPending().user}
                         onChange={(e) => handleInputChange("user", e.target.value)}
-                        fullWidth={true}
                     />
                 </Grid>
                 <Grid item xs={3}>
                     <TextField
                         label="Workflow Args"
+                        fullWidth={true}
                         value={workflowSettings.getPending().wf_args}
                         onChange={(e) => handleInputChange("wf_args", e.target.value)}
-                        fullWidth={true}
                     />
                 </Grid>
                 <Grid item xs={1.5}>
                     <TextField
                         label="WF Attribute Key"
+                        fullWidth={true}
                         value={workflowSettings.getPending().wf_attribute_key}
                         onChange={(e) => handleInputChange("wf_attribute_key", e.target.value)}
-                        fullWidth={true}
                     />
 
                 </Grid>
@@ -73,9 +71,9 @@ export default function WorkflowFilters() {
                 <Grid item xs={3}>
                     <TextField
                         label="Tool"
+                        fullWidth={true}
                         value={workflowSettings.getPending().tool}
                         onChange={(e) => handleInputChange("tool", e.target.value)}
-                        fullWidth={true}
                     />
 
                 </Grid>
@@ -83,8 +81,8 @@ export default function WorkflowFilters() {
                     <LocalizationProvider dateAdapter={AdapterDayjs}>
                         <DatePicker
                             label={"Submitted Date Start"}
-                            value={workflowSettings.getPending().date_submitted}
-                            onChange={(value) => handleInputChange("date_submitted", value)}
+                            value={workflowSettings.getPending().date_submitted ? dayjs(workflowSettings.getPending().date_submitted) : dayjs().subtract(2, "weeks")}
+                            onChange={(value) => handleInputChange("date_submitted", dayjs(value))}
                             sx={{width: "100%"}}
                         />
                     </LocalizationProvider>
@@ -94,33 +92,30 @@ export default function WorkflowFilters() {
                     <LocalizationProvider dateAdapter={AdapterDayjs}>
                         <DatePicker
                             label={"Submitted Date End"}
-                            value={workflowSettings.getPending().date_submitted_end}
-                            onChange={(value) => handleInputChange("date_submitted_end", value)}
+                            value={workflowSettings.getPending().date_submitted_end ? dayjs(workflowSettings.getPending().date_submitted_end) : dayjs()}
+                            onChange={(value) => handleInputChange("date_submitted_end", dayjs(value))}
                             sx={{width: "100%"}}
                         />
                     </LocalizationProvider>
 
                 </Grid>
                 <Grid item xs={3}>
-                    <TextField
-                        label="Workflow Name"
-                        value={workflowSettings.getPending().wf_name}
-                        onChange={(e) => handleInputChange("wf_name", e.target.value)}
-                        fullWidth={true}
-                    />
+                    <TextField label="Workflow Name"
+                               fullWidth={true}
+                               value={workflowSettings.getPending().wf_name}
+                               onChange={(e) => handleInputChange("wf_name", e.target.value)}/>
 
                 </Grid>
                 <Grid item xs={3}>
                     <FormControl fullWidth={true}>
                         <InputLabel id="LABEL-workflow-status">Workflow Status</InputLabel>
-                        <Select
-                            labelId="LABEL-workflow-status"
-                            label="Workflow Status"
-                            id={"SELECT-workflow-status"}
-                            value={workflowSettings.getPending().status}
-                            onChange={(e) => handleInputChange("status", e.target.value)}
-                            fullWidth={true}
-                        >
+                        <Select labelId="LABEL-workflow-status"
+
+                                label="Workflow Status"
+                                id={"SELECT-workflow-status"}
+                                onChange={(e) => handleInputChange("status", e.target.value)}
+                                value={workflowSettings.getPending().status}
+                                fullWidth={true}>
                             <MenuItem>{undefined}</MenuItem>
                             <MenuItem value="A">Aborted</MenuItem>
                             <MenuItem value="D">Done</MenuItem>
@@ -135,11 +130,10 @@ export default function WorkflowFilters() {
                     </FormControl>
                 </Grid>
                 <Grid item xs={3}>
-                    <TextField
-                        label="Workflow ID" fullWidth={true}
-                        value={workflowSettings.getPending().wf_id}
-                        onChange={(e) => handleInputChange("wf_id", e.target.value)}
-                    />
+                    <TextField label="Workflow ID" fullWidth={true}
+                               value={workflowSettings.getPending().wf_id}
+                               onChange={(e) => handleInputChange("wf_id", e.target.value)}/>
+
                 </Grid>
                 <Grid item xs={12}>
                     <Grid container spacing={2}>

--- a/jobmon_gui/src/components/workflow_overview/WorkflowFilters.tsx
+++ b/jobmon_gui/src/components/workflow_overview/WorkflowFilters.tsx
@@ -2,7 +2,7 @@ import {Button, FormControl, Grid, InputLabel, MenuItem, Select, TextField} from
 import {DatePicker, LocalizationProvider} from "@mui/x-date-pickers";
 import {AdapterDayjs} from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
-import React, {useEffect, useState} from "react";
+import React, {useEffect} from "react";
 import {useWorkflowSearchSettings} from "@jobmon_gui/stores/workflow_settings";
 import {useSearchParams} from "react-router-dom";
 import {useQueryClient} from "@tanstack/react-query";
@@ -13,115 +13,77 @@ export default function WorkflowFilters() {
     const workflowSettings = useWorkflowSearchSettings()
     const [searchParams] = useSearchParams();
 
-    const [localFilters, setLocalFilters] = useState({
-        user: "",
-        wf_args: "",
-        wf_attribute_key: "",
-        wf_attribute_value: "",
-        tool: "",
-        date_submitted: null,
-        date_submitted_end: null,
-        wf_name: "",
-        status: "",
-        wf_id: ""
-    });
-
     useEffect(() => {
         workflowSettings.loadValuesFromSearchParams(searchParams);
-        setLocalFilters({
-            user: workflowSettings.get().user,
-            wf_args: workflowSettings.get().wf_args,
-            wf_attribute_key: workflowSettings.get().wf_attribute_key,
-            wf_attribute_value: workflowSettings.get().wf_attribute_value,
-            tool: workflowSettings.get().tool,
-            date_submitted: workflowSettings.get().date_submitted,
-            date_submitted_end: workflowSettings.get().date_submitted_end,
-            wf_name: workflowSettings.get().wf_name,
-            status: workflowSettings.get().status,
-            wf_id: workflowSettings.get().wf_id
-        });
     }, []);
 
     const handleClear = () => {
         workflowSettings.clear();
-        setLocalFilters({
-            user: "",
-            wf_args: "",
-            wf_attribute_key: "",
-            wf_attribute_value: "",
-            tool: "",
-            date_submitted: null,
-            date_submitted_end: null,
-            wf_name: "",
-            status: "",
-            wf_id: ""
-        });
         workflowSettings.triggerDataRefresh();
         void queryClient.invalidateQueries({ queryKey: ["workflow_overview", "workflows"] });
     };
 
     const handleSubmit = (event) => {
         event.preventDefault();
-        workflowSettings.set({
-            user: localFilters.user,
-            wf_args: localFilters.wf_args,
-            wf_attribute_key: localFilters.wf_attribute_key,
-            wf_attribute_value: localFilters.wf_attribute_value,
-            tool: localFilters.tool,
-            date_submitted: localFilters.date_submitted,
-            date_submitted_end: localFilters.date_submitted_end,
-            wf_name: localFilters.wf_name,
-            status: localFilters.status,
-            wf_id: localFilters.wf_id
-        });
+        workflowSettings.applyPendingSettings();
         workflowSettings.triggerDataRefresh();
         void queryClient.invalidateQueries({ queryKey: ["workflow_overview", "workflows"] });
     };
 
     const handleInputChange = (key, value) => {
-        setLocalFilters((prev) => ({ ...prev, [key]: value }));
+        workflowSettings.setPendingSetting(key, value);
     };
 
     return (<Box className="div-level-2">
         <form onSubmit={handleSubmit}>
             <Grid container spacing={2}>
                 <Grid item xs={3}>
-                    <TextField label="Username"
-                               fullWidth={true}
-                               value={localFilters.user}
-                               onChange={(e) => handleInputChange("user", e.target.value)}/>
+                    <TextField
+                        label="Username"
+                        value={workflowSettings.getPending().user}
+                        onChange={(e) => handleInputChange("user", e.target.value)}
+                        fullWidth={true}
+                    />
                 </Grid>
                 <Grid item xs={3}>
-                    <TextField label="Workflow Args"
-                               fullWidth={true}
-                               value={localFilters.wf_args}
-                               onChange={(e) => handleInputChange("wf_args", e.target.value)}/>
+                    <TextField
+                        label="Workflow Args"
+                        value={workflowSettings.getPending().wf_args}
+                        onChange={(e) => handleInputChange("wf_args", e.target.value)}
+                        fullWidth={true}
+                    />
                 </Grid>
                 <Grid item xs={1.5}>
-                    <TextField label="WF Attribute Key"
-                               fullWidth={true}
-                               value={localFilters.wf_attribute_key}
-                               onChange={(e) => handleInputChange("wf_attribute_key", e.target.value)}/>
+                    <TextField
+                        label="WF Attribute Key"
+                        value={workflowSettings.getPending().wf_attribute_key}
+                        onChange={(e) => handleInputChange("wf_attribute_key", e.target.value)}
+                        fullWidth={true}
+                    />
 
                 </Grid>
                 <Grid item xs={1.5}>
-                    <TextField label="WF Attribute Value" fullWidth={true}
-                               value={localFilters.wf_attribute_value}
-                               onChange={(e) => handleInputChange("wf_attribute_value", e.target.value)}/>
+                    <TextField
+                        label="WF Attribute Value" fullWidth={true}
+                        value={workflowSettings.getPending().wf_attribute_value}
+                        onChange={(e) => handleInputChange("wf_attribute_value", e.target.value)}
+                    />
 
                 </Grid>
                 <Grid item xs={3}>
-                    <TextField label="Tool"
-                               fullWidth={true}
-                               value={localFilters.tool}
-                               onChange={(e) => handleInputChange("tool", e.target.value)}/>
+                    <TextField
+                        label="Tool"
+                        value={workflowSettings.getPending().tool}
+                        onChange={(e) => handleInputChange("tool", e.target.value)}
+                        fullWidth={true}
+                    />
 
                 </Grid>
                 <Grid item xs={1.5}>
                     <LocalizationProvider dateAdapter={AdapterDayjs}>
                         <DatePicker
                             label={"Submitted Date Start"}
-                            value={localFilters.date_submitted ? dayjs(localFilters.date_submitted) : dayjs("1970-01-01")}
+                            value={workflowSettings.getPending().date_submitted}
                             onChange={(value) => handleInputChange("date_submitted", value)}
                             sx={{width: "100%"}}
                         />
@@ -132,7 +94,7 @@ export default function WorkflowFilters() {
                     <LocalizationProvider dateAdapter={AdapterDayjs}>
                         <DatePicker
                             label={"Submitted Date End"}
-                            value={localFilters.date_submitted ? dayjs(localFilters.date_submitted_end) : dayjs("1970-01-01")}
+                            value={workflowSettings.getPending().date_submitted_end}
                             onChange={(value) => handleInputChange("date_submitted_end", value)}
                             sx={{width: "100%"}}
                         />
@@ -140,22 +102,25 @@ export default function WorkflowFilters() {
 
                 </Grid>
                 <Grid item xs={3}>
-                    <TextField label="Workflow Name"
-                               fullWidth={true}
-                               value={localFilters.wf_name}
-                               onChange={(e) => handleInputChange("wf_name", e.target.value)}/>
+                    <TextField
+                        label="Workflow Name"
+                        value={workflowSettings.getPending().wf_name}
+                        onChange={(e) => handleInputChange("wf_name", e.target.value)}
+                        fullWidth={true}
+                    />
 
                 </Grid>
                 <Grid item xs={3}>
                     <FormControl fullWidth={true}>
                         <InputLabel id="LABEL-workflow-status">Workflow Status</InputLabel>
-                        <Select labelId="LABEL-workflow-status"
-
-                                label="Workflow Status"
-                                id={"SELECT-workflow-status"}
-                                onChange={(e) => handleInputChange("status", e.target.value)}
-                                value={localFilters.status}
-                                fullWidth={true}>
+                        <Select
+                            labelId="LABEL-workflow-status"
+                            label="Workflow Status"
+                            id={"SELECT-workflow-status"}
+                            value={workflowSettings.getPending().status}
+                            onChange={(e) => handleInputChange("status", e.target.value)}
+                            fullWidth={true}
+                        >
                             <MenuItem>{undefined}</MenuItem>
                             <MenuItem value="A">Aborted</MenuItem>
                             <MenuItem value="D">Done</MenuItem>
@@ -170,10 +135,11 @@ export default function WorkflowFilters() {
                     </FormControl>
                 </Grid>
                 <Grid item xs={3}>
-                    <TextField label="Workflow ID" fullWidth={true}
-                               value={localFilters.wf_id}
-                               onChange={(e) => handleInputChange("wf_id", e.target.value)}/>
-
+                    <TextField
+                        label="Workflow ID" fullWidth={true}
+                        value={workflowSettings.getPending().wf_id}
+                        onChange={(e) => handleInputChange("wf_id", e.target.value)}
+                    />
                 </Grid>
                 <Grid item xs={12}>
                     <Grid container spacing={2}>

--- a/jobmon_gui/src/stores/workflow_settings.ts
+++ b/jobmon_gui/src/stores/workflow_settings.ts
@@ -1,11 +1,6 @@
 import {create} from 'zustand'
-import {createJSONStorage, devtools, persist} from 'zustand/middleware'
+import {devtools, persist} from 'zustand/middleware'
 import dayjs, {Dayjs} from "dayjs"; // required for devtools typing
-
-const getUrlSearch = () => {
-    return window.location.search.substring(1)
-}
-
 
 export type WorkflowSearchSettings = {
     user: string
@@ -20,11 +15,6 @@ export type WorkflowSearchSettings = {
     "status": string
 }
 
-type WorkflowSearchSettingsSearchParams = Omit<WorkflowSearchSettings, 'date_submitted'> & { date_submitted: string };
-
-
-const twoWeeksMs = 12096e5; // 2 weeks in milliseconds
-const twoWeeksAgo = new Date(Date.now() - twoWeeksMs);
 const defaultSettings = {
     user: "",
     tool: "",


### PR DESCRIPTION
## Description

Removes the auto-filtering of `WorkflowList` search functionality. Now, instead of trying to refresh the workflow list whenever an individual filter input is updated, the list data will only be refreshed when either the "Submit" button or the "Clear All" button are clicked.

## Type of Change

GUI update

## Changes Made

- Triggers workflow list data refresh only on Submit or Clear All, instead of when individual `TextField`, etc. filter inputs are updated.
- Introduces `pendingSettings` to the existing `WorkflowSearchSettingsStore` zustand store. Maybe some additional overhead on the zustand store, but felt cleaner than storing locally, esp. given the store already existed with `defaultSettings`.

## Screenshots

(Does not show exhaustive test, just example)

https://github.com/user-attachments/assets/dddf8dfe-6b38-4537-a453-25fb497f241c



## Additional Notes

- Did not touch the url because I know there is a separate, concurrent branch in progress for updating this.
