### PR TITLE
Change clustered error handling

### DIFF
--- a/jobmon_server/src/jobmon/server/web/error_log_clustering.py
+++ b/jobmon_server/src/jobmon/server/web/error_log_clustering.py
@@ -8,7 +8,12 @@ nltk.download("punkt", quiet=True)
 def cluster_error_logs(df: DataFrame) -> DataFrame:
     """Cluster error logs using unsupervised learning."""
     count_vectorizer = ext.CountVectorizer()
-    doc_matrix = count_vectorizer.fit_transform(df["task_instance_stderr_log"])
+    if df["task_instance_stderr_log"].isin([None, '']).any():
+        doc_matrix = count_vectorizer.fit_transform(df["error"])
+        sample_error = "error"
+    else:
+        doc_matrix = count_vectorizer.fit_transform(df["task_instance_stderr_log"])
+        sample_error = "task_instance_stderr_log"
 
     # TF-IDF transformation
     tf_idf_transformer = ext.TfidfTransformer()
@@ -24,7 +29,7 @@ def cluster_error_logs(df: DataFrame) -> DataFrame:
             group_instance_count=("error_score", "count"),
             task_instance_ids=("task_instance_id", lambda x: list(set(x))),
             task_ids=("task_id", lambda x: list(set(x))),
-            sample_error=("task_instance_stderr_log", "first"),
+            sample_error=(sample_error, "first"),
             first_error_time=("error_time", "first"),
             workflow_run_id=("workflow_run_id", "first"),
             workflow_id=("workflow_id", "first"),

--- a/jobmon_server/src/jobmon/server/web/error_log_clustering.py
+++ b/jobmon_server/src/jobmon/server/web/error_log_clustering.py
@@ -8,12 +8,9 @@ nltk.download("punkt", quiet=True)
 def cluster_error_logs(df: DataFrame) -> DataFrame:
     """Cluster error logs using unsupervised learning."""
     count_vectorizer = ext.CountVectorizer()
-    if df["task_instance_stderr_log"].isin([None, ""]).any():
-        doc_matrix = count_vectorizer.fit_transform(df["error"])
-        sample_error = "error"
-    else:
-        doc_matrix = count_vectorizer.fit_transform(df["task_instance_stderr_log"])
-        sample_error = "task_instance_stderr_log"
+    df["processed_log"] = df["task_instance_stderr_log"].where(
+        df["task_instance_stderr_log"].notna() & (df["task_instance_stderr_log"] != ""), df["error"])
+    doc_matrix = count_vectorizer.fit_transform(df["processed_log"])
 
     # TF-IDF transformation
     tf_idf_transformer = ext.TfidfTransformer()
@@ -29,7 +26,7 @@ def cluster_error_logs(df: DataFrame) -> DataFrame:
             group_instance_count=("error_score", "count"),
             task_instance_ids=("task_instance_id", lambda x: list(set(x))),
             task_ids=("task_id", lambda x: list(set(x))),
-            sample_error=(sample_error, "first"),
+            sample_error=("processed_log", "first"),
             first_error_time=("error_time", "first"),
             workflow_run_id=("workflow_run_id", "first"),
             workflow_id=("workflow_id", "first"),

--- a/jobmon_server/src/jobmon/server/web/error_log_clustering.py
+++ b/jobmon_server/src/jobmon/server/web/error_log_clustering.py
@@ -8,7 +8,7 @@ nltk.download("punkt", quiet=True)
 def cluster_error_logs(df: DataFrame) -> DataFrame:
     """Cluster error logs using unsupervised learning."""
     count_vectorizer = ext.CountVectorizer()
-    if df["task_instance_stderr_log"].isin([None, '']).any():
+    if df["task_instance_stderr_log"].isin([None, ""]).any():
         doc_matrix = count_vectorizer.fit_transform(df["error"])
         sample_error = "error"
     else:

--- a/jobmon_server/src/jobmon/server/web/error_log_clustering.py
+++ b/jobmon_server/src/jobmon/server/web/error_log_clustering.py
@@ -9,7 +9,9 @@ def cluster_error_logs(df: DataFrame) -> DataFrame:
     """Cluster error logs using unsupervised learning."""
     count_vectorizer = ext.CountVectorizer()
     df["processed_log"] = df["task_instance_stderr_log"].where(
-        df["task_instance_stderr_log"].notna() & (df["task_instance_stderr_log"] != ""), df["error"])
+        df["task_instance_stderr_log"].notna() & (df["task_instance_stderr_log"] != ""),
+        df["error"],
+    )
     doc_matrix = count_vectorizer.fit_transform(df["processed_log"])
 
     # TF-IDF transformation


### PR DESCRIPTION
WHAT:
Jobmon stores two types of errors in two locations in the database:

- Jobmon application errors are in task_instance_error_log.description. These include things like resources scaling messages etc
- User application errors are in task_instance.stderr_log

Previously we only clustered errors on the second type. This PR changes it so if there are no user errors found in the task_instance table, we will cluster jobmon errors from the task_instance_error_log table.