### PR TITLE
Add OTel semantic convention attributes to OTLP log handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ docker_config/logconfig.otlp.yaml
 
 # Ignore design documents folder
 /design/
+
+# Ignore Claude Code artifacts
+.claude/worktrees/
+.playwright-mcp/
+.github-pat

--- a/jobmon_core/src/jobmon/core/otlp/handlers.py
+++ b/jobmon_core/src/jobmon/core/otlp/handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import traceback
 from typing import Any, Dict, Optional, Union
 
 from jobmon.core.config.structlog_config import (
@@ -141,9 +142,12 @@ class JobmonOTLPLoggingHandler(logging.Handler):
         Strips the 'telemetry_' prefix from attribute names for cleaner OTLP exports
         while maintaining internal namespacing.
         """
+        # exc_info is captured properly as exception.* attributes — skip the raw boolean
+        _SKIP_KEYS = frozenset(("event", "timestamp", "exc_info"))
+
         attributes = {}
         for key, value in event_dict.items():
-            if key.startswith("_") or key in ("event", "timestamp"):
+            if key.startswith("_") or key in _SKIP_KEYS:
                 continue
 
             # Strip telemetry_ prefix for OTLP export
@@ -214,6 +218,25 @@ class JobmonOTLPLoggingHandler(logging.Handler):
             # Add request correlation if available
             if event_dict and "request_id" in event_dict:
                 attributes["jobmon.request_id"] = event_dict["request_id"]
+
+            # Add source code attributes
+            attributes["code.filepath"] = record.pathname
+            attributes["code.lineno"] = record.lineno
+            attributes["code.function"] = record.funcName
+            attributes["code.namespace"] = record.name
+
+            # Add thread attributes
+            attributes["thread.id"] = record.thread
+            attributes["thread.name"] = record.threadName
+
+            # Add exception info using standard OTLP exception attributes
+            if record.exc_info and record.exc_info[0] is not None:
+                exc_type, exc_value, exc_tb = record.exc_info
+                attributes["exception.type"] = exc_type.__qualname__
+                attributes["exception.message"] = str(exc_value)
+                attributes["exception.stacktrace"] = "".join(
+                    traceback.format_exception(exc_type, exc_value, exc_tb)
+                )
 
             # Create OTLP log record (using public API from 1.39+)
             from opentelemetry._logs import LogRecord as OTLPLogRecord

--- a/jobmon_core/src/jobmon/core/otlp/handlers.py
+++ b/jobmon_core/src/jobmon/core/otlp/handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import traceback
 from typing import Any, Dict, Optional, Union
 
@@ -229,9 +230,21 @@ class JobmonOTLPLoggingHandler(logging.Handler):
             attributes["thread.id"] = record.thread
             attributes["thread.name"] = record.threadName
 
-            # Add exception info using standard OTLP exception attributes
-            if record.exc_info and record.exc_info[0] is not None:
-                exc_type, exc_value, exc_tb = record.exc_info
+            # Add exception info using standard OTLP exception attributes.
+            # Resolve exc_info: record.exc_info may be None when structlog's
+            # direct rendering path receives exc_info=True (the boolean doesn't
+            # survive _extract_exc_info). Fall back to event_dict or sys.exc_info().
+            exc_info = record.exc_info
+            if (not exc_info or exc_info[0] is None) and event_dict:
+                raw = event_dict.get("exc_info")
+                if raw is True:
+                    exc_info = sys.exc_info()
+                elif isinstance(raw, tuple) and len(raw) == 3:
+                    exc_info = raw
+                elif isinstance(raw, BaseException):
+                    exc_info = (type(raw), raw, raw.__traceback__)
+            if exc_info and exc_info[0] is not None:
+                exc_type, exc_value, exc_tb = exc_info
                 attributes["exception.type"] = exc_type.__qualname__
                 attributes["exception.message"] = str(exc_value)
                 attributes["exception.stacktrace"] = "".join(

--- a/tests/unit/logging/test_otlp.py
+++ b/tests/unit/logging/test_otlp.py
@@ -542,6 +542,155 @@ class TestOTLPConfigurationOverrides:
                 )
 
 
+class TestOTLPExceptionCapture:
+    """Test exception info extraction in OTLP handler."""
+
+    @patch("jobmon.core.otlp.handlers.OTLP_AVAILABLE", True)
+    def test_exc_info_from_record(self):
+        """Test that exception info is captured from record.exc_info."""
+        from jobmon.core.otlp import JobmonOTLPLoggingHandler
+
+        mock_logger_provider = Mock()
+        mock_logger = Mock()
+        mock_logger_provider.get_logger.return_value = mock_logger
+
+        handler = JobmonOTLPLoggingHandler(logger_provider=mock_logger_provider)
+
+        try:
+            raise ValueError("test error")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=42,
+            msg="something failed",
+            args=(),
+            exc_info=exc_info,
+        )
+
+        with patch("jobmon.core.config.structlog_config._thread_local") as mock_tl:
+            mock_tl.last_event_dict = None
+            handler.emit(record)
+
+        emitted = mock_logger.emit.call_args[0][0]
+        assert emitted.attributes["exception.type"] == "ValueError"
+        assert emitted.attributes["exception.message"] == "test error"
+        assert "ValueError: test error" in emitted.attributes["exception.stacktrace"]
+
+    @patch("jobmon.core.otlp.handlers.OTLP_AVAILABLE", True)
+    def test_exc_info_true_falls_back_to_event_dict(self):
+        """Test that exc_info=True in event_dict is resolved via sys.exc_info().
+
+        When structlog's direct rendering path receives exc_info=True, the
+        boolean doesn't survive into record.exc_info. The handler should fall
+        back to event_dict and call sys.exc_info().
+        """
+        from jobmon.core.otlp import JobmonOTLPLoggingHandler
+
+        mock_logger_provider = Mock()
+        mock_logger = Mock()
+        mock_logger_provider.get_logger.return_value = mock_logger
+
+        handler = JobmonOTLPLoggingHandler(logger_provider=mock_logger_provider)
+
+        # record.exc_info is None (simulating structlog direct rendering path)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=42,
+            msg="something failed",
+            args=(),
+            exc_info=None,
+        )
+
+        try:
+            raise RuntimeError("direct rendering error")
+        except RuntimeError:
+            # event_dict has exc_info=True while we're still in the except block
+            with patch("jobmon.core.config.structlog_config._thread_local") as mock_tl:
+                mock_tl.last_event_dict = {
+                    "event": "something failed",
+                    "exc_info": True,
+                }
+                handler.emit(record)
+
+        emitted = mock_logger.emit.call_args[0][0]
+        assert emitted.attributes["exception.type"] == "RuntimeError"
+        assert emitted.attributes["exception.message"] == "direct rendering error"
+        assert "RuntimeError" in emitted.attributes["exception.stacktrace"]
+
+    @patch("jobmon.core.otlp.handlers.OTLP_AVAILABLE", True)
+    def test_exc_info_exception_instance_in_event_dict(self):
+        """Test that a bare exception instance in event_dict is handled."""
+        from jobmon.core.otlp import JobmonOTLPLoggingHandler
+
+        mock_logger_provider = Mock()
+        mock_logger = Mock()
+        mock_logger_provider.get_logger.return_value = mock_logger
+
+        handler = JobmonOTLPLoggingHandler(logger_provider=mock_logger_provider)
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=42,
+            msg="something failed",
+            args=(),
+            exc_info=None,
+        )
+
+        exc = TypeError("bad type")
+        with patch("jobmon.core.config.structlog_config._thread_local") as mock_tl:
+            mock_tl.last_event_dict = {
+                "event": "something failed",
+                "exc_info": exc,
+            }
+            handler.emit(record)
+
+        emitted = mock_logger.emit.call_args[0][0]
+        assert emitted.attributes["exception.type"] == "TypeError"
+        assert emitted.attributes["exception.message"] == "bad type"
+
+    @patch("jobmon.core.otlp.handlers.OTLP_AVAILABLE", True)
+    def test_exc_info_boolean_not_in_attributes(self):
+        """Test that exc_info boolean is filtered from OTLP attributes."""
+        from jobmon.core.otlp import JobmonOTLPLoggingHandler
+
+        mock_logger_provider = Mock()
+        mock_logger = Mock()
+        mock_logger_provider.get_logger.return_value = mock_logger
+
+        handler = JobmonOTLPLoggingHandler(logger_provider=mock_logger_provider)
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=42,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+
+        with patch("jobmon.core.config.structlog_config._thread_local") as mock_tl:
+            mock_tl.last_event_dict = {
+                "event": "test message",
+                "exc_info": True,
+                "level": "info",
+            }
+            handler.emit(record)
+
+        emitted = mock_logger.emit.call_args[0][0]
+        assert "exc_info" not in emitted.attributes
+
+
 class TestOTLPErrorHandling:
     """Test error handling and resilience of OTLP functionality."""
 


### PR DESCRIPTION
## Summary

- Adds `exception.type`, `exception.message`, and `exception.stacktrace` from `record.exc_info` so full tracebacks appear in Elastic rather than the raw `labels.exc_info=true` boolean
- Adds `code.filepath`, `code.lineno`, `code.function`, `code.namespace` for source location on every log record
- Adds `thread.id` and `thread.name` for multi-threaded distributor log correlation
- Filters the `exc_info` boolean from event_dict attributes since it is now captured properly via `exception.*` attributes

## Test plan

- [ ] Trigger a job failure that hits the `except Exception` block in `distributor_service.launch_task_instance_batch` and verify `exception.stacktrace` appears in Elastic with the full traceback
- [ ] Verify `code.filepath` and `code.lineno` appear on log records pointing to the correct source location
- [ ] Verify `labels.exc_info=true` no longer appears on exception log records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core OTLP logging handler and changes what attributes get exported, which could affect log volume/querying and how exceptions appear in observability backends. Logic is covered by new unit tests but still impacts production telemetry behavior.
> 
> **Overview**
> **Enriches OTLP log exports with OpenTelemetry semantic convention fields.** The OTLP logging handler now always attaches source and thread metadata (`code.*`, `thread.*`) and emits exceptions as `exception.type`, `exception.message`, and `exception.stacktrace`, with fallbacks to resolve structlog cases where `exc_info=True` doesn’t populate `record.exc_info`.
> 
> It also stops exporting the raw `exc_info` key from structlog event attributes (avoiding `labels.exc_info=true`), adds unit tests covering the new exception-capture paths, and updates `.gitignore` to exclude Claude-related local artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6623c3e926f0f877d45d077dd0dc2d1eff613012. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->