### PR TITLE
Fix jobmon gui bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Jobmon will be documented in this file.
 
 ### Changed
 - Swapped the location of the DAG viz and TaskInstance table on the Task Details page (PR 255).
+- Changed tasks in "G" state (registering) to white in Task DAG viz (PR 255).
 
 ### Fixed
 - Fixed a bug where dates were appearing in UTC (not in user's specified timezone) in the Jobmon GUI (PR 251).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,24 @@ All notable changes to Jobmon will be documented in this file.
 ### Deprecated
 ### Removed
 
-## [3.4.11] - TBD
+## [3.4.13] - 2025-04-21
 ### Added
-- Added the ability to specify upstream tasks in TaskGenerator create_task(s) methods.
+- Added a link to the TaskDetails page from the clustered errors modal (PR 255).
+
+### Changed
+- Swapped the location of the DAG viz and TaskInstance table on the Task Details page (PR 255).
 
 ### Fixed
-- Fixed bug in requester where ValueErrors weren't being handled (PR 250).
 - Fixed a bug where dates were appearing in UTC (not in user's specified timezone) in the Jobmon GUI (PR 251).
+- Fixed broken home button on TaskDetails page (PR 255).
+
+## [3.4.12] - 2025-04-03
+### Added
+- Added the ability to specify upstream tasks in TaskGenerator create_task(s) methods (PR 254).
+
+## [3.4.11] - 2025-03-31
+### Fixed
+- Fixed bug in requester where ValueErrors weren't being handled (PR 250).
 
 ## [3.4.10] - 2025-03-25
 ### Fixed

--- a/jobmon_gui/src/components/task_details/TaskDAG.tsx
+++ b/jobmon_gui/src/components/task_details/TaskDAG.tsx
@@ -64,7 +64,7 @@ export default function TaskDAG({taskId, taskName, taskStatus}: NodeListsProps) 
     });
 
     const statusColorMap: Record<string, string> = {
-        G: '#0072b2', // Registering
+        G: '#FFFFFF', // Registering
         Q: '#0072b2', // Queued
         I: '#0072b2', // Instantiating
         O: '#0072b2', // Launched

--- a/jobmon_gui/src/components/task_template_details/ClusteredErrors.tsx
+++ b/jobmon_gui/src/components/task_template_details/ClusteredErrors.tsx
@@ -29,6 +29,8 @@ import {
     ErrorDetails,
     ErrorSampleModalDetails
 } from "@jobmon_gui/types/ClusteredErrors.ts";
+import {Link} from "react-router-dom";
+import {getTaskDetailsQueryFn} from "@jobmon_gui/queries/GetTaskDetails.ts";
 
 export default function ClusteredErrors({taskTemplateId, workflowId}: ClusteredErrorsProps) {
     const columnHelper = createMRTColumnHelper<ColumnType>()
@@ -276,16 +278,31 @@ export default function ClusteredErrors({taskTemplateId, workflowId}: ClusteredE
                         <Grid item xs={3}><Typography sx={labelStyles}>Error Time:</Typography></Grid>
                         <Grid item xs={9}>{formatJobmonDate(error.error_time)}</Grid>
 
-                        <Grid item xs={3}><Typography sx={labelStyles}>task_id:</Typography></Grid>
-                        <Grid item xs={9}>{error.task_id}</Grid>
+                        <Grid item xs={3}><Typography sx={labelStyles}>Task ID:</Typography></Grid>
+                        <Grid item xs={9}>
+                            <nav>
+                                <Link
+                                    to={{pathname: `/task_details/${error.task_id}`, search: location.search}}
+                                    key={error.task_id}
+                                    onMouseEnter={async () => {
+                                        queryClient.prefetchQuery({
+                                            queryKey: ["task_details", error.task_id],
+                                            queryFn: getTaskDetailsQueryFn
+                                        })
 
+                                    }}
+                                >
+                                    {error.task_id}
+                                </Link>
+                            </nav>
+                        </Grid>
                         <Grid item xs={3}><Typography sx={labelStyles}>Task Instance Error ID:</Typography></Grid>
                         <Grid item xs={9}>{error.task_instance_err_id}</Grid>
 
-                        <Grid item xs={3}><Typography sx={labelStyles}>workflow_id:</Typography></Grid>
+                        <Grid item xs={3}><Typography sx={labelStyles}>Workflow ID:</Typography></Grid>
                         <Grid item xs={9}>{error.workflow_id}</Grid>
 
-                        <Grid item xs={3}><Typography sx={labelStyles}>workflow_run_id:</Typography></Grid>
+                        <Grid item xs={3}><Typography sx={labelStyles}>WorkflowRun ID:</Typography></Grid>
                         <Grid item xs={9}>{error.workflow_run_id}</Grid>
 
                         <Grid item xs={12}><Typography sx={labelStyles}>Error Message:</Typography></Grid>

--- a/jobmon_gui/src/screens/TaskDetails.tsx
+++ b/jobmon_gui/src/screens/TaskDetails.tsx
@@ -50,7 +50,7 @@ export default function TaskDetails() {
     };
 
     const breadcrumbItems: BreadcrumbItem[] = [
-        {label: 'Home', onClick: handleHomeClick},
+        {label: 'Home', to: "/", onClick: handleHomeClick},
         {
             label: `Workflow ID ${task_details?.data?.workflow_id}`,
             to: `/workflow/${task_details?.data?.workflow_id}`,
@@ -78,9 +78,15 @@ export default function TaskDetails() {
                     <p className='color-dark'>
                         Task Name: {task_details?.data?.task_name}&nbsp;
                     </p>
-                    <p className="color-dark">
-                        Task Dependencies&nbsp;
-                        <span>
+                </header>
+            </div>
+            <div id="wftable" className="div-level-2">
+                <TaskInstanceTable taskId={taskId}/>
+            </div>
+            <header className="div-level-2 header-1 ">
+                <p className="color-dark">
+                    Task Dependencies&nbsp;
+                    <span>
                         <HtmlTooltip
                             title="Task Finite State Machine"
                             arrow={true}
@@ -100,16 +106,12 @@ export default function TaskDetails() {
                                 </IconButton>
                             </HtmlTooltip>
                         </span>
-                    </p>
-                </header>
-            </div>
-            <div className='row pt-2 mx-0 px-0'>
-                <TaskDAG taskId={taskId} taskName={task_details?.data?.task_name}
-                         taskStatus={task_details?.data?.task_status}/>
-            </div>
-            <div id="wftable" className="div-level-2">
-                <TaskInstanceTable taskId={taskId}/>
-            </div>
+                </p>
+                <div className='row pt-2 mx-0 px-0'>
+                    <TaskDAG taskId={taskId} taskName={task_details?.data?.task_name}
+                             taskStatus={task_details?.data?.task_status}/>
+                </div>
+            </header>
             <JobmonModal
                 title={
                     "Task Finite State Machine"
@@ -133,10 +135,12 @@ export default function TaskDetails() {
                         <Grid item xs={9}> Task errored with a resource error, the resources will be adjusted before
                             retrying.</Grid>
                         <Grid item xs={3}><b>Error Fatal (F):</b></Grid>
-                        <Grid item xs={9}> Task errored out and has used all of the attempts, therefore has failed for
+                        <Grid item xs={9}> Task errored out and has used all of the attempts, therefore has failed
+                            for
                             this WorkflowRun. <br/>It can be resumed in a new WFR.</Grid>
                         <Grid item xs={3}><b>Done (D):</b></Grid>
-                        <Grid item xs={9}> Task ran successfully to completion; it has a TaskInstance that successfully
+                        <Grid item xs={9}> Task ran successfully to completion; it has a TaskInstance that
+                            successfully
                             completed.</Grid>
                     </Grid>
                 }


### PR DESCRIPTION
- Added a link to the TaskDetails page from the clustered errors modal (per helpdesk request)
- Swapped the location of the DAG viz and TaskInstance table on the Task Details page (per slack request)
- Fixed broken home button on TaskDetails page (I noticed it and was in the file so fixed it)
- Changed tasks in "G" state (registering) to white in Task DAG viz 