### PR TITLE
Use `<pre>` to honor line breaks in log output.

### DIFF
--- a/jobmon_gui/src/components/task_details/TaskInstanceTable.tsx
+++ b/jobmon_gui/src/components/task_details/TaskInstanceTable.tsx
@@ -226,7 +226,9 @@ export default function TaskInstanceTable({ taskId }: TaskInstanceTableProps) {
                         </Grid>
                         <Grid item xs={12}>
                             <ScrollableCodeBlock>
-                                {rowDetail.ti_stdout_log}
+                                <pre>
+                                    {rowDetail.ti_stdout_log}
+                                </pre>
                             </ScrollableCodeBlock>
                         </Grid>
                     </Grid>
@@ -257,7 +259,9 @@ export default function TaskInstanceTable({ taskId }: TaskInstanceTableProps) {
                         </Grid>
                         <Grid item xs={12}>
                             <ScrollableCodeBlock>
-                                {rowDetail.ti_stderr_log}
+                                <pre>
+                                    {rowDetail.ti_stderr_log}
+                                </pre>
                             </ScrollableCodeBlock>
                         </Grid>
                         <Grid item xs={12}>


### PR DESCRIPTION
The error logs were displayed allruntogether, in this task-instance-specific view, making them more or less unreadable. The `<pre>` tag makes them more readable*.

*Note that the modal where these are displayed seems unnecessarily constricting. Error logs tend to be wide.

Side note: The other logs page, the one under "Clustered Errors", should probably be updated to match this one. The Cluster Errors seems to apply a formatter for _Python code_. Error logs are not, in general, Python. Sometimes you get a Python stack trace, and that include bits of Python that can be meaningfully formatted, but it also colorizes some non-Python-code lines incorrectly.

Moreover, it makes sense to have the two log displays display in the same way.