### PR TITLE
[FORENG-6782] remove ``--args`` separator from task template

### DIFF
--- a/jobmon_core/src/jobmon/core/task_generator.py
+++ b/jobmon_core/src/jobmon/core/task_generator.py
@@ -268,15 +268,13 @@ class TaskGenerator:
             serializable types
 
     Users can also supply serializers for custom types by providing a dictionary of type to
-    a tuple of serialization and deserialization functions. Serializers can return either a
-    string or a list of strings. Lists of strings are represented on the command line as
-    ``--arg-name value1 --arg-name value2``. If you're serializing to a list of strings, the
-    deserializer should be prepared to handle either a single string or a list of strings.
+    a tuple of serialization and deserialization functions. Serializers must always turn
+    objects into a single string. Lists of strings are represented on the command line as
+    ``arg_name='[value1,value2]'``.
 
     Note:
         While lists, tuples and sets (and their ``Optional`` counterparts) can currently
         serialize empty collections, we can't currently serialize custom types as empty lists.
-
     """
 
     def __init__(
@@ -417,11 +415,11 @@ class TaskGenerator:
 
     def _generate_task_template(self) -> None:
         """Generate and store the task template."""
-        # args convert to --args foo=1 --args bar=2
-        args_template = " --args ".join(
+        # args convert to foo=1 bar=2
+        args_template = " ".join(
             f"{arg_name}={{{arg_name}}}" for arg_name in self.params
         )
-        args_template = " --args " + args_template
+        args_template = " " + args_template
         if self.module_source_path:
             self._task_template = self.tool.get_task_template(
                 template_name=self.name,
@@ -766,7 +764,7 @@ class TaskGenerator:
         """Run the task_function with the given args and return any result."""
         # Parse the args
         parsed_arg_value_pairs: Dict[str, Union[str, List[str]]] = dict()
-        # args is a list of string like ["arg1=1", "arg2=[2, 3]", "arg1=4]
+        # args is a list of string like ["arg1=1", "arg2=[2, 3]", "arg1=4"]
         for arg in args:
             arg_name, arg_value = arg.split("=")
             # if the arg_name key, already exists, append the value to the list

--- a/jobmon_core/src/jobmon/worker_node/cli.py
+++ b/jobmon_core/src/jobmon/worker_node/cli.py
@@ -115,7 +115,14 @@ class WorkerNodeCLI(CLI):
             print(task_generator.help())
             return ReturnCodes.OK
         try:
-            task_generator.run(args.args)
+            if len(args.args) != 1:
+                raise ValueError(
+                    "Internal error parsing command line arguments. Expected to find a single "
+                    f"element in the parsed args list, but found {len(args.args)}.\n"
+                    f"Parsed args: {args.args}"
+                )
+
+            task_generator.run(args.args[0])
             return ReturnCodes.OK
         except Exception as e:
             print(e)
@@ -136,18 +143,6 @@ class WorkerNodeCLI(CLI):
             required=True,
         )
         generator_parser.add_argument(
-            "--args",
-            type=str,
-            help="Followed by the key=value; .\n"
-            "For example: \n"
-            "If you method has two argument: def func(foo: int, bar: str), pass\n"
-            "    --args foo=1 --args bar='test'\n"
-            "If you method has two argument: def func(foo: int, bar: List[str), pass\n"
-            "    --args foo=1 --args bar=[a,b]\n",
-            required=False,
-            action="append",
-        )
-        generator_parser.add_argument(
             "--arghelp",
             type=str,
             help="Show the help message for the task generator. For example: --arghelp",
@@ -159,6 +154,18 @@ class WorkerNodeCLI(CLI):
             help="The directory the module source code located; "
             "you do not need this if the module is installed in your system.",
             required=False,
+        )
+        generator_parser.add_argument(
+            "args",
+            type=str,
+            nargs="*",
+            action="append",
+            help=(
+                "Arbitrary key-value pairs to pass to the task generator. Expected form is:\n"
+                "    key1='val1' key2='val2' ..."
+                "For lists of values, expected form is:\n"
+                "    key1='[val1,val2,val3]'"
+            ),
         )
 
     def _add_worker_node_job_parser(self) -> None:

--- a/tests/worker_node/test_task_generator.py
+++ b/tests/worker_node/test_task_generator.py
@@ -476,7 +476,9 @@ def test_deserialize_empty_string(client_env) -> None:
     )
 
     # Exercise by calling deserialize
-    result = task_gen.deserialize(obj=task_generator.SERIALIZED_EMPTY_STRING, obj_type=str)
+    result = task_gen.deserialize(
+        obj=task_generator.SERIALIZED_EMPTY_STRING, obj_type=str
+    )
 
     # Verify the result is the empty string
     assert result == ""

--- a/tests/worker_node/test_task_generator.py
+++ b/tests/worker_node/test_task_generator.py
@@ -46,8 +46,8 @@ def test_simple_task(client_env, monkeypatch: pytest.fixture) -> None:
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name simple_function"
-        " --args foo='1'"
-        " --args bar='b a z'"
+        " foo='1'"
+        " bar='b a z'"
     )
 
     assert task.command == expected_command
@@ -89,8 +89,8 @@ def test_list_args(client_env, monkeypatch: pytest.fixture) -> None:
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name list_function"
-        " --args foo='[a,b b]'"
-        " --args bar='[c\"]'"
+        " foo='[a,b b]'"
+        " bar='[c\"]'"
     )
     assert task.command == expected_command
     assert task.compute_resources == compute_resources
@@ -144,8 +144,8 @@ def test_naming_args(
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name simple_function"
-        " --args foo='1'"
-        " --args bar='baz'"
+        " foo='1'"
+        " bar='baz'"
     )
     assert task.command == expected_command
     assert task.compute_resources == compute_resources
@@ -772,8 +772,8 @@ def test_simple_task_array(client_env, monkeypatch: pytest.fixture) -> None:
             f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
             f" --module_name tests.worker_node.test_task_generator"
             " --func_name simple_function"
-            f" --args foo='{i}'"
-            " --args bar='baz'"
+            f" foo='{i}'"
+            " bar='baz'"
         )
 
         assert tasks[i - 1].command == expected_command
@@ -813,8 +813,8 @@ def test_array_list_arg(client_env, monkeypatch: pytest.fixture) -> None:
             f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
             f" --module_name tests.worker_node.test_task_generator"
             " --func_name simple_function"
-            f" --args foo='{i}'"
-            " --args bar='[a,b]'"
+            f" foo='{i}'"
+            " bar='[a,b]'"
         )
 
         assert tasks[i - 1].command == expected_command
@@ -1018,12 +1018,12 @@ def test_fhs_task(client_env, monkeypatch) -> None:
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name simple_function"
-        " --args yr='2020-2021'"
-        " --args v='[1.0, 2.0]'"
-        " --args fSpec='/path/to/file'"
-        " --args dSpec='/path/to/dir'"
-        " --args vm='1.0'"
-        " --args q='[0.1, 0.9]'"
+        " yr='2020-2021'"
+        " v='[1.0, 2.0]'"
+        " fSpec='/path/to/file'"
+        " dSpec='/path/to/dir'"
+        " vm='1.0'"
+        " q='[0.1, 0.9]'"
     )
     assert task1.name == "simple_function:yr=2020-2021:v=1.0,_2.0"
     assert task1.command == expected_command
@@ -1043,12 +1043,12 @@ def test_fhs_task(client_env, monkeypatch) -> None:
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name simple_function"
-        " --args yr='2020-2021'"
-        " --args v='[1.0, 2.0]'"
-        " --args fSpec='/path/to/file'"
-        " --args dSpec='/path/to/dir'"
-        " --args vm='1.0'"
-        " --args q='None'"
+        " yr='2020-2021'"
+        " v='[1.0, 2.0]'"
+        " fSpec='/path/to/file'"
+        " dSpec='/path/to/dir'"
+        " vm='1.0'"
+        " q='None'"
     )
     assert task2.name == "simple_function:yr=2020-2021:v=1.0,_2.0"
     assert task2.command == expected_command
@@ -1070,12 +1070,12 @@ def test_fhs_task(client_env, monkeypatch) -> None:
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name simple_function"
-        " --args yr='2020-2021'"
-        " --args v='[1.0, 2.0]'"
-        " --args fSpec='/path/to/file'"
-        " --args dSpec='/path/to/dir'"
-        " --args vm='1.0'"
-        " --args q='[0.1, 0.9]'"
+        " yr='2020-2021'"
+        " v='[1.0, 2.0]'"
+        " fSpec='/path/to/file'"
+        " dSpec='/path/to/dir'"
+        " vm='1.0'"
+        " q='[0.1, 0.9]'"
     )
     assert tasks[0].command == expected_command1
     # Verify command
@@ -1083,12 +1083,12 @@ def test_fhs_task(client_env, monkeypatch) -> None:
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name simple_function"
-        " --args yr='2020-2021'"
-        " --args v='[1.0, 2.0]'"
-        " --args fSpec='/path/to/file'"
-        " --args dSpec='/path/to/dir'"
-        " --args vm='1.0'"
-        " --args q='None'"
+        " yr='2020-2021'"
+        " v='[1.0, 2.0]'"
+        " fSpec='/path/to/file'"
+        " dSpec='/path/to/dir'"
+        " vm='1.0'"
+        " q='None'"
     )
     assert tasks[1].command == expected_command2
 
@@ -1318,8 +1318,8 @@ def test_naming_func(client_env, monkeypatch: pytest.fixture) -> None:
         f"{task_generator.TASK_RUNNER_NAME} {task_generator.TASK_RUNNER_SUB_COMMAND}"
         f" --module_name tests.worker_node.test_task_generator"
         " --func_name simple_function"
-        " --args foo='1'"
-        " --args bar='baz'"
+        " foo='1'"
+        " bar='baz'"
     )
     assert task.command == expected_command
     assert task.compute_resources == compute_resources


### PR DESCRIPTION
UI improvement: remove ``--args`` separator between each TaskGenerator parameter. Turns command from something like:
```
worker_node_entry_point task_generator --module_name fhs_lib_file_interface.run.task --func_name finalize_provenance_stage --args log_level='DEBUG' --args stage_key='met_need_weights' --args scenario_id='None' --args scenario_version_number='None' --args output_area='nightly'
```
To:
```
worker_node_entry_point task_generator --module_name fhs_lib_file_interface.run.task --func_name finalize_provenance_stage log_level='DEBUG' stage_key='met_need_weights' scenario_id='None' scenario_version_number='None' output_area='nightly'
```

Manually verified on: https://jobmon-gui.ihme.washington.edu/#/workflow/400015