### PR TITLE
Bugfix/fix clustered error problem

### DIFF
--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -881,6 +881,7 @@ class TaskTemplateRepository:
                         task_instance_err_id=row.id,
                         error_time=row.error_time,
                         error=row.description,
+                        task_instance_stderr_log=row.stderr_log,
                         workflow_run_id=row.workflow_run_id,
                         workflow_id=row.workflow_id,
                     )


### PR DESCRIPTION
We had users report that when they clicked their clustered error, the modal didn't show the full stack trace. This PR fixes that.


