### PR TITLE
fix: restore v2 behavior in queue_task_batch to always return task st…

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
@@ -164,7 +164,7 @@ def transit_ti_and_t(
             return
         except OperationalError as e:
             logger.warning(
-                f"Database error detected {e}, retrying attempt {i+1}/{max_retries}"
+                f"Database error detected {e}, retrying attempt {i + 1}/{max_retries}"
             )
             db.rollback()  # Clear the corrupted session state
             sleep(0.001 * (2 ** (i + 1)))  # Exponential backoff: 2ms, 4ms...


### PR DESCRIPTION
…atus

When no tasks need updating in queue_task_batch, the function now continues to query and return the actual current status of all requested tasks instead of returning an empty dict. This matches v2 behavior and provides better feedback to callers about why tasks weren't updated.

Also fixed pre-existing linter error in task_instance.py