### PR TITLE
fix: include task ID and error detail in failure logs (#352)

### DIFF
--- a/jobmon_client/src/jobmon/client/swarm/gateway.py
+++ b/jobmon_client/src/jobmon/client/swarm/gateway.py
@@ -413,6 +413,25 @@ class ServerGateway:
 
         return DownstreamTasksResponse(downstream_tasks=downstream_tasks)
 
+    async def get_most_recent_ti_error(
+        self, task_id: int
+    ) -> tuple[Optional[int], str]:
+        """Fetch the most recent task instance error for a failed task.
+
+        Args:
+            task_id: The task ID to query.
+
+        Returns:
+            Tuple of (task_instance_id, error_description). task_instance_id
+            is None if no error record exists.
+        """
+        _, response = await self._request(
+            app_route=f"/task/{task_id}/most_recent_ti_error",
+            message={},
+            request_type="get",
+        )
+        return response["task_instance_id"], response.get("error_description", "")
+
     async def get_server_time(self) -> datetime:
         """Get the current time from the server.
 

--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -485,7 +485,9 @@ class WorkflowRunOrchestrator:
         if update.task_statuses:
             changed_tasks = self._state.apply_update(update)
             if changed_tasks:
-                self._process_changed_tasks(changed_tasks)
+                failed_tasks = self._process_changed_tasks(changed_tasks)
+                if failed_tasks:
+                    await self._log_failed_task_errors(failed_tasks)
 
     # ──────────────────────────────────────────────────────────────────────────
     # Synchronization
@@ -504,7 +506,9 @@ class WorkflowRunOrchestrator:
 
         # Process changed tasks (propagate completions, set resources)
         if changed_tasks:
-            self._process_changed_tasks(changed_tasks)
+            failed_tasks = self._process_changed_tasks(changed_tasks)
+            if failed_tasks:
+                await self._log_failed_task_errors(failed_tasks)
 
         logger.debug(
             f"State synchronized. ready_to_run_count: {self._state.get_ready_to_run_count()}, "
@@ -512,7 +516,7 @@ class WorkflowRunOrchestrator:
             f"full_sync: {full_sync}"
         )
 
-    def _process_changed_tasks(self, changed_tasks: set["SwarmTask"]) -> None:
+    def _process_changed_tasks(self, changed_tasks: set["SwarmTask"]) -> list["SwarmTask"]:
         """Process tasks whose status changed.
 
         This handles post-update operations that can't be done in SwarmState:
@@ -529,9 +533,12 @@ class WorkflowRunOrchestrator:
         when A is processed, and again when B is processed directly (since it has
         REGISTERING status and all_upstreams_done). We prevent this by tracking
         tasks enqueued via propagation.
+
+        Returns:
+            List of tasks that transitioned to ERROR_FATAL in this update.
         """
         num_newly_completed = 0
-        num_newly_failed = 0
+        newly_failed: list["SwarmTask"] = []
 
         # Track tasks enqueued via propagation to prevent double-enqueuing
         enqueued_via_propagation: set["SwarmTask"] = set()
@@ -549,7 +556,7 @@ class WorkflowRunOrchestrator:
                     enqueued_via_propagation.add(downstream)
 
             elif task.status == TaskStatus.ERROR_FATAL:
-                num_newly_failed += 1
+                newly_failed.append(task)
 
             elif task.status == TaskStatus.REGISTERING and task.all_upstreams_done:
                 # Skip if already enqueued via propagation from an upstream DONE task
@@ -579,8 +586,42 @@ class WorkflowRunOrchestrator:
                 telemetry_percent_done=percent_done,
             )
 
-        if num_newly_failed > 0:
-            logger.warning(f"{num_newly_failed} newly failed tasks.")
+        if newly_failed:
+            failed_ids = [t.task_id for t in newly_failed]
+            logger.warning(
+                f"{len(newly_failed)} newly failed tasks.",
+                failed_task_ids=failed_ids,
+            )
+
+        return newly_failed
+
+    async def _log_failed_task_errors(self, failed_tasks: list["SwarmTask"]) -> None:
+        """Fetch and log error details for each newly-failed task.
+
+        Makes one API call per failed task to retrieve the most recent
+        task instance error, then logs task_id, task_instance_id, and
+        error description together.
+
+        Args:
+            failed_tasks: Tasks that just transitioned to ERROR_FATAL.
+        """
+        for task in failed_tasks:
+            try:
+                ti_id, error_desc = await self._gateway.get_most_recent_ti_error(
+                    task.task_id
+                )
+                logger.warning(
+                    "Task failed",
+                    task_id=task.task_id,
+                    task_instance_id=ti_id,
+                    error=error_desc[:500] if error_desc else "",
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Task failed (could not retrieve error details)",
+                    task_id=task.task_id,
+                    error=str(exc),
+                )
 
     # ──────────────────────────────────────────────────────────────────────────
     # Resource Management


### PR DESCRIPTION
Closes #352

The orchestrator previously logged only a count of newly failed tasks with no identifying information. This change adds task ID, instance ID, and available error context to the failure log line, eliminating the need to manually query the database to diagnose failures.

**Changes:**
- `orchestrator.py`: `_process_changed_tasks` now collects failed `SwarmTask` objects (instead of just counting) and logs their `task_id`s in the summary warning. Returns the list of failed tasks.
- `orchestrator.py`: Both async callers (`_do_scheduling`, `_do_sync`) now call a new `_log_failed_task_errors` method with the failed tasks.
- `orchestrator.py`: `_log_failed_task_errors` fetches `task_instance_id` and `error_description` from the existing `GET /task/{id}/most_recent_ti_error` endpoint for each failed task, logging them at WARNING level.
- `gateway.py`: Added `get_most_recent_ti_error(task_id)` method wrapping the existing server endpoint.

**Example log output after fix:**
```
WARNING: 1 newly failed tasks. failed_task_ids=[42]
WARNING: Task failed task_id=42 task_instance_id=1337 error="Traceback (most recent call last)..."
```

Automated fix generated by Claude Code agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds per-failed-task API calls in the orchestrator loop to retrieve and log error details; low functional risk but could impact performance/noise during large failure bursts and depends on the new endpoint wrapper behaving as expected.
> 
> **Overview**
> Improves failure observability by logging **which tasks failed** and their most recent error context instead of only a count.
> 
> `WorkflowRunOrchestrator` now has `_process_changed_tasks()` return newly `ERROR_FATAL` tasks; both `_do_scheduling()` and `_do_sync()` fetch and log each failed task’s `task_id`, `task_instance_id`, and truncated error text via a new `_log_failed_task_errors()` helper.
> 
> Adds `ServerGateway.get_most_recent_ti_error()` to call `GET /task/{task_id}/most_recent_ti_error` and return `(task_instance_id, error_description)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b24a36bb8b734b61d290bab6ca3b5fab2c30b96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->