### PR TITLE
Feat/dns

### DIFF
--- a/jobmon_server/pyproject.toml
+++ b/jobmon_server/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     'httpx',
     'authlib',
     'itsdangerous',
+    'dnspython',
 ]
 dynamic = ["version"]
 

--- a/jobmon_server/src/jobmon/server/web/db_admin.py
+++ b/jobmon_server/src/jobmon/server/web/db_admin.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple, cast
 
 from alembic import command
 from alembic.config import Config
-from dnspython import resolver
+from dns import resolver
 from sqlalchemy import create_engine, event, exc
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.interfaces import DBAPIConnection
@@ -41,7 +41,7 @@ _DEFAULT_MAX_TTL = 300  # 5 min max TTL to prevent stale IPs
 def _resolve_from_dns(hostname: str) -> Tuple[str, int]:
     """Resolve hostname to IP with retries. Returns (ip, ttl_seconds)."""
     answers = resolver.resolve(hostname, "A", lifetime=2)  # Fail-fast after 2 seconds
-    ttl = answers.rrset.ttl or _DEFAULT_MAX_TTL
+    ttl = getattr(answers.rrset, 'ttl', None) or _DEFAULT_MAX_TTL
     return answers[0].address, ttl
 
 

--- a/jobmon_server/src/jobmon/server/web/db_admin.py
+++ b/jobmon_server/src/jobmon/server/web/db_admin.py
@@ -100,9 +100,6 @@ def get_engine_from_config(uri: str) -> Engine:
         engine = create_engine(
             uri,
             connect_args={"check_same_thread": False},  # Allow multi-threaded use
-            pool_size=1,  # Single connection is sufficient for SQLite
-            max_overflow=0,
-            pool_recycle=-1,  # No recycling for local file
             future=True,
         )
         return engine

--- a/jobmon_server/src/jobmon/server/web/db_admin.py
+++ b/jobmon_server/src/jobmon/server/web/db_admin.py
@@ -3,7 +3,7 @@ from importlib.resources import files
 import logging
 import threading
 import time
-from typing import Dict, Tuple, cast
+from typing import cast, Dict, Tuple
 
 from alembic import command
 from alembic.config import Config
@@ -41,7 +41,7 @@ _DEFAULT_MAX_TTL = 300  # 5 min max TTL to prevent stale IPs
 def _resolve_from_dns(hostname: str) -> Tuple[str, int]:
     """Resolve hostname to IP with retries. Returns (ip, ttl_seconds)."""
     answers = resolver.resolve(hostname, "A", lifetime=2)  # Fail-fast after 2 seconds
-    ttl = getattr(answers.rrset, 'ttl', None) or _DEFAULT_MAX_TTL
+    ttl = getattr(answers.rrset, "ttl", None) or _DEFAULT_MAX_TTL
     return answers[0].address, ttl
 
 
@@ -95,7 +95,7 @@ def get_engine_from_config(uri: str) -> Engine:
     """
     parsed = make_url(uri)
     hostname = parsed.host
-    
+
     # Add null check for hostname
     if hostname is None:
         raise ValueError("URI must have a hostname")
@@ -114,14 +114,14 @@ def get_engine_from_config(uri: str) -> Engine:
         """
         if hostname is None:
             raise ValueError("Hostname cannot be None")
-            
+
         ip_now, ttl_now = get_ip_with_ttl(hostname)
         # Adjust recycle so connections don't live past their DNS validity
         engine.pool._recycle = min(ttl_now, _DEFAULT_MAX_TTL)
         conn = create_engine(
             parsed.set(host=ip_now), connect_args={"connect_timeout": 2}
         ).raw_connection()
-        
+
         # Explicitly cast the return value to DBAPIConnection
         return cast(DBAPIConnection, conn)
 
@@ -145,7 +145,7 @@ def get_engine_from_config(uri: str) -> Engine:
         """Stash the IP we used when this connection was first made."""
         if hostname is None:
             raise ValueError("Hostname cannot be None")
-            
+
         ip_used, _ = get_ip_with_ttl(hostname)
         conn_record.info["peer_ip"] = ip_used
 
@@ -161,7 +161,7 @@ def get_engine_from_config(uri: str) -> Engine:
         """
         if hostname is None:
             raise ValueError("Hostname cannot be None")
-            
+
         old_ip = conn_record.info.get("peer_ip")
         current_ip, _ = get_ip_with_ttl(hostname)
         if old_ip != current_ip:

--- a/jobmon_server/src/jobmon/server/web/db_admin.py
+++ b/jobmon_server/src/jobmon/server/web/db_admin.py
@@ -1,18 +1,26 @@
+import functools
 from importlib.resources import files
+import logging
+import threading
+import time
+from typing import Dict, Tuple, cast
+
 from alembic import command
 from alembic.config import Config
 from dnspython import resolver
 from sqlalchemy import create_engine, event, exc
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import _ConnectionRecord
 from sqlalchemy_utils import create_database, database_exists, drop_database
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
-import time
-import threading
-import functools
-import logging
-from typing import Dict, Tuple
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 
 from jobmon.server.web.config import get_jobmon_config
@@ -21,8 +29,9 @@ logger = logging.getLogger(__name__)
 
 # DNS Cache Internals
 _DNS_CACHE: Dict[str, Tuple[str, float]] = {}  # hostname -> (ip, expires_epoch)
-_CACHE_LOCK = threading.RLock()                # Thread-safe lock for cache
-_DEFAULT_MAX_TTL = 300                         # 5 min max TTL to prevent stale IPs
+_CACHE_LOCK = threading.RLock()  # Thread-safe lock for cache
+_DEFAULT_MAX_TTL = 300  # 5 min max TTL to prevent stale IPs
+
 
 @retry(
     stop=stop_after_attempt(3),
@@ -35,9 +44,10 @@ def _resolve_from_dns(hostname: str) -> Tuple[str, int]:
     ttl = answers.rrset.ttl or _DEFAULT_MAX_TTL
     return answers[0].address, ttl
 
+
 def get_ip_with_ttl(hostname: str) -> Tuple[str, int]:
-    """
-    Get the current IP and TTL for a hostname using a TTL cache.
+    """Get the current IP and TTL for a hostname using a TTL cache.
+
     - Returns cached IP and TTL if valid.
     - Resolves DNS and updates cache if expired or missing.
     - Falls back to last known IP if DNS resolution fails.
@@ -64,6 +74,7 @@ def get_ip_with_ttl(hostname: str) -> Tuple[str, int]:
             return ip, 30  # 30 seconds
         raise
 
+
 # Database Functions
 def apply_migrations(sqlalchemy_database_uri: str, revision: str = "head") -> None:
     """Apply database migrations using Alembic."""
@@ -74,35 +85,45 @@ def apply_migrations(sqlalchemy_database_uri: str, revision: str = "head") -> No
     alembic_cfg.set_main_option("script_location", str(migration_path))
     command.upgrade(alembic_cfg, revision)
 
+
 @functools.lru_cache(maxsize=4)
 def get_engine_from_config(uri: str) -> Engine:
-    """
-    Create a SQLAlchemy Engine whose connections always point to the
-    *current* IP of `uri`’s host, with automated cache-and-recycle
-    driven by the DNS record’s TTL.
+    """Create a SQLAlchemy Engine whose connections always point to the current IP.
+
+    The connections always point to the *current* IP of `uri`'s host, with
+    automated cache-and-recycle driven by the DNS record's TTL.
     """
     parsed = make_url(uri)
     hostname = parsed.host
+    
+    # Add null check for hostname
+    if hostname is None:
+        raise ValueError("URI must have a hostname")
 
     # Do an initial lookup so we can set the starting pool_recycle
     _, initial_ttl = get_ip_with_ttl(hostname)
     recycle_interval = min(initial_ttl, _DEFAULT_MAX_TTL)
 
-    def _creator():
-        """
-        This is called once per new DBAPI connection.
+    def _creator() -> DBAPIConnection:
+        """This is called once per new DBAPI connection.
+
         We:
           1. resolve the host (getting fresh TTL)
           2. bump pool_recycle so old sockets get closed at the right time
           3. open a raw driver connection straight to that IP
         """
+        if hostname is None:
+            raise ValueError("Hostname cannot be None")
+            
         ip_now, ttl_now = get_ip_with_ttl(hostname)
-        # Adjust recycle so connections don’t live past their DNS validity
+        # Adjust recycle so connections don't live past their DNS validity
         engine.pool._recycle = min(ttl_now, _DEFAULT_MAX_TTL)
-        return create_engine(
-            parsed.set(host=ip_now),
-            connect_args={"connect_timeout": 2}
+        conn = create_engine(
+            parsed.set(host=ip_now), connect_args={"connect_timeout": 2}
         ).raw_connection()
+        
+        # Explicitly cast the return value to DBAPIConnection
+        return cast(DBAPIConnection, conn)
 
     # We need *some* dummy URL here so SQLAlchemy knows which dialect/driver
     placeholder = parsed.set(host="127.0.0.1", port=1)
@@ -118,37 +139,55 @@ def get_engine_from_config(uri: str) -> Engine:
     )
 
     @event.listens_for(engine, "connect")
-    def _on_connect(dbapi_conn, conn_record):
+    def _on_connect(
+        dbapi_conn: DBAPIConnection, conn_record: _ConnectionRecord
+    ) -> None:
         """Stash the IP we used when this connection was first made."""
+        if hostname is None:
+            raise ValueError("Hostname cannot be None")
+            
         ip_used, _ = get_ip_with_ttl(hostname)
         conn_record.info["peer_ip"] = ip_used
 
     @event.listens_for(engine, "checkout")
-    def _on_checkout(dbapi_conn, conn_record, conn_proxy):
+    def _on_checkout(
+        dbapi_conn: DBAPIConnection,
+        conn_record: _ConnectionRecord,
+        conn_proxy: Connection,
+    ) -> None:
+        """Every time the pool gives out a connection, check IP matches current DNS IP.
+
+        If the IP doesn't match the current DNS IP, drop the connection.
         """
-        Every time the pool gives out a connection, make sure its
-        peer_ip matches the *current* DNS IP. If not, drop it.
-        """
+        if hostname is None:
+            raise ValueError("Hostname cannot be None")
+            
         old_ip = conn_record.info.get("peer_ip")
         current_ip, _ = get_ip_with_ttl(hostname)
         if old_ip != current_ip:
-            conn_record.invalidate(dbapi_conn)  # kill the socket
+            # Fix: Use None instead of dbapi_conn for the first argument
+            conn_record.invalidate(None)  # kill the socket
             raise exc.DisconnectionError(
                 f"Host IP changed from {old_ip} → {current_ip}; reconnecting"
             )
 
     return engine
 
+
 @functools.lru_cache(maxsize=4)
 def _get_session_factory(uri: str) -> sessionmaker:
     """Cached session factory for database sessions."""
-    return sessionmaker(bind=get_engine_from_config(uri), autoflush=False, autocommit=False)
+    return sessionmaker(
+        bind=get_engine_from_config(uri), autoflush=False, autocommit=False
+    )
+
 
 def get_session_local() -> sessionmaker:
     """Get or create a sessionmaker for database sessions."""
     config = get_jobmon_config()
     uri = config.get("db", "sqlalchemy_database_uri")
     return _get_session_factory(uri)
+
 
 def init_db() -> None:
     """Initialize database and apply migrations."""
@@ -161,7 +200,9 @@ def init_db() -> None:
     apply_migrations(sqlalchemy_database_uri)
     if add_metadata:
         from jobmon.server.web.models import load_metadata
+
         load_metadata(get_engine_from_config(sqlalchemy_database_uri))
+
 
 def terminate_db(sqlalchemy_database_uri: str) -> None:
     """Drop the database if it exists."""

--- a/tests/server/test_dns.py
+++ b/tests/server/test_dns.py
@@ -1,0 +1,92 @@
+# tests/test_dns_cache.py
+import importlib
+import pytest
+from types import SimpleNamespace
+
+# import the module under test
+db = importlib.import_module("jobmon.server.web.db_admin")
+
+# a tiny FakeAnswers that mimics dnspython’s Answer
+class FakeAnswers(list):
+    def __init__(self, records, ttl):
+        super().__init__(records)
+        # dnspython puts TTL on the rrset
+        self.rrset = SimpleNamespace(ttl=ttl)
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    # clear before and after each test
+    db._DNS_CACHE.clear()
+    yield
+    db._DNS_CACHE.clear()
+
+def test_initial_resolution_and_caching(monkeypatch):
+    host = "db.example.local"
+    # stub resolver.resolve → one record, TTL=120
+    fake = FakeAnswers([ SimpleNamespace(address="1.2.3.4") ], ttl=120)
+    monkeypatch.setattr(db.resolver, "resolve",
+                        lambda hostname, qtype, lifetime: fake)
+    # stub time to a fixed point
+    t0 = 1_000_000.0
+    monkeypatch.setattr(db.time, "time", lambda: t0)
+
+    # first call must do a DNS lookup
+    ip, ttl = db.get_ip_with_ttl(host)
+    assert ip  == "1.2.3.4"
+    assert ttl == 120
+
+    # check that cache now contains our entry
+    assert host in db._DNS_CACHE
+
+    # advance time by 30s → still cached, remaining TTL = 90
+    monkeypatch.setattr(db.time, "time", lambda: t0 + 30)
+    ip2, ttl2 = db.get_ip_with_ttl(host)
+    assert ip2  == "1.2.3.4"
+    assert ttl2 == 90
+
+def test_cache_expiry_triggers_new_dns(monkeypatch):
+    host = "db.example.local"
+
+    # first resolve returns IP A, TTL 60
+    ans1 = FakeAnswers([ SimpleNamespace(address="1.2.3.4") ], ttl=60)
+    # second resolve returns IP B, TTL 30
+    ans2 = FakeAnswers([ SimpleNamespace(address="5.6.7.8") ], ttl=30)
+
+    # count how many times resolver.resolve is called
+    calls = {"n": 0}
+    def fake_resolve(hostname, qtype, lifetime):
+        calls["n"] += 1
+        return ans1 if calls["n"] == 1 else ans2
+
+    monkeypatch.setattr(db.resolver, "resolve", fake_resolve)
+    t0 = 2_000_000.0
+    monkeypatch.setattr(db.time, "time", lambda: t0)
+
+    # initial lookup
+    ip1, ttl1 = db.get_ip_with_ttl(host)
+    assert ip1  == "1.2.3.4"
+    assert ttl1 == 60
+
+    # simulate expiration (t0 + 61 > t0+60)
+    monkeypatch.setattr(db.time, "time", lambda: t0 + 61)
+    ip2, ttl2 = db.get_ip_with_ttl(host)
+    assert ip2  == "5.6.7.8"
+    assert ttl2 == 30
+
+def test_dns_failure_uses_fallback_and_short_ttl(monkeypatch):
+    host = "db.example.local"
+
+    # pre-seed cache with a “known-good” IP that’s already expired
+    # so we go past the cache-hit check and into the retry/fallback logic
+    t0 = 1_000_000.0
+    monkeypatch.setattr(db.time, "time", lambda: t0)
+    db._DNS_CACHE[host] = ("9.9.9.9", t0 - 1)  # expired by 1 second
+
+    # make resolver.resolve always blow up
+    monkeypatch.setattr(db.resolver, "resolve",
+                        lambda hostname, qtype, lifetime: (_ for _ in ()).throw(Exception("boom")))
+
+    ip, ttl = db.get_ip_with_ttl(host)
+    assert ip  == "9.9.9.9"
+    # on failure we hard-code a 30-second retry window
+    assert ttl == 30


### PR DESCRIPTION
feat(db_admin): Enhance DNS resilience and connection management

- Implement dynamic IP resolution with TTL-aware caching for database connections
- Add adaptive pool recycling based on DNS TTL to prevent stale connections
- Cache engine and session factory with lru_cache for efficiency
- Validate connection IPs on checkout to ensure freshness
- Introduce structured logging for DNS failures to improve observability
- Set fast DNS timeouts (2s) to handle brown-outs gracefully