### PR TITLE
Fix task details for pre-audit tasks

### DIFF
--- a/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
+++ b/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
@@ -645,6 +645,239 @@ function AttemptRow({
     );
 }
 
+// --- Fallback for pre-audit tasks ---
+
+function FallbackInstanceList({
+    instances,
+    modalState,
+    setModalState,
+}: {
+    instances: TaskInstance[];
+    modalState: ModalState;
+    setModalState: (s: ModalState) => void;
+}) {
+    const sorted = sortTaskInstancesById(instances);
+    const [expandedIdx, setExpandedIdx] = useState<number>(-1);
+    const modalInstance = modalState.instance;
+
+    return (
+        <Box sx={{ py: 1 }}>
+            <Typography
+                variant="subtitle2"
+                sx={{ mb: 1, fontWeight: 600 }}
+            >
+                Task Instances
+            </Typography>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 0.75,
+                }}
+            >
+                {sorted.map((inst, idx) => {
+                    const expanded = expandedIdx === idx;
+                    const statusColor = inst.ti_status
+                        ? getStatusColor(inst.ti_status)
+                        : '#999';
+                    const statusLabel = inst.ti_status
+                        ? getStatusLabel(inst.ti_status)
+                        : 'Unknown';
+                    return (
+                        <Box key={inst.ti_id}>
+                            <Box
+                                onClick={() =>
+                                    setExpandedIdx(
+                                        expanded ? -1 : idx
+                                    )
+                                }
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 1,
+                                    cursor: 'pointer',
+                                    borderRadius: '4px',
+                                    px: 0.5,
+                                    '&:hover': {
+                                        backgroundColor:
+                                            'action.hover',
+                                    },
+                                }}
+                            >
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        flexShrink: 0,
+                                        color: 'text.secondary',
+                                    }}
+                                >
+                                    {expanded ? (
+                                        <ExpandLessIcon fontSize="small" />
+                                    ) : (
+                                        <ExpandMoreIcon fontSize="small" />
+                                    )}
+                                </Box>
+                                <Typography
+                                    variant="caption"
+                                    sx={{
+                                        width: 90,
+                                        flexShrink: 0,
+                                        fontWeight: 500,
+                                        color: 'text.secondary',
+                                    }}
+                                >
+                                    Attempt {idx + 1}
+                                </Typography>
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 0.5,
+                                    }}
+                                >
+                                    <Box
+                                        sx={{
+                                            width: 8,
+                                            height: 8,
+                                            borderRadius: '50%',
+                                            backgroundColor:
+                                                statusColor,
+                                            flexShrink: 0,
+                                        }}
+                                    />
+                                    <Typography
+                                        variant="caption"
+                                        sx={{ fontWeight: 500 }}
+                                    >
+                                        {statusLabel}
+                                    </Typography>
+                                </Box>
+                            </Box>
+                            <Collapse in={expanded}>
+                                <Box
+                                    sx={{
+                                        ml: 4,
+                                        mt: 0.5,
+                                        mb: 1,
+                                        borderLeft: '2px solid',
+                                        borderColor: 'divider',
+                                        pl: 1.5,
+                                    }}
+                                >
+                                    <AttemptDetailPanel
+                                        instance={inst}
+                                        onViewStdout={() =>
+                                            setModalState({
+                                                type: 'stdout',
+                                                instance: inst,
+                                            })
+                                        }
+                                        onViewStderr={() =>
+                                            setModalState({
+                                                type: 'stderr',
+                                                instance: inst,
+                                            })
+                                        }
+                                    />
+                                </Box>
+                            </Collapse>
+                        </Box>
+                    );
+                })}
+            </Box>
+
+            {/* Stdout modal */}
+            <JobmonModal
+                title="Standard Out"
+                open={
+                    modalState.type === 'stdout' &&
+                    !!modalInstance
+                }
+                onClose={() =>
+                    setModalState({ type: null, instance: null })
+                }
+                width="80%"
+            >
+                <Grid container spacing={2}>
+                    <Grid item xs={12}>
+                        <Typography variant="h6">
+                            Standard Out Path:
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ScrollableCodeBlock>
+                            {modalInstance?.ti_stdout}
+                        </ScrollableCodeBlock>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Typography variant="h6">
+                            Standard Out Log:
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ScrollableCodeBlock>
+                            <pre>
+                                {modalInstance?.ti_stdout_log}
+                            </pre>
+                        </ScrollableCodeBlock>
+                    </Grid>
+                </Grid>
+            </JobmonModal>
+
+            {/* Stderr modal */}
+            <JobmonModal
+                title="Standard Error"
+                open={
+                    modalState.type === 'stderr' &&
+                    !!modalInstance
+                }
+                onClose={() =>
+                    setModalState({ type: null, instance: null })
+                }
+                width="80%"
+            >
+                <Grid container spacing={2}>
+                    <Grid item xs={12}>
+                        <Typography variant="h6">
+                            Standard Error Path:
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ScrollableCodeBlock>
+                            {modalInstance?.ti_stderr}
+                        </ScrollableCodeBlock>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Typography variant="h6">
+                            Standard Error Log:
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ScrollableCodeBlock>
+                            <pre>
+                                {modalInstance?.ti_stderr_log}
+                            </pre>
+                        </ScrollableCodeBlock>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Typography variant="h6">
+                            Standard Error Description:
+                        </Typography>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ScrollableCodeBlock>
+                            {
+                                modalInstance?.ti_error_log_description
+                            }
+                        </ScrollableCodeBlock>
+                    </Grid>
+                </Grid>
+            </JobmonModal>
+        </Box>
+    );
+}
+
 // --- Main component ---
 
 export default function TaskStatusTimeline({
@@ -719,6 +952,25 @@ export default function TaskStatusTimeline({
     }
 
     if (attempts.length === 0) {
+        // Fallback for tasks that predate the audit table: show instance
+        // details directly so users can still access stdout/stderr.
+        const fallbackInstances = tiQuery.data;
+        if (tiQuery.isLoading) {
+            return (
+                <Box sx={{ py: 1 }}>
+                    <CircularProgress size={20} />
+                </Box>
+            );
+        }
+        if (fallbackInstances && fallbackInstances.length > 0) {
+            return (
+                <FallbackInstanceList
+                    instances={fallbackInstances}
+                    modalState={modalState}
+                    setModalState={setModalState}
+                />
+            );
+        }
         return (
             <Typography variant="caption" color="text.secondary">
                 No status history available.


### PR DESCRIPTION
## Summary
- Tasks run before the `task_status_audit` migration have no audit records, causing the TaskStatusTimeline to show "No status history available" with no way to access stdout/stderr
- Adds a fallback `FallbackInstanceList` component that displays task instances directly (with expandable attempt rows, resource bars, stdout/stderr modals) when audit records are empty but task instances exist

## Test plan
- [ ] Navigate to a task that was run before the 3.6 release (e.g. task 327407492) and verify attempts are visible and expandable
- [ ] Verify stdout/stderr modals work from the fallback view
- [ ] Verify tasks with audit records still show the normal timeline view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a conditional fallback rendering path when `task_status_audit` is empty, without altering backend queries or data writes.
> 
> **Overview**
> When a task has **no `task_status_audit` records** (e.g., pre-migration tasks), `TaskStatusTimeline` now falls back to rendering the task’s `TaskInstance` list instead of only showing “No status history available”.
> 
> The new `FallbackInstanceList` provides expandable attempt rows and reuses the existing `AttemptDetailPanel` plus stdout/stderr modals so users can still view instance metadata and logs for these older tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f992422e35144fb70382dcc7bccb12493201b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->