### PR TITLE
Preformatted error logs

### DIFF
--- a/jobmon_gui/src/components/task_details/TaskInstanceTable.tsx
+++ b/jobmon_gui/src/components/task_details/TaskInstanceTable.tsx
@@ -226,7 +226,9 @@ export default function TaskInstanceTable({ taskId }: TaskInstanceTableProps) {
                         </Grid>
                         <Grid item xs={12}>
                             <ScrollableCodeBlock>
-                                {rowDetail.ti_stdout_log}
+                                <pre>
+                                    {rowDetail.ti_stdout_log}
+                                </pre>
                             </ScrollableCodeBlock>
                         </Grid>
                     </Grid>
@@ -257,7 +259,9 @@ export default function TaskInstanceTable({ taskId }: TaskInstanceTableProps) {
                         </Grid>
                         <Grid item xs={12}>
                             <ScrollableCodeBlock>
-                                {rowDetail.ti_stderr_log}
+                                <pre>
+                                    {rowDetail.ti_stderr_log}
+                                </pre>
                             </ScrollableCodeBlock>
                         </Grid>
                         <Grid item xs={12}>


### PR DESCRIPTION
The error logs were displayed allruntogether, in this task-instance-specific view, making them more or less unreadable. The `<pre>` tag makes them more readable*.

*Note that the _modal_ where these are displayed seems unnecessarily constricting. Error logs tend to be wide.