### PR TITLE
Sync concurrency limit before creating swam command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Jobmon will be documented in this file.
 - Fixed OpenTelemetry instrumentation order to initialize before database access, preventing instrumentation issues.
 - Fixed test suite warnings and failures including AsyncIO deprecation warnings, Pydantic configuration warnings, Pandas FutureWarnings, and multiprocessing fork warnings on macOS.
 - Fixed pre-existing test failures related to configuration type handling and swarm test infrastructure.
+- Sync concurrency limit before creating swam commands.
 
 ### Deprecated
 ### Removed

--- a/jobmon_client/src/jobmon/client/swarm/workflow_run.py
+++ b/jobmon_client/src/jobmon/client/swarm/workflow_run.py
@@ -623,6 +623,10 @@ class WorkflowRun:
 
     def get_swarm_commands(self) -> Generator[SwarmCommand, None, None]:
         """Generator to get next chunk of work to be done. Must be idempotent."""
+        # Sync concurrency limits from server before starting
+        self._synchronize_max_concurrently_running()
+        self._synchronize_array_max_concurrently_running()
+
         # compute capacities. max - active
         active_tasks: Set[SwarmTask] = set()
         for task_status in self._active_states:


### PR DESCRIPTION
Add syncing concurrency limit before creating swam command. 