### PR TITLE
Update resource usage plot based on user request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to Jobmon will be documented in this file.
 - Overhauled frontend resource utilization page for better performance and user experience.
 - Migrated project dependency management from pip-tools to UV workspace configuration.
 - Consolidated database session management and configuration for improved consistency and performance.
+- Updated Workflow.add_tasks() parameter type from Sequence[Task] to Iterable[Task] to accept a broader range of iterable types including generators and iterators. (PR 279)
+- Expanded error message when a TaskInstance doesn't report a heartbeat.
+- Refactored task status update endpoint into smaller functions for better maintainability.
 
 ### Fixed
 - Fixed critical database session leaks in workflow routes that could cause connection pool exhaustion in production.
@@ -25,18 +28,11 @@ All notable changes to Jobmon will be documented in this file.
 - Fixed OpenTelemetry instrumentation order to initialize before database access, preventing instrumentation issues.
 - Fixed test suite warnings and failures including AsyncIO deprecation warnings, Pydantic configuration warnings, Pandas FutureWarnings, and multiprocessing fork warnings on macOS.
 - Fixed pre-existing test failures related to configuration type handling and swarm test infrastructure.
-
-### Deprecated
-### Removed
-
-## [3.4.24] - TBD
-### Changed
-- Updated Workflow.add_tasks() parameter type from Sequence[Task] to Iterable[Task] to accept a broader range of iterable types including generators and iterators. (PR 279)
-
-### Fixed
 - Fixed ClientDisconnect exceptions appearing as errors in APM by adding global exception handler. (PR 282)
 - Fixed get_max_concurrently_running endpoint to handle non-existent workflows gracefully by returning a 404 error with descriptive message instead of raising an exception. (PR 278)
+- Fixed 'Set' object is not subscriptable in CLI error in `/update_statuses` route.
 
+### Fixed
 ## [3.4.23] - 2025-07-10
 ### Added
 - Added optional authentication support for Jobmon server and GUI (PR TBD). Authentication can now be disabled via `JOBMON__AUTH__ENABLED=false` server-side and `VITE_APP_AUTH_ENABLED=false` client-side environment variables for development and testing environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to Jobmon will be documented in this file.
 - Added enhanced OpenTelemetry database instrumentation with error capture for better observability.
 - Added JUnit XML report generation for test dashboard integration.
 - Added consolidated JSON logging fixture for server tests to improve test maintainability.
+- Added `Task Name` to the tooltip in the resource usage scatter plot.
+- Enabled filtering by `Task Name` in the resource usage scatter plot.
+- Added a `Download CSV button` to the resource usage page, allowing users to export all plot data regardless of filters.
 
 ### Changed
 - Overhauled frontend resource utilization page for better performance and user experience.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./jobmon_gui/src:/app/src:ro
+      - ./jobmon_gui/src:/app/src
     env_file:
       - .env  # Load environment variables from the .env file
 

--- a/jobmon_gui/src/components/task_template_details/usage/RuntimeMemoryScatterPlot.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/RuntimeMemoryScatterPlot.tsx
@@ -139,7 +139,12 @@ const RuntimeMemoryScatterPlot: React.FC<RuntimeMemoryScatterPlotProps> = ({
                         taskStatusMeta.UNKNOWN;
 
                     // Generate simplified tooltip with actual requested resources
-                    let tooltip = `<b>Task ${d.task_id}</b> (${pointStatusMeta.label})<br>`;
+                    let tooltip = `<b>Task ID: ${d.task_id}</b> (${pointStatusMeta.label})<br>`;
+                    
+                    // Add task name if available
+                    if (d.task_name) {
+                        tooltip += `<b>Task Name:</b> ${d.task_name}<br>`;
+                    }
 
                     // Runtime information
                     if (d.requestedRuntime) {

--- a/jobmon_gui/src/components/task_template_details/usage/Usage.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/Usage.tsx
@@ -138,6 +138,7 @@ export default function Usage({
 
     const filteredScatterData = useMemo(() => {
         if (!rawTaskNodesFromApi) return [];
+        
         return rawTaskNodesFromApi
             .filter(d => {
                 const clusterKey = getResourceClusterKey(d.requested_resources);
@@ -180,6 +181,8 @@ export default function Usage({
                     // Skip invalid JSON, leave as undefined
                 }
 
+                const taskName = item.task_name;
+
                 if (
                     runtime !== null &&
                     runtime > 0 &&
@@ -188,6 +191,7 @@ export default function Usage({
                 ) {
                     return {
                         task_id: item.task_id,
+                        task_name: taskName,
                         runtime: runtime,
                         memory: memoryGiB,
                         status: String(item.status || 'UNKNOWN').toUpperCase(),

--- a/jobmon_gui/src/components/task_template_details/usage/Usage.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/Usage.tsx
@@ -65,12 +65,15 @@ export default function Usage({
         selectedAttempts,
         selectedStatuses,
         selectedResourceClusters,
+        selectedTaskNames,
         availableAttempts,
         availableStatuses,
         availableResourceClusters,
+        availableTaskNames,
         setSelectedAttempts,
         setSelectedStatuses,
         setSelectedResourceClusters,
+        setSelectedTaskNames,
         resetFilters,
         clearFilters,
     } = useUsageFilters({ rawTaskNodesFromApi });
@@ -90,7 +93,8 @@ export default function Usage({
                             String(d.status || 'UNKNOWN').toUpperCase()
                         ) &&
                         (clusterKey === null ||
-                            selectedResourceClusters.has(clusterKey))
+                            selectedResourceClusters.has(clusterKey)) &&
+                        (!d.task_name || selectedTaskNames.has(d.task_name))
                     );
                 })
                 .map(item => {
@@ -110,6 +114,7 @@ export default function Usage({
         selectedAttempts,
         selectedStatuses,
         selectedResourceClusters,
+        selectedTaskNames,
     ]);
 
     // State for plot interactions
@@ -246,7 +251,8 @@ export default function Usage({
                         String(d.status || 'UNKNOWN').toUpperCase()
                     ) &&
                     (clusterKey === null ||
-                        selectedResourceClusters.has(clusterKey))
+                        selectedResourceClusters.has(clusterKey)) &&
+                    (!d.task_name || selectedTaskNames.has(d.task_name))
                 );
             })
             .map((item): ScatterDataPoint | null => {
@@ -304,6 +310,7 @@ export default function Usage({
         selectedAttempts,
         selectedStatuses,
         selectedResourceClusters,
+        selectedTaskNames,
     ]);
 
     // Determine which data to use for KPI calculations: selected data if available, otherwise filtered data
@@ -537,13 +544,16 @@ export default function Usage({
                 availableAttempts={availableAttempts}
                 availableStatuses={availableStatuses}
                 availableResourceClusters={availableResourceClusters}
+                availableTaskNames={availableTaskNames}
                 selectedAttempts={selectedAttempts}
                 selectedStatuses={selectedStatuses}
                 selectedResourceClusters={selectedResourceClusters}
+                selectedTaskNames={selectedTaskNames}
                 showResourceZones={showResourceZones}
                 onSelectedAttemptsChange={setSelectedAttempts}
                 onSelectedStatusesChange={setSelectedStatuses}
                 onSelectedResourceClustersChange={setSelectedResourceClusters}
+                onSelectedTaskNamesChange={setSelectedTaskNames}
                 onShowResourceZonesChange={setShowResourceZones}
                 onClearFilters={clearFilters}
                 onResetFilters={resetFilters}

--- a/jobmon_gui/src/components/task_template_details/usage/UsageFilters.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/UsageFilters.tsx
@@ -30,13 +30,16 @@ interface UsageFiltersProps {
     availableAttempts: string[];
     availableStatuses: string[];
     availableResourceClusters: ResourceCluster[];
+    availableTaskNames: string[];
     selectedAttempts: Set<string>;
     selectedStatuses: Set<string>;
     selectedResourceClusters: Set<string>;
+    selectedTaskNames: Set<string>;
     showResourceZones: boolean;
     onSelectedAttemptsChange: (attempts: Set<string>) => void;
     onSelectedStatusesChange: (statuses: Set<string>) => void;
     onSelectedResourceClustersChange: (clusters: Set<string>) => void;
+    onSelectedTaskNamesChange: (taskNames: Set<string>) => void;
     onShowResourceZonesChange: (show: boolean) => void;
     onClearFilters: () => void;
     onResetFilters: () => void;
@@ -46,13 +49,16 @@ const UsageFilters: React.FC<UsageFiltersProps> = ({
     availableAttempts,
     availableStatuses,
     availableResourceClusters,
+    availableTaskNames,
     selectedAttempts,
     selectedStatuses,
     selectedResourceClusters,
+    selectedTaskNames,
     showResourceZones,
     onSelectedAttemptsChange,
     onSelectedStatusesChange,
     onSelectedResourceClustersChange,
+    onSelectedTaskNamesChange,
     onShowResourceZonesChange,
     onClearFilters,
     onResetFilters,
@@ -349,6 +355,80 @@ const UsageFilters: React.FC<UsageFiltersProps> = ({
                                         />
                                         <ListItemText
                                             primary={cluster.label}
+                                            primaryTypographyProps={{
+                                                fontSize: '0.875rem',
+                                            }}
+                                        />
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+
+                        <FormControl size="small" sx={{ minWidth: 250 }}>
+                            <InputLabel id="task-name-filter-label">
+                                Task Names
+                            </InputLabel>
+                            <Select
+                                labelId="task-name-filter-label"
+                                multiple
+                                value={Array.from(selectedTaskNames)}
+                                onChange={event => {
+                                    const {
+                                        target: { value },
+                                    } = event;
+                                    onSelectedTaskNamesChange(
+                                        new Set(
+                                            typeof value === 'string'
+                                                ? value.split(',')
+                                                : (value as string[])
+                                        )
+                                    );
+                                }}
+                                input={<OutlinedInput label="Task Names" />}
+                                renderValue={selected => (
+                                    <Box
+                                        display="flex"
+                                        flexWrap="wrap"
+                                        gap={0.5}
+                                    >
+                                        {selected.slice(0, 1).map(value => (
+                                            <Chip
+                                                key={value}
+                                                label={
+                                                    value.length > 20
+                                                        ? `${value.substring(0, 20)}...`
+                                                        : value
+                                                }
+                                                size="small"
+                                                color="secondary"
+                                                variant="outlined"
+                                            />
+                                        ))}
+                                        {selected.length > 1 && (
+                                            <Chip
+                                                label={`+${selected.length - 1}`}
+                                                size="small"
+                                                variant="outlined"
+                                            />
+                                        )}
+                                    </Box>
+                                )}
+                                MenuProps={{
+                                    PaperProps: { style: { maxHeight: 300 } },
+                                }}
+                            >
+                                {availableTaskNames.map(taskName => (
+                                    <MenuItem
+                                        key={taskName}
+                                        value={taskName}
+                                        dense
+                                    >
+                                        <Checkbox
+                                            checked={selectedTaskNames.has(taskName)}
+                                            size="small"
+                                        />
+                                        <ListItemText
+                                            primary={taskName}
                                             primaryTypographyProps={{
                                                 fontSize: '0.875rem',
                                             }}

--- a/jobmon_gui/src/components/task_template_details/usage/UsagePlotSection.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/UsagePlotSection.tsx
@@ -1,8 +1,8 @@
 // Plot section component for Usage analysis
 
 import React from 'react';
-import { Box, Paper, Skeleton, Typography } from '@mui/material';
-import { Info as InfoIcon } from '@mui/icons-material';
+import { Box, Paper, Skeleton, Typography, Button } from '@mui/material';
+import { Info as InfoIcon, Download as DownloadIcon } from '@mui/icons-material';
 import RuntimeMemoryScatterPlot from './RuntimeMemoryScatterPlot';
 import { ScatterDataPoint } from '@jobmon_gui/types/Usage';
 
@@ -15,6 +15,8 @@ interface UsagePlotSectionProps {
     showResourceZones: boolean;
     onTaskClick: (taskId: number | string) => void;
     onSelected: (selectedPoints: ScatterDataPoint[]) => void;
+    onDownloadCSV?: () => void;
+    hasData?: boolean;
 }
 
 const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
@@ -26,6 +28,8 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
     showResourceZones,
     onTaskClick,
     onSelected,
+    onDownloadCSV,
+    hasData = false,
 }) => {
     return (
         <Paper
@@ -39,14 +43,39 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
             }}
         >
             <Box sx={{ p: 3, pb: 1 }}>
-                <Typography
-                    variant="h6"
-                    fontWeight="bold"
-                    color="primary.main"
-                    sx={{ mb: 0.5 }}
-                >
-                    Interactive Scatter Plot
-                </Typography>
+                <Box sx={{ 
+                    display: 'flex', 
+                    justifyContent: 'space-between', 
+                    alignItems: 'center',
+                    mb: 0.5 
+                }}>
+                    <Typography
+                        variant="h6"
+                        fontWeight="bold"
+                        color="primary.main"
+                    >
+                        Interactive Scatter Plot
+                    </Typography>
+                    {onDownloadCSV && (
+                        <Button
+                            variant="outlined"
+                            size="small"
+                            startIcon={<DownloadIcon />}
+                            onClick={onDownloadCSV}
+                            disabled={!hasData}
+                            sx={{
+                                color: 'primary.main',
+                                borderColor: 'primary.main',
+                                '&:hover': {
+                                    borderColor: 'primary.dark',
+                                    backgroundColor: 'primary.light',
+                                },
+                            }}
+                        >
+                            Download CSV
+                        </Button>
+                    )}
+                </Box>
                 <Typography
                     variant="body2"
                     color="text.secondary"

--- a/jobmon_gui/src/hooks/useUsageFilters.ts
+++ b/jobmon_gui/src/hooks/useUsageFilters.ts
@@ -17,12 +17,15 @@ interface UseUsageFiltersReturn {
     selectedAttempts: Set<string>;
     selectedStatuses: Set<string>;
     selectedResourceClusters: Set<string>;
+    selectedTaskNames: Set<string>;
     availableAttempts: string[];
     availableStatuses: string[];
     availableResourceClusters: ResourceCluster[];
+    availableTaskNames: string[];
     setSelectedAttempts: (attempts: Set<string>) => void;
     setSelectedStatuses: (statuses: Set<string>) => void;
     setSelectedResourceClusters: (clusters: Set<string>) => void;
+    setSelectedTaskNames: (taskNames: Set<string>) => void;
     resetFilters: () => void;
     clearFilters: () => void;
 }
@@ -40,6 +43,9 @@ export const useUsageFilters = ({
     const [selectedResourceClusters, setSelectedResourceClusters] = useState<
         Set<string>
     >(new Set());
+    const [selectedTaskNames, setSelectedTaskNames] = useState<Set<string>>(
+        new Set()
+    );
 
     // Calculate available filter options
     const availableAttempts = useMemo(() => {
@@ -66,6 +72,17 @@ export const useUsageFilters = ({
         return extractResourceClusters(rawTaskNodesFromApi);
     }, [rawTaskNodesFromApi]);
 
+    const availableTaskNames = useMemo(() => {
+        if (!rawTaskNodesFromApi) return [];
+        const taskNames = new Set<string>();
+        rawTaskNodesFromApi.forEach(d => {
+            if (d.task_name && d.task_name.trim()) {
+                taskNames.add(d.task_name);
+            }
+        });
+        return Array.from(taskNames).sort();
+    }, [rawTaskNodesFromApi]);
+
     // Initialize filters when data changes
     useEffect(() => {
         setSelectedAttempts(new Set(availableAttempts));
@@ -81,6 +98,10 @@ export const useUsageFilters = ({
         );
     }, [availableResourceClusters]);
 
+    useEffect(() => {
+        setSelectedTaskNames(new Set(availableTaskNames));
+    }, [availableTaskNames]);
+
     // Reset to defaults
     const resetFilters = () => {
         setSelectedAttempts(new Set(availableAttempts));
@@ -88,6 +109,7 @@ export const useUsageFilters = ({
         setSelectedResourceClusters(
             new Set(availableResourceClusters.map(cluster => cluster.id))
         );
+        setSelectedTaskNames(new Set(availableTaskNames));
     };
 
     // Clear all filters
@@ -97,18 +119,22 @@ export const useUsageFilters = ({
         setSelectedResourceClusters(
             new Set(availableResourceClusters.map(cluster => cluster.id))
         );
+        setSelectedTaskNames(new Set(availableTaskNames));
     };
 
     return {
         selectedAttempts,
         selectedStatuses,
         selectedResourceClusters,
+        selectedTaskNames,
         availableAttempts,
         availableStatuses,
         availableResourceClusters,
+        availableTaskNames,
         setSelectedAttempts,
         setSelectedStatuses,
         setSelectedResourceClusters,
+        setSelectedTaskNames,
         resetFilters,
         clearFilters,
     };

--- a/jobmon_gui/src/types/Usage.ts
+++ b/jobmon_gui/src/types/Usage.ts
@@ -2,6 +2,7 @@
 
 export interface ScatterDataPoint {
     task_id: number | string;
+    task_name?: string;
     runtime: number;
     memory: number;
     status: string;

--- a/jobmon_gui/src/types/apiSchema.ts
+++ b/jobmon_gui/src/types/apiSchema.ts
@@ -4151,6 +4151,8 @@ export interface components {
             node_id: number;
             /** Task Id */
             task_id: number;
+            /** Task Name */
+            task_name?: string | null;
             /** Requested Resources */
             requested_resources?: string | null;
             /** Attempt Number Of Instance */

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -61,6 +61,7 @@ class TaskTemplateRepository:
                 TaskInstance.maxrss,
                 Node.id.label("node_id_col"),
                 Task.id.label("task_id_col"),
+                Task.name.label("task_name_col"),
                 TaskInstance.id.label("task_instance_id_col"),
                 TaskResources.requested_resources.label("requested_resources_col"),
                 attempt_number_col,
@@ -85,9 +86,10 @@ class TaskTemplateRepository:
                     "m_orig": row[1],
                     "node_id": row[2],
                     "task_id": row[3],
-                    "requested_resources": row[5],
-                    "attempt_number_of_instance": row[6],
-                    "status_orig": row[7],
+                    "task_name": row[4],
+                    "requested_resources": row[6],
+                    "attempt_number_of_instance": row[7],
+                    "status_orig": row[8],
                 }
             )
 
@@ -148,6 +150,7 @@ class TaskTemplateRepository:
                         ),
                         node_id=task_item_dict["node_id"],
                         task_id=task_item_dict["task_id"],
+                        task_name=task_item_dict.get("task_name"),
                         requested_resources=task_item_dict["requested_resources"],
                         attempt_number_of_instance=task_item_dict.get(
                             "attempt_number_of_instance"
@@ -180,6 +183,7 @@ class TaskTemplateRepository:
                         ),
                         node_id=task_item_dict["node_id"],
                         task_id=task_item_dict["task_id"],
+                        task_name=task_item_dict.get("task_name"),
                         requested_resources=task_item_dict["requested_resources"],
                         attempt_number_of_instance=task_item_dict.get(
                             "attempt_number_of_instance"
@@ -217,6 +221,7 @@ class TaskTemplateRepository:
                         m=detail_item.m,
                         node_id=detail_item.node_id,
                         task_id=detail_item.task_id,
+                        task_name=detail_item.task_name,
                         requested_resources=detail_item.requested_resources,
                         attempt_number_of_instance=detail_item.attempt_number_of_instance,
                         status=detail_item.status,

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -24,20 +24,10 @@ class TaskResourceDetailItem(BaseModel):
     m: Optional[int] = Field(default=None, alias="maxrss")
     node_id: int
     task_id: int
-    requested_resources: Optional[str] = None  # Raw JSON string from DB
-    attempt_number_of_instance: Optional[int] = None  # Added field
-    status: Optional[str] = None  # Added field: Will hold 'D', 'F', etc.
-
-    # Example for parsing if you choose to send requested_resources_obj
-    # @validator('requested_resources_obj', pre=True, always=True)
-    # def parse_requested_resources(cls, v, values):
-    #     if values.get('requested_resources'):
-    #         try:
-    #             return RequestedResourcesModel(**json.loads(values['requested_resources']))
-    #         except json.JSONDecodeError:
-    #             return None
-    #     return None
-
+    task_name: Optional[str] = None
+    requested_resources: Optional[str] = None
+    attempt_number_of_instance: Optional[int] = None
+    status: Optional[str] = None
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -46,9 +36,10 @@ class TaskResourceVizItem(BaseModel):
     m: Optional[int] = None
     node_id: int
     task_id: int
+    task_name: Optional[str] = None
     requested_resources: Optional[str] = None
-    attempt_number_of_instance: Optional[int] = None  # Added field
-    status: Optional[str] = None  # Added field: Will hold 'D', 'F', etc.
+    attempt_number_of_instance: Optional[int] = None
+    status: Optional[str] = None
 
 
 class TaskTemplateResourceUsageResponse(BaseModel):


### PR DESCRIPTION
Added the following to the resource usage scatter plot:

- Added Task name to the tooltip when a user hovers over a data point
- Added a button that allows users to download a CSV file of all of the resource usage data
- Added a new filter that allows users to filter the scatter plot by Task name

<img width="1801" height="848" alt="Screenshot 2025-07-17 at 11 47 10 AM" src="https://github.com/user-attachments/assets/46439573-58f3-4ff7-9077-f72c8937face" />