### PR TITLE
Fix date time bug

### DIFF
--- a/jobmon_gui/src/utils/DayTime.ts
+++ b/jobmon_gui/src/utils/DayTime.ts
@@ -2,19 +2,19 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import timezone from "dayjs/plugin/timezone";
-import {useDisplayTimeFormatStore, useDisplayTimezoneStore} from "@jobmon_gui/stores/DateTime.ts";
+import { useDisplayTimeFormatStore, useDisplayTimezoneStore } from "@jobmon_gui/stores/DateTime.ts";
 
+dayjs.extend(utc);
+dayjs.extend(advancedFormat);
+dayjs.extend(timezone);
 
-export const formatDayjsDate = (date: dayjs.Dayjs)=> {
-    dayjs.extend(utc)
-    dayjs.extend(advancedFormat);
-    dayjs.extend(timezone);
-    return date.tz(useDisplayTimezoneStore.getState().timezone || Intl.DateTimeFormat().resolvedOptions().timeZone).format(useDisplayTimeFormatStore.getState().timeFormat)
-}
+export const formatDayjsDate = (date: dayjs.Dayjs) => {
+    return date
+        .tz(useDisplayTimezoneStore.getState().timezone || Intl.DateTimeFormat().resolvedOptions().timeZone)
+        .format(useDisplayTimeFormatStore.getState().timeFormat);
+};
 
-export const formatJobmonDate = (date: string|null|undefined)=> {
-    if(!date)
-        return ""
-    dayjs.extend(timezone);
+export const formatJobmonDate = (date: string | null | undefined) => {
+    if (!date) return "";
     return formatDayjsDate(dayjs.tz(date, "America/Los_Angeles"));
-}
+};


### PR DESCRIPTION
WHAT:

Follow up to a previous datetime fix. Workflow details page would render if you clicked in from the landing page, wouldn't render if you went to the link directly or reloaded the page. 

Needed to extend the .tz() at the top of the file instead of in the function, to make sure that it's available always.