### PR TITLE
Fix dag viz problems

### DIFF
--- a/jobmon_gui/src/components/task_details/TaskDAG.tsx
+++ b/jobmon_gui/src/components/task_details/TaskDAG.tsx
@@ -145,7 +145,7 @@ export default function TaskDAG({taskId, taskName, taskStatus}: NodeListsProps) 
 
     return (
         <div style={{width: '100%', height: '500px'}}>
-            {nodes.length === 0 || edges.length === 0 ? (
+            {nodes.length === 0 ? (
                 <CircularProgress/>
             ) : (
                 <ReactFlow

--- a/jobmon_gui/src/components/workflow_details/WorkflowDAG.tsx
+++ b/jobmon_gui/src/components/workflow_details/WorkflowDAG.tsx
@@ -141,8 +141,8 @@ export default function WorkflowDAG(workflowId) {
     }, []);
 
     return (
-        <div style={{ height: 500 }}>
-            {nodes.length === 0 || edges.length === 0 ? (
+        <div style={{ height: "100vh", width: "100vw", position: "relative" }}>
+            {nodes.length === 0 ? (
                 <CircularProgress/>
             ) : (
                 <ReactFlow


### PR DESCRIPTION
WHAT:

- There was an error where the dag viz would endlessly spin if a DAG had a single task template with no edges. Removed that check
- Changed it so the workflow DAG viz takes up the whole screen