### PR TITLE
More improvement tt detail

### DIFF
--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -975,7 +975,7 @@ class TaskTemplateRepository:
                  and node.task_template_version_id=22938253
                  group by task.id
                  order by ttel_id
-            takes 0.006s (0.108s for Joh's).
+            takes 0.006s (0.108s for Jon's).
 
             At last, test a case of many failures, wf 492914 ttv 53173:
                 Original count query: 3 min 13.148 sec;
@@ -994,8 +994,8 @@ class TaskTemplateRepository:
                 .join_from(TaskInstance, Task, TaskInstance.task_id == Task.id)
                 .join_from(Task, Node, Task.node_id == Node.id)
                 .where(
-                    TaskInstance.workflow_run_id == 351880,
-                    Node.task_template_version_id == 23926275,
+                    TaskInstance.workflow_run_id == workflow_run_id,
+                    Node.task_template_version_id == ttv_id,
                 )
                 .group_by(Task.id)
                 .order_by("ttel_id")


### PR DESCRIPTION
Jon's 500 error page in dev (using prod db): https://jobmon-gui.dev.scicomp.ihme.washington.edu/#/workflow/490688/task_template/9739

The route GET http://jobmon.dev.scicomp.ihme.washington.edu/api/v3/get_task_template_details?workflow_id=490688&task_template_id=9739
now takes 234ms; the route http://jobmon.dev.scicomp.ihme.washington.edu/api/v3/tt_error_log_viz/490688/9739?cluster_errors=true now takes 794ms.

Since this is not a normal sql optimization, but taking advantage of the jobmon special situation like the same wf won't have 2 versions of a tt, I add lots of comments in the code. Let me know if I should remove them.