### PR TITLE
Handle no row was found when one was expected error

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/workflow.py
@@ -323,7 +323,9 @@ async def get_max_concurrently_running(workflow_id: int, request: Request) -> An
 
             if workflow is None:
                 return JSONResponse(
-                    content={"error": f"Workflow with ID {workflow_id} not found in database."},
+                    content={
+                        "error": f"Workflow with ID {workflow_id} not found in database."
+                    },
                     status_code=StatusCodes.NOT_FOUND,
                 )
 


### PR DESCRIPTION
This was probably being caused by users mistyping their workflow ID in to https://jobmon-gui.scicomp.ihme.washington.edu/#/workflow/<workflow_id>. Since that page calls this route to populate the technical panel with the workflow's concurrency limit.