### PR TITLE
Improve get task template detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to Jobmon will be documented in this file.
 - **Performance Optimization**: Enhanced `/api/v3/task_instance/instantiate_task_instances` endpoint with atomic transactions and retry logic to prevent deadlocks during high-concurrency task instantiation.
 - **Performance Optimization**: Improved `/api/v3/dag/{dag_id}/edges` endpoint with explicit transaction commits and standardized error handling patterns.
 - **Performance Optimization**: Optimized array transition endpoints (`/api/v3/array/{array_id}/transition_to_launched` and `/api/v3/array/{array_id}/transition_to_killed`) with atomic Task and TaskInstance updates in single transactions.
+- **Performance Optimization**: Dramatically improved `/api/v3/get_task_template_details` endpoint performance by replacing complex 4-table JOIN  with 4 targeted queries and O(n) set intersection.
 - JSON Compatibility Layer: Added backward compatibility for `downstream_node_ids` field - clients ≤ 3.4.23 receive quoted JSON strings, newer clients receive unquoted arrays
 
 ### Changed

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -417,7 +417,7 @@ class TaskTemplateRepository:
         self, workflow_id: int, task_template_id: int
     ) -> Optional[TaskTemplateDetailsResponse]:
         """Get task template details."""
-        # breach sql to get task template name separately
+        # break down sql to get task template name separately
         sql1 = select(
             TaskTemplate.name,
         ).where(TaskTemplate.id == task_template_id)


### PR DESCRIPTION
This PR isn’t a traditional single-query optimization; it makes a deliberate trade-off: accept a tiny overhead for small workflows (milliseconds to a few hundred ms) to speed up large workflows.

Original raw SQL:
SELECT DISTINCT 
    task_template.id,
    task_template.name,
    task_template_version.id AS task_template_version_id
FROM task
JOIN node ON task.node_id = node.id
JOIN task_template_version ON node.task_template_version_id = task_template_version.id
JOIN task_template ON task_template_version.task_template_id = task_template.id
WHERE 
    task.workflow_id = :workflow_id
    AND task_template_version.task_template_id = :task_template_id
    AND task_template_version.task_template_id = task_template.id
    
This has already been optimized. However, this performs poorly in corner cases. Example (Jon’s workflow 491686, task template 9740):
Set 1 (W): node_ids in the workflow → ~20K
Set 2 (T): node_ids that belong to the task template → ~2M
Joining to compute everything at once takes >12s in this case.

Indeed, we only need any one node in the overlap W ∩ T. For a given workflow and task template, all overlapping nodes share the same task_template_version_id, so finding one overlap is sufficient.

Approach (split into simpler steps)
1. Get the task template name (by :task_template_id).
2. Get Set 2 (T): node_ids associated with the task template.
3. Get Set 1 (W): node_ids in the workflow.
4: In Python, find one element of W ∩ T, then query its task_template_version_id.

Profiling (Jon’s example) using interactive SQL (note: this counts in the I/O time of interactive session):
Step 1: 0.004s
Step 2 (Set 2): 1.142s
Step 3 (Set 1): 0.040s
Step 4 (lookup id → version id): 0.013s
Python intersection cost:
Binary search in a 2M-element sorted list ≈ 0.01 ms
Worst case across 20K candidates ≈ 0.2 s
**Estimated total: ≲ 2 s.**
