### PR TITLE
Adding upstream_tasks to TaskGenerator create_task and create_tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to Jobmon will be documented in this file.
 ### Removed
 
 ## [3.4.11] - TBD
+### Added
+- Added the ability to specify upstream tasks in TaskGenerator create_task(s) methods.
+
 ### Fixed
 - Fixed bug in requester where ValueErrors weren't being handled (PR 250).
 

--- a/jobmon_core/src/jobmon/core/task_generator.py
+++ b/jobmon_core/src/jobmon/core/task_generator.py
@@ -662,6 +662,7 @@ class TaskGenerator:
         cluster_name: str = "",
         compute_resources: Optional[Dict] = None,
         resource_scales: Optional[Dict[str, Any]] = None,
+        upstream_tasks: List[Task] = [],
         **kwargs: Any,
     ) -> Task:
         """Create a task for the task_function with the given kwargs."""
@@ -708,6 +709,7 @@ class TaskGenerator:
             resource_scales=resource_scales,
             max_attempts=self.max_attempts,
             executable=executable_path,
+            upstream_tasks=upstream_tasks,
             **kwargs_for_task,  # type: ignore
         )
 
@@ -718,6 +720,7 @@ class TaskGenerator:
         cluster_name: str = "",
         compute_resources: Optional[Dict] = None,
         resource_scales: Optional[Dict[str, Any]] = None,
+        upstream_tasks: Optional[List[Task]] = None,
         **kwargs: Any,
     ) -> List[Task]:
         """Create a task array for the task_function with the given kwargs."""
@@ -755,6 +758,7 @@ class TaskGenerator:
             resource_scales=resource_scales,
             max_attempts=self.max_attempts,
             executable=executable_path,
+            upstream_tasks=upstream_tasks,
             **kwargs_for_task,  # type: ignore
         )
 

--- a/tests/worker_node/test_task_generator.py
+++ b/tests/worker_node/test_task_generator.py
@@ -55,7 +55,7 @@ def test_simple_task(client_env, monkeypatch: pytest.fixture) -> None:
 
 
 def test_upstream_task(client_env, monkeypatch: pytest.fixture) -> None:
-    """Verify that we get a good looking command string."""
+    """Verify that we get expected upstream task."""
     # Set up function
     monkeypatch.setattr(
         task_generator,
@@ -818,7 +818,7 @@ def test_simple_task_array(client_env, monkeypatch: pytest.fixture) -> None:
 
 
 def test_upstream_task_array(client_env, monkeypatch: pytest.fixture) -> None:
-    """Verify that we get a good looking command string for an array task."""
+    """Verify that we get expected upstream tasks."""
     # Set up function
     monkeypatch.setattr(
         task_generator,

--- a/tests/worker_node/test_task_generator.py
+++ b/tests/worker_node/test_task_generator.py
@@ -86,7 +86,7 @@ def test_upstream_task(client_env, monkeypatch: pytest.fixture) -> None:
         upstream_tasks=[upstream_task],
     )
 
-    assert downstream_task.upstream_tasks == [upstream_task]
+    assert downstream_task.upstream_tasks == {upstream_task}
 
 
 
@@ -850,7 +850,8 @@ def test_upstream_task_array(client_env, monkeypatch: pytest.fixture) -> None:
         upstream_tasks=upstream_tasks,
     )
 
-    assert downstream_tasks.upstream_tasks == upstream_tasks
+    for downstream_task in downstream_tasks:
+        assert downstream_task.upstream_tasks == set(upstream_tasks)
 
 
 def test_array_list_arg(client_env, monkeypatch: pytest.fixture) -> None:


### PR DESCRIPTION
Passes the upstream_tasks arg through from TaskGenerator.create_task(s) to TaskTemplate.create_task(s)