### PR TITLE
Improve query for tt error log viz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Jobmon will be documented in this file.
 - Added `Task Name` to the tooltip in the resource usage scatter plot.
 - Enabled filtering by `Task Name` in the resource usage scatter plot.
 - Added a `Download CSV button` to the resource usage page, allowing users to export all plot data regardless of filters.
+- **Performance Optimization**: Improved query performance for task template error log visualization by replacing correlated subqueries with CTEs and combining queries using window functions.
 
 ### Changed
 - **BREAKING: Logging System Migration**: Completely replaced legacy logging system with new elegant architecture:


### PR DESCRIPTION
When investigating the wait_timout issue, I suspected that there maybe wrongly managed session, so dig further, and saw this one: https://kibana.aks.scicomp.ihme.washington.edu/app/apm/services/jobmon/errors/d76d7446c8578503?comparisonEnabled=true&environment=ENVIRONMENT_ALL&kuery=&latencyAggregationType=p99&offset=705600000ms&page=0&pageSize=10&rangeFrom=2025-09-01T15:00:00.000Z&rangeTo=2025-09-09T19:00:00.000Z&serviceGroup=&sortDirection=desc&sortField=lastSeen&transactionType=request&errorId=b670956410311c2d1334eff5503a7c57

Corrected the session scope, and improved the query. 