### PR TITLE
Fix distributor batch KeyError causing stuck task instances

### DIFF
--- a/jobmon_core/src/jobmon/distributor/distributor_command.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_command.py
@@ -25,7 +25,14 @@ class DistributorCommand:
         try:
             self._func(*self._args, **self._kwargs)
         except Exception as e:
+            self.error_raised = True
             if raise_on_error:
                 raise
             else:
-                logger.exception("Distributor command failed", error=str(e))
+                logger.exception(
+                    "Distributor command failed",
+                    command=getattr(self._func, "__qualname__", str(self._func)),
+                    error_type=type(e).__name__,
+                    error=str(e),
+                    args=str(self._args)[:200],
+                )

--- a/jobmon_core/src/jobmon/distributor/distributor_task_instance.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_task_instance.py
@@ -121,6 +121,7 @@ class DistributorTaskInstance:
             message={"no_id_err_msg": no_id_err_msg},
             request_type="post",
         )
+        self.status = TaskInstanceStatus.NO_DISTRIBUTOR_ID
 
         logger.info(
             "Task instance transitioned INSTANTIATED → NO_DISTRIBUTOR_ID",


### PR DESCRIPTION
## Summary
- Fix `KeyError` in `DistributorService.process_status()` when a TaskInstance moves to a non-tracked status (e.g., `NO_DISTRIBUTOR_ID`) — the TI is now expired from distributor memory instead of crashing
- Fix `KeyError` in `launch_task_instance_batch()` by using safe `.pop(key, None)` with early return when a batch was already removed
- Sync local `DistributorTaskInstance.status` after `transition_to_no_distributor_id()` so `process_status()` sees the correct state
- Enhance error logging in `DistributorCommand` with function name, error type, and truncated args

## Test plan
- [x] Added regression test `test_array_submit_error_no_stuck_batch` that reproduces the exact failure: batch submit error → second refresh/process cycle no longer crashes with KeyError
- [x] Existing `test_array_submit_raises_error` continues to pass
- [x] All distributor integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches distributor state tracking and launch flow; bugs could cause tasks to be dropped from memory or skipped, but changes are small and covered by a targeted integration regression test.
> 
> **Overview**
> Prevents distributor crashes and stuck `INSTANTIATED` task instances after batch submission failures by making in-memory tracking tolerant of tasks/batches that have already transitioned or been removed.
> 
> `DistributorService.process_status()` now expires task instances that move to non-tracked statuses instead of raising `KeyError`, and `launch_task_instance_batch()` safely skips launching when a batch key is already gone. `DistributorTaskInstance.transition_to_no_distributor_id()` now updates the local status, and `DistributorCommand` logs richer error context (callable name/type + truncated args).
> 
> Adds an integration regression test (`test_array_submit_error_no_stuck_batch`) covering the failure/retry cycle to ensure no `KeyError` and no lingering `INSTANTIATED` tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c2f2b25205c72b0e662813e80e56d7bdb2bf3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->