### PR TITLE
Bundle optimization, resource error UI, and accessibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Jobmon will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- **Resource Error Detection**: New `/workflow_has_resource_errors` endpoint to check if any task instances in a workflow have resource errors; drives conditional UI in template list
+- **Fatal Error Breakdown**: New `/fatal_error_breakdown` endpoint classifying fatal tasks by last TI status (resource, app, infra) with resource error TI sample IDs for drill-down
+- **Error Log Fallback**: Error log queries now fall back to reading `stderr_log`/`stderr` directly from task instances when no `TaskInstanceErrorLog` entries exist, so resource-killed tasks still show output
+- **Copy Button**: Reusable `CopyButton` component added to task command displays in TaskDAG side panel, TaskSummaryCard, and ErrorClustersCard
+- **Resource Error Banner**: Task status timeline shows a resource error banner with specific diagnosis (runtime/memory exceeded) when a task instance has status RESOURCE_ERROR
 - **Task Status Audit**: TI-centric audit logging for task status transitions with `task_status_audit` table, `TaskFSM` service, and `TransitionService` with SKIP LOCKED support and retry logic
 - **Task Concurrency Visualization**: Interactive concurrency tab on workflow details with stacked bar charts per status, configurable bucket sizes, template grouping, and scale sync toggles
 - **Workflow DAG Redesign**: Two-panel workflow details layout with status-colored DAG nodes, mini status bars, edge highlighting, and visual state store for efficient re-renders
@@ -24,6 +29,12 @@ All notable changes to Jobmon will be documented in this file.
 - **Force Cleanup for Stuck Task Instances**: New `--force-cleanup` flag in `jobmon workflow resume` command to manually cleanup stuck `KILL_SELF` task instances when jobs have been externally terminated (e.g., via `scancel` or node failure)
 
 ### Changed
+- **Bundle Optimization**: Replaced `plotly.js-dist` (3.5 MB) with `plotly.js-cartesian-dist` (1.4 MB); added route-level lazy loading with `React.lazy`; split vendors into separate cacheable chunks (plotly, MUI, reactflow, core); total bundle reduced from 7.1 MB to ~3.2 MB across chunks
+- **Lazy Chart Tabs**: Workflow details chart tabs (Gantt, Status) lazy-load plotly on first render via `React.lazy` + `Suspense`, so the page shell renders without waiting for the 1.4 MB chart library
+- **Lighter Syntax Highlighter**: Switched `react-syntax-highlighter` from Prism (all languages) to Light build with only python, r, and bash registered
+- **Registered Status Color**: Changed Registered (`G`) status color from orange (`#e69f00`) to gray (`#999999`) so colorblind users can distinguish it from Done (green)
+- **Progress Bar CSS Specificity**: Increased selector specificity for status progress bars (`.progress-bar.pending-progress-bar`) to reliably override Bootstrap defaults regardless of CSS chunk load order
+- **Attempt Grouping**: Task status timeline now starts a new attempt on `A` (Adjusting Resources) status in addition to `G` (Registered), correctly grouping resource error retries
 - **Status Chart**: Merged 5 separate concurrency subplots into single stacked bar chart; selected template highlighted with solid bars against dimmed background
 - **Tab Renaming**: Bottom panel tabs renamed from "Concurrency"/"Timeline" to "Status"/"Gantt"
 - **DAG Layout**: Switched to left-to-right orientation, auto-sizes panel based on node count, lowered minZoom to 0.05 for large workflows
@@ -39,6 +50,7 @@ All notable changes to Jobmon will be documented in this file.
 - Unified status colors across all views (DAG, popover, concurrency chart, summary panel) into shared constants
 
 ### Fixed
+- **WorkflowDAG Missing CSS**: Added `reactflow/dist/style.css` import to `WorkflowDAG.tsx`; previously relied on `TaskDAG.tsx` importing it, which broke when route-level code splitting separated them into different chunks
 - **Concurrency Input**: PUT request now fires on blur instead of every keystroke
 - **Template Detail State**: Panel resets local state (concurrency value, status message) when switching templates
 - **DAG Self-Loops**: Filtered out meaningless self-loop edges at template level

--- a/jobmon_gui/package-lock.json
+++ b/jobmon_gui/package-lock.json
@@ -41,7 +41,7 @@
         "mustache": "^4.2.0",
         "npm": "^10.5.0",
         "plotly.js": "^2.16.1",
-        "plotly.js-dist": "^2.16.1",
+        "plotly.js-cartesian-dist": "^2.16.1",
         "qs": "6.10.5",
         "react": "^18.3.1",
         "react-bootstrap": "^2.7.2",
@@ -13748,8 +13748,10 @@
         "world-calendars": "^1.0.3"
       }
     },
-    "node_modules/plotly.js-dist": {
+    "node_modules/plotly.js-cartesian-dist": {
       "version": "2.35.3",
+      "resolved": "https://registry.npmjs.org/plotly.js-cartesian-dist/-/plotly.js-cartesian-dist-2.35.3.tgz",
+      "integrity": "sha512-BC2mSQwWl9YVoRXSux9T7eOd0XdMzpqsGq0pMCtwx+3JLKdiwBKdRU2IiWQx38Nsu1uzGxEDnLyy+l5z2DkinQ==",
       "license": "MIT"
     },
     "node_modules/point-in-polygon": {

--- a/jobmon_gui/package.json
+++ b/jobmon_gui/package.json
@@ -37,7 +37,7 @@
     "mustache": "^4.2.0",
     "npm": "^10.5.0",
     "plotly.js": "^2.16.1",
-    "plotly.js-dist": "^2.16.1",
+    "plotly.js-cartesian-dist": "^2.16.1",
     "qs": "6.10.5",
     "react": "^18.3.1",
     "react-bootstrap": "^2.7.2",

--- a/jobmon_gui/src/components/common/CopyButton.tsx
+++ b/jobmon_gui/src/components/common/CopyButton.tsx
@@ -1,0 +1,30 @@
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+
+interface CopyButtonProps {
+    text: string;
+    tooltip?: string;
+    size?: number;
+}
+
+export default function CopyButton({
+    text,
+    tooltip = 'Copy',
+    size = 16,
+}: CopyButtonProps) {
+    return (
+        <Tooltip title={tooltip}>
+            <IconButton
+                size="small"
+                onClick={() =>
+                    navigator.clipboard
+                        .writeText(text)
+                        .catch(() => {})
+                }
+            >
+                <ContentCopyIcon sx={{ fontSize: size }} />
+            </IconButton>
+        </Tooltip>
+    );
+}

--- a/jobmon_gui/src/components/task_details/TaskDAG.tsx
+++ b/jobmon_gui/src/components/task_details/TaskDAG.tsx
@@ -18,6 +18,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CloseIcon from '@mui/icons-material/Close';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import CopyButton from '@jobmon_gui/components/common/CopyButton';
 import ReactFlow, {
     Background,
     Controls,
@@ -471,18 +472,35 @@ export default function TaskDAG({
                         {/* Command */}
                         {task_details?.data?.task_command && (
                             <>
-                                <Typography
-                                    variant="caption"
-                                    color="text.secondary"
+                                <Box
                                     sx={{
-                                        fontWeight: 600,
-                                        textTransform:
-                                            'uppercase',
-                                        letterSpacing: 0.5,
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent:
+                                            'space-between',
                                     }}
                                 >
-                                    Command
-                                </Typography>
+                                    <Typography
+                                        variant="caption"
+                                        color="text.secondary"
+                                        sx={{
+                                            fontWeight: 600,
+                                            textTransform:
+                                                'uppercase',
+                                            letterSpacing: 0.5,
+                                        }}
+                                    >
+                                        Command
+                                    </Typography>
+                                    <CopyButton
+                                        text={
+                                            task_details.data
+                                                .task_command
+                                        }
+                                        tooltip="Copy command"
+                                        size={14}
+                                    />
+                                </Box>
                                 <ScrollableCodeBlock
                                     maxheight="80px"
                                     sx={{ fontSize: 11 }}

--- a/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
+++ b/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
@@ -17,6 +17,7 @@ import {
     getStatusLabel,
     getStatusTextColor,
     taskStatusMeta,
+    RESOURCE_ERROR_COLORS,
 } from '@jobmon_gui/constants/taskStatus';
 import { components } from '@jobmon_gui/types/apiSchema';
 import { TaskInstance } from '@jobmon_gui/types/TaskInstance';
@@ -115,9 +116,13 @@ function groupIntoAttempts(records: AuditRecord[]): Attempt[] {
 
     for (const record of records) {
         const seg = buildSegment(record);
-        // A new attempt starts when we transition into G (Registered),
+        // A new attempt starts when we transition into G (Registered)
+        // or A (Adjusting Resources — resource error retry),
         // except for the very first record which always starts attempt 1.
-        if (seg.status === 'G' && current.length > 0) {
+        const isNewAttempt =
+            (seg.status === 'G' || seg.status === 'A') &&
+            current.length > 0;
+        if (isNewAttempt) {
             attempts.push(finalizeAttempt(current));
             current = [];
         }
@@ -255,8 +260,64 @@ function AttemptDetailPanel({
         metaChips.push({ label: 'I/O', value: instance.ti_io });
     }
 
+    const isResourceError =
+        instance.ti_status === 'RESOURCE_ERROR';
+    const runtimeExceeded =
+        utilizedRuntimeSec != null &&
+        requestedRuntimeSec != null &&
+        requestedRuntimeSec > 0 &&
+        utilizedRuntimeSec / requestedRuntimeSec >= 0.95;
+    const memoryExceeded =
+        utilizedMemoryGiB != null &&
+        requestedMemoryGiB != null &&
+        requestedMemoryGiB > 0 &&
+        utilizedMemoryGiB / requestedMemoryGiB >= 0.95;
+
     return (
         <Box sx={{ px: 2, py: 1 }}>
+            {/* Resource error banner */}
+            {isResourceError && (
+                <Box
+                    sx={{
+                        backgroundColor: RESOURCE_ERROR_COLORS.bannerBg,
+                        border: `1px solid ${RESOURCE_ERROR_COLORS.main}`,
+                        borderRadius: 1,
+                        px: 1.5,
+                        py: 0.75,
+                        mb: 1,
+                    }}
+                >
+                    <Typography
+                        variant="body2"
+                        sx={{
+                            fontWeight: 600,
+                            color: RESOURCE_ERROR_COLORS.main,
+                        }}
+                    >
+                        Resource Error
+                        {runtimeExceeded && memoryExceeded
+                            ? ' — runtime and memory limits exceeded'
+                            : runtimeExceeded
+                              ? ' — runtime limit exceeded'
+                              : memoryExceeded
+                                ? ' — memory limit exceeded'
+                                : ' — insufficient resources'}
+                    </Typography>
+                    {instance.ti_error_log_description && (
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                color: 'text.secondary',
+                                display: 'block',
+                                mt: 0.25,
+                            }}
+                        >
+                            {instance.ti_error_log_description}
+                        </Typography>
+                    )}
+                </Box>
+            )}
+
             {/* Metadata row */}
             <Box
                 sx={{
@@ -411,7 +472,10 @@ function AttemptDetailPanel({
                             color="text.secondary"
                             sx={{ ml: 1 }}
                         >
-                            <strong>Stderr:</strong> no output
+                            <strong>Stderr:</strong>{' '}
+                            {isResourceError
+                                ? 'killed by cluster (no stderr captured)'
+                                : 'no output'}
                         </Typography>
                         <Button
                             size="small"

--- a/jobmon_gui/src/components/task_details/TaskSummaryCard.tsx
+++ b/jobmon_gui/src/components/task_details/TaskSummaryCard.tsx
@@ -10,6 +10,7 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import CopyButton from '@jobmon_gui/components/common/CopyButton';
 import { BiRun } from 'react-icons/bi';
 import { IoMdCloseCircle, IoMdCloseCircleOutline } from 'react-icons/io';
 import {
@@ -197,26 +198,34 @@ export default function TaskSummaryCard({
                     >
                         Command
                     </Typography>
-                    <Tooltip
-                        title={
-                            commandOpen
-                                ? 'Hide command'
-                                : 'Show command'
-                        }
-                    >
-                        <IconButton
-                            size="small"
-                            onClick={() =>
-                                setCommandOpen(!commandOpen)
+                    <Box sx={{ display: 'flex', gap: 0.5 }}>
+                        {commandOpen && taskDetails.task_command && (
+                            <CopyButton
+                                text={taskDetails.task_command}
+                                tooltip="Copy command"
+                            />
+                        )}
+                        <Tooltip
+                            title={
+                                commandOpen
+                                    ? 'Hide command'
+                                    : 'Show command'
                             }
                         >
-                            {commandOpen ? (
-                                <ExpandLessIcon fontSize="small" />
-                            ) : (
-                                <ExpandMoreIcon fontSize="small" />
-                            )}
-                        </IconButton>
-                    </Tooltip>
+                            <IconButton
+                                size="small"
+                                onClick={() =>
+                                    setCommandOpen(!commandOpen)
+                                }
+                            >
+                                {commandOpen ? (
+                                    <ExpandLessIcon fontSize="small" />
+                                ) : (
+                                    <ExpandMoreIcon fontSize="small" />
+                                )}
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
                 </Box>
                 <Collapse in={commandOpen}>
                     <ScrollableCodeBlock maxheight="150px">

--- a/jobmon_gui/src/components/task_template_details/usage/ErrorClustersCard.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/ErrorClustersCard.tsx
@@ -23,12 +23,12 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useLocation } from 'react-router-dom';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import python from 'react-syntax-highlighter/dist/esm/languages/hljs/python';
-import r from 'react-syntax-highlighter/dist/esm/languages/hljs/r';
+import rLang from 'react-syntax-highlighter/dist/esm/languages/hljs/r';
 import bash from 'react-syntax-highlighter/dist/esm/languages/hljs/bash';
 import { error_log_viz_url } from '@jobmon_gui/configs/ApiUrls';
 
 SyntaxHighlighter.registerLanguage('python', python);
-SyntaxHighlighter.registerLanguage('r', r);
+SyntaxHighlighter.registerLanguage('r', rLang);
 SyntaxHighlighter.registerLanguage('bash', bash);
 import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios';
 import HtmlTooltip from '@jobmon_gui/components/HtmlToolTip';

--- a/jobmon_gui/src/components/task_template_details/usage/ErrorClustersCard.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/ErrorClustersCard.tsx
@@ -17,11 +17,19 @@ import CloseIcon from '@mui/icons-material/Close';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import CopyButton from '@jobmon_gui/components/common/CopyButton';
 import axios from 'axios';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useLocation } from 'react-router-dom';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import python from 'react-syntax-highlighter/dist/esm/languages/hljs/python';
+import r from 'react-syntax-highlighter/dist/esm/languages/hljs/r';
+import bash from 'react-syntax-highlighter/dist/esm/languages/hljs/bash';
 import { error_log_viz_url } from '@jobmon_gui/configs/ApiUrls';
+
+SyntaxHighlighter.registerLanguage('python', python);
+SyntaxHighlighter.registerLanguage('r', r);
+SyntaxHighlighter.registerLanguage('bash', bash);
 import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios';
 import HtmlTooltip from '@jobmon_gui/components/HtmlToolTip';
 import { formatJobmonDate } from '@jobmon_gui/utils/DayTime.ts';
@@ -29,7 +37,7 @@ import { getTaskDetailsQueryFn } from
     '@jobmon_gui/queries/GetTaskDetails.ts';
 import {
     ClusteredError,
-    ErrorDetails,
+    ErrorLog,
     ErrorSampleDetails,
 } from '@jobmon_gui/types/ClusteredErrors.ts';
 
@@ -63,7 +71,9 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
     const [language, setLanguage] = useState('python');
 
     // --- Error detail query ---
-    const errorDetails = useQuery({
+    const errorDetails = useQuery<{
+        error_logs: ErrorLog[];
+    } | undefined>({
         queryKey: [
             'workflow_details',
             'error_details',
@@ -73,26 +83,35 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
         ],
         queryFn: async () => {
             if (errorDetailIndex === null) {
-                return;
+                return undefined;
             }
             if (
                 errorDetailIndex.sample_index >=
                 errorDetailIndex.sample_ids.length
             ) {
-                return;
+                return undefined;
             }
             const ti_id =
                 errorDetailIndex.sample_ids[
                     errorDetailIndex.sample_index
                 ];
             return axios
-                .get(
+                .get<{ error_logs: ErrorLog[] }>(
                     `${error_log_viz_url}${workflowId}/${taskTemplateId}/${ti_id}`,
                     { ...jobmonAxiosConfig, data: null }
                 )
                 .then(r => r.data);
         },
         enabled: !!taskTemplateId && errorDetailIndex !== null,
+    });
+
+    const currentError =
+        errorDetails.data?.error_logs?.[0] ?? null;
+    const taskDetailsQuery = useQuery({
+        queryKey: ['task_details', currentError?.task_id],
+        queryFn: getTaskDetailsQueryFn,
+        enabled: currentError?.task_id != null,
+        staleTime: 300000,
     });
 
     // Prefetch next sample
@@ -195,8 +214,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
             );
         }
         const error =
-            (errorDetails as unknown as ErrorDetails)?.data
-                ?.error_logs?.[0] ?? null;
+            errorDetails.data?.error_logs?.[0] ?? null;
         if (errorDetails.isError || !error) {
             return (
                 <Typography sx={{ p: 2 }}>
@@ -352,6 +370,62 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                             'No stderr output found'}
                     </SyntaxHighlighter>
                 </Box>
+
+                {/* Command */}
+                {taskDetailsQuery.data?.task_command && (
+                    <>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent:
+                                    'space-between',
+                                mt: 2,
+                                mb: 1,
+                            }}
+                        >
+                            <Typography
+                                variant="subtitle2"
+                                fontWeight="bold"
+                            >
+                                Command
+                            </Typography>
+                            <CopyButton
+                                text={
+                                    taskDetailsQuery.data
+                                        .task_command
+                                }
+                                tooltip="Copy command"
+                            />
+                        </Box>
+                        <Box
+                            sx={{
+                                maxHeight: '20vh',
+                                overflow: 'auto',
+                                bgcolor: '#eee',
+                                borderRadius: 1,
+                                fontSize: '0.75rem',
+                                '& pre': {
+                                    whiteSpace:
+                                        'pre-wrap !important',
+                                    wordBreak:
+                                        'break-word !important',
+                                    m: '0 !important',
+                                },
+                            }}
+                        >
+                            <SyntaxHighlighter
+                                language="bash"
+                                wrapLongLines
+                            >
+                                {
+                                    taskDetailsQuery.data
+                                        .task_command
+                                }
+                            </SyntaxHighlighter>
+                        </Box>
+                    </>
+                )}
             </Box>
         );
     };

--- a/jobmon_gui/src/components/task_template_details/usage/RuntimeMemoryScatterPlot.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/RuntimeMemoryScatterPlot.tsx
@@ -7,7 +7,7 @@ import React, {
     useImperativeHandle,
     forwardRef,
 } from 'react';
-import Plotly from 'plotly.js-dist';
+import Plotly from 'plotly.js-cartesian-dist';
 import createPlotlyComponent from 'react-plotly.js/factory';
 import { Box, useMediaQuery, useTheme } from '@mui/material';
 import {

--- a/jobmon_gui/src/components/workflow_details/ResourceCard.tsx
+++ b/jobmon_gui/src/components/workflow_details/ResourceCard.tsx
@@ -117,13 +117,7 @@ export default function ResourceCard({
     const currentTiId =
         selectedTiIdx !== null ? tiIds[selectedTiIdx] : null;
 
-    const retried = breakdown
-        ? Math.max(
-              0,
-              breakdown.resource_error_total -
-                  breakdown.resource
-          )
-        : 0;
+    const retried = breakdown?.resource_error_retried ?? 0;
 
     const errorDetailQuery = useQuery<{
         error_logs: ErrorLog[];

--- a/jobmon_gui/src/components/workflow_details/ResourceCard.tsx
+++ b/jobmon_gui/src/components/workflow_details/ResourceCard.tsx
@@ -1,0 +1,855 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
+import CloseIcon from '@mui/icons-material/Close';
+import MemoryIcon from '@mui/icons-material/Memory';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import humanizeDuration from 'humanize-duration';
+import axios from 'axios';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useLocation } from 'react-router-dom';
+import { FatalErrorBreakdown } from '@jobmon_gui/queries/GetFatalErrorBreakdown';
+import { getTaskDetailsQueryFn } from '@jobmon_gui/queries/GetTaskDetails';
+import { RESOURCE_ERROR_COLORS } from '@jobmon_gui/constants/taskStatus';
+import { error_log_viz_url } from '@jobmon_gui/configs/ApiUrls';
+import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios';
+import { ErrorLog } from '@jobmon_gui/types/ClusteredErrors';
+import CopyButton from '@jobmon_gui/components/common/CopyButton';
+import ResourceComparisonBar from '@jobmon_gui/components/task_details/ResourceComparisonBar';
+import { formatBytes, bytes_to_gib } from '@jobmon_gui/utils/formatters';
+import { parseResourceJson } from '@jobmon_gui/utils/csvExport';
+
+function fmtRuntime(seconds: number | null | undefined): string {
+    if (seconds == null) return 'N/A';
+    return humanizeDuration(seconds * 1000, {
+        largest: 1,
+        round: true,
+    });
+}
+
+function fmtMemory(bytes: number | null | undefined): string {
+    if (bytes == null) return 'N/A';
+    const gib = bytes / 1073741824;
+    return `${gib.toFixed(2)} GiB`;
+}
+
+interface ResourceCardProps {
+    workflowId: string | number;
+    taskTemplateId: string | number;
+    usageData: {
+        median_runtime?: number | null;
+        min_runtime?: number | null;
+        max_runtime?: number | null;
+        median_mem?: number | null;
+        min_mem?: number | null;
+        max_mem?: number | null;
+    } | null;
+    usageLoading: boolean;
+    breakdown: FatalErrorBreakdown | null | undefined;
+    breakdownLoading: boolean;
+}
+
+function StatColumn({
+    label,
+    value,
+}: {
+    label: string;
+    value: string;
+}) {
+    return (
+        <Grid item xs={12} sm={4}>
+            <Typography
+                variant="caption"
+                color="text.secondary"
+                fontWeight="medium"
+                sx={{
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                    fontSize: '0.6rem',
+                }}
+            >
+                {label}
+            </Typography>
+            <Typography
+                variant="body2"
+                fontWeight="bold"
+                sx={{ mt: 0.25 }}
+            >
+                {value}
+            </Typography>
+        </Grid>
+    );
+}
+
+export default function ResourceCard({
+    workflowId,
+    taskTemplateId,
+    usageData,
+    usageLoading,
+    breakdown,
+    breakdownLoading: _breakdownLoading,
+}: ResourceCardProps) {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const location = useLocation();
+    const [selectedTiIdx, setSelectedTiIdx] = useState<
+        number | null
+    >(null);
+
+    const hasUsage =
+        usageData &&
+        (usageData.median_runtime != null ||
+            usageData.median_mem != null);
+    const hasResourceErrors =
+        breakdown && breakdown.resource_error_total > 0;
+    const tiIds = breakdown?.resource_error_ti_ids ?? [];
+    const currentTiId =
+        selectedTiIdx !== null ? tiIds[selectedTiIdx] : null;
+
+    const retried = breakdown
+        ? Math.max(
+              0,
+              breakdown.resource_error_total -
+                  breakdown.resource
+          )
+        : 0;
+
+    const errorDetailQuery = useQuery<{
+        error_logs: ErrorLog[];
+    }>({
+        queryKey: [
+            'workflow_details',
+            'resource_error_detail',
+            workflowId,
+            taskTemplateId,
+            currentTiId,
+        ],
+        queryFn: async () => {
+            return axios
+                .get<{ error_logs: ErrorLog[] }>(
+                    `${error_log_viz_url}${workflowId}/${taskTemplateId}/${currentTiId}`,
+                    { ...jobmonAxiosConfig, data: null }
+                )
+                .then(r => r.data);
+        },
+        enabled: currentTiId != null,
+        staleTime: 120000,
+    });
+
+    const errorLog =
+        errorDetailQuery.data?.error_logs?.[0] ?? null;
+    const taskDetailsQuery = useQuery({
+        queryKey: ['task_details', errorLog?.task_id],
+        queryFn: getTaskDetailsQueryFn,
+        enabled: errorLog?.task_id != null,
+        staleTime: 300000,
+    });
+
+    const tiDetailsQuery = useQuery({
+        queryKey: ['ti_details', errorLog?.task_id],
+        queryFn: async () => {
+            const resp = await axios.get<{
+                taskinstances: Array<{
+                    ti_id: number;
+                    ti_maxrss: string | null;
+                    ti_wallclock: string | null;
+                    ti_resources: string | null;
+                }>;
+            }>(
+                `${import.meta.env.VITE_APP_BASE_URL}/task/get_ti_details_viz/${errorLog!.task_id}`,
+                { ...jobmonAxiosConfig, data: null }
+            );
+            return resp.data.taskinstances;
+        },
+        enabled: errorLog?.task_id != null,
+        staleTime: 120000,
+    });
+
+    const tiDetail = tiDetailsQuery.data?.find(
+        ti => ti.ti_id === currentTiId
+    );
+
+    if (usageLoading) {
+        return (
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    p: 1,
+                }}
+            >
+                <CircularProgress size={16} />
+                <Typography
+                    variant="caption"
+                    color="text.secondary"
+                >
+                    Loading resources...
+                </Typography>
+            </Box>
+        );
+    }
+
+    if (!hasUsage && !hasResourceErrors && !usageLoading) return null;
+
+    const drawerContent = () => {
+        if (errorDetailQuery.isLoading) {
+            return (
+                <Box
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        p: 4,
+                    }}
+                >
+                    <CircularProgress />
+                </Box>
+            );
+        }
+        if (!errorLog) {
+            return (
+                <Typography sx={{ p: 2 }}>
+                    No error details available.
+                </Typography>
+            );
+        }
+
+        const resources = tiDetail
+            ? parseResourceJson(tiDetail.ti_resources)
+            : null;
+        const requestedMemGiB = resources?.memory ?? null;
+        const utilizedMemGiB = tiDetail
+            ? bytes_to_gib(
+                  parseInt(
+                      String(tiDetail.ti_maxrss ?? '0'),
+                      10
+                  ) || 0
+              )
+            : null;
+        const requestedRuntimeSec =
+            resources?.runtime ?? null;
+        const utilizedRuntimeSec = tiDetail?.ti_wallclock
+            ? parseInt(String(tiDetail.ti_wallclock), 10)
+            : null;
+
+        return (
+            <Box sx={{ p: 2, overflow: 'auto' }}>
+                {/* Metadata */}
+                <Box
+                    sx={{
+                        display: 'grid',
+                        gridTemplateColumns: '1fr 1fr',
+                        gap: 1.5,
+                        mb: 2,
+                    }}
+                >
+                    <Box>
+                        <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            fontWeight="bold"
+                        >
+                            Task ID
+                        </Typography>
+                        {errorLog.task_id ? (
+                            <Link
+                                to={{
+                                    pathname: `/task_details/${errorLog.task_id}`,
+                                    search: location.search,
+                                }}
+                                style={{
+                                    color: '#1976d2',
+                                    fontSize: '0.875rem',
+                                    display: 'block',
+                                }}
+                            >
+                                {errorLog.task_id}
+                            </Link>
+                        ) : (
+                            <Typography variant="body2">
+                                —
+                            </Typography>
+                        )}
+                    </Box>
+                    <Box>
+                        <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            fontWeight="bold"
+                        >
+                            TI Status
+                        </Typography>
+                        <Typography variant="body2">
+                            Resource Error
+                        </Typography>
+                    </Box>
+                </Box>
+
+                {/* Resource comparison bars */}
+                {tiDetail && (
+                    <Box sx={{ mb: 2 }}>
+                        <Typography
+                            variant="subtitle2"
+                            fontWeight="bold"
+                            sx={{ mb: 1 }}
+                        >
+                            Resource Usage
+                        </Typography>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                gap: 3,
+                                flexWrap: 'wrap',
+                            }}
+                        >
+                            <Box
+                                sx={{
+                                    flex: '1 1 200px',
+                                    maxWidth: 300,
+                                }}
+                            >
+                                <ResourceComparisonBar
+                                    label="Memory"
+                                    requested={requestedMemGiB}
+                                    utilized={utilizedMemGiB}
+                                    requestedDisplay={
+                                        requestedMemGiB != null
+                                            ? `${requestedMemGiB} GiB`
+                                            : 'N/A'
+                                    }
+                                    utilizedDisplay={formatBytes(
+                                        tiDetail.ti_maxrss
+                                    )}
+                                />
+                            </Box>
+                            <Box
+                                sx={{
+                                    flex: '1 1 200px',
+                                    maxWidth: 300,
+                                }}
+                            >
+                                <ResourceComparisonBar
+                                    label="Runtime"
+                                    requested={
+                                        requestedRuntimeSec
+                                    }
+                                    utilized={
+                                        utilizedRuntimeSec
+                                    }
+                                    requestedDisplay={
+                                        requestedRuntimeSec !=
+                                        null
+                                            ? humanizeDuration(
+                                                  requestedRuntimeSec *
+                                                      1000,
+                                                  {
+                                                      largest: 2,
+                                                      round: true,
+                                                  }
+                                              )
+                                            : 'N/A'
+                                    }
+                                    utilizedDisplay={
+                                        utilizedRuntimeSec !=
+                                        null
+                                            ? humanizeDuration(
+                                                  utilizedRuntimeSec *
+                                                      1000,
+                                                  {
+                                                      largest: 2,
+                                                      round: true,
+                                                  }
+                                              )
+                                            : 'N/A'
+                                    }
+                                />
+                            </Box>
+                        </Box>
+                    </Box>
+                )}
+
+                {/* Error message / stderr */}
+                {errorLog.error && (
+                    <Box sx={{ mb: 2 }}>
+                        <Typography
+                            variant="subtitle2"
+                            fontWeight="bold"
+                            sx={{ mb: 0.5 }}
+                        >
+                            Error
+                        </Typography>
+                        <Box
+                            sx={{
+                                maxHeight: '20vh',
+                                overflow: 'auto',
+                                bgcolor: '#eee',
+                                borderRadius: 1,
+                                px: 1.5,
+                                py: 1,
+                                fontFamily: 'monospace',
+                                fontSize: '0.75rem',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-word',
+                            }}
+                        >
+                            {errorLog.error}
+                        </Box>
+                    </Box>
+                )}
+
+                {/* Command */}
+                {taskDetailsQuery.data?.task_command && (
+                    <Box>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent:
+                                    'space-between',
+                                mb: 0.5,
+                            }}
+                        >
+                            <Typography
+                                variant="subtitle2"
+                                fontWeight="bold"
+                            >
+                                Command
+                            </Typography>
+                            <CopyButton
+                                text={
+                                    taskDetailsQuery.data
+                                        .task_command
+                                }
+                                tooltip="Copy command"
+                            />
+                        </Box>
+                        <Box
+                            sx={{
+                                maxHeight: '15vh',
+                                overflow: 'auto',
+                                bgcolor: '#eee',
+                                borderRadius: 1,
+                                px: 1.5,
+                                py: 1,
+                                fontFamily: 'monospace',
+                                fontSize: '0.75rem',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-word',
+                            }}
+                        >
+                            {
+                                taskDetailsQuery.data
+                                    .task_command
+                            }
+                        </Box>
+                    </Box>
+                )}
+            </Box>
+        );
+    };
+
+    return (
+        <>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 1,
+                }}
+            >
+                {/* Resource error card */}
+                {hasResourceErrors && (
+                    <Card
+                        elevation={0}
+                        sx={{
+                            flex: '1 1 0',
+                            minWidth: 0,
+                            border: '1px solid',
+                            borderColor:
+                                RESOURCE_ERROR_COLORS.main,
+                            borderLeft: '3px solid',
+                            borderLeftColor:
+                                RESOURCE_ERROR_COLORS.main,
+                            borderRadius: 2,
+                        }}
+                    >
+                        <CardContent
+                            sx={{
+                                p: 1.5,
+                                '&:last-child': { pb: 1.5 },
+                            }}
+                        >
+                            <Typography
+                                variant="caption"
+                                sx={{
+                                    color: RESOURCE_ERROR_COLORS.main,
+                                    fontWeight: 'bold',
+                                    textTransform: 'uppercase',
+                                    letterSpacing: 0.5,
+                                    mb: 0.5,
+                                    display: 'block',
+                                }}
+                            >
+                                Resource Errors
+                            </Typography>
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    flexWrap: 'wrap',
+                                    gap: 0.5,
+                                    mb:
+                                        tiIds.length > 0
+                                            ? 1
+                                            : 0,
+                                }}
+                            >
+                                <Chip
+                                    icon={
+                                        <MemoryIcon
+                                            sx={{
+                                                fontSize: 12,
+                                                color: '#fff !important',
+                                            }}
+                                        />
+                                    }
+                                    label={`${breakdown!.resource_error_total} total`}
+                                    size="small"
+                                    sx={{
+                                        height: 22,
+                                        fontSize: '0.7rem',
+                                        fontWeight: 'bold',
+                                        backgroundColor:
+                                            RESOURCE_ERROR_COLORS.main,
+                                        color: '#fff',
+                                    }}
+                                />
+                                {retried > 0 && (
+                                    <Chip
+                                        label={`${retried} retried`}
+                                        size="small"
+                                        sx={{
+                                            height: 22,
+                                            fontSize: '0.7rem',
+                                            backgroundColor:
+                                                RESOURCE_ERROR_COLORS.retriedBg,
+                                            color: RESOURCE_ERROR_COLORS.retried,
+                                            fontWeight: 600,
+                                        }}
+                                    />
+                                )}
+                                {breakdown!.resource > 0 && (
+                                    <Chip
+                                        label={`${breakdown!.resource} fatal`}
+                                        size="small"
+                                        sx={{
+                                            height: 22,
+                                            fontSize: '0.7rem',
+                                            backgroundColor:
+                                                RESOURCE_ERROR_COLORS.fatal,
+                                            color: '#fff',
+                                            fontWeight: 600,
+                                        }}
+                                    />
+                                )}
+                            </Box>
+                            {/* Clickable TI sample list */}
+                            {tiIds.length > 0 && (
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        gap: 0.25,
+                                        maxHeight: 100,
+                                        overflow: 'auto',
+                                    }}
+                                >
+                                    {tiIds
+                                        .slice(0, 5)
+                                        .map((tiId, idx) => (
+                                            <Typography
+                                                key={tiId}
+                                                variant="caption"
+                                                onClick={() =>
+                                                    setSelectedTiIdx(
+                                                        idx
+                                                    )
+                                                }
+                                                sx={{
+                                                    fontFamily:
+                                                        'monospace',
+                                                    cursor: 'pointer',
+                                                    color: 'primary.main',
+                                                    '&:hover': {
+                                                        textDecoration:
+                                                            'underline',
+                                                    },
+                                                }}
+                                            >
+                                                TI {tiId}
+                                            </Typography>
+                                        ))}
+                                    {tiIds.length > 5 && (
+                                        <Typography
+                                            variant="caption"
+                                            color="text.secondary"
+                                        >
+                                            +{tiIds.length - 5}{' '}
+                                            more
+                                        </Typography>
+                                    )}
+                                </Box>
+                            )}
+                        </CardContent>
+                    </Card>
+                )}
+
+                {/* Runtime card */}
+                {hasUsage &&
+                    usageData!.median_runtime != null && (
+                        <Card
+                            elevation={0}
+                            sx={{
+                                flex: '1 1 0',
+                                minWidth: 0,
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                borderLeft: '3px solid',
+                                borderLeftColor:
+                                    'primary.main',
+                                borderRadius: 2,
+                            }}
+                        >
+                            <CardContent
+                                sx={{
+                                    p: 1.5,
+                                    '&:last-child': {
+                                        pb: 1.5,
+                                    },
+                                }}
+                            >
+                                <Typography
+                                    variant="caption"
+                                    color="primary.main"
+                                    fontWeight="bold"
+                                    sx={{
+                                        textTransform:
+                                            'uppercase',
+                                        letterSpacing: 0.5,
+                                        mb: 0.5,
+                                        display: 'block',
+                                    }}
+                                >
+                                    Runtime
+                                </Typography>
+                                <Grid
+                                    container
+                                    spacing={0.5}
+                                >
+                                    <StatColumn
+                                        label="Minimum"
+                                        value={fmtRuntime(
+                                            usageData!
+                                                .min_runtime
+                                        )}
+                                    />
+                                    <StatColumn
+                                        label="Maximum"
+                                        value={fmtRuntime(
+                                            usageData!
+                                                .max_runtime
+                                        )}
+                                    />
+                                    <StatColumn
+                                        label="Median"
+                                        value={fmtRuntime(
+                                            usageData!
+                                                .median_runtime
+                                        )}
+                                    />
+                                </Grid>
+                            </CardContent>
+                        </Card>
+                    )}
+
+                {/* Memory card */}
+                {hasUsage &&
+                    usageData!.median_mem != null && (
+                        <Card
+                            elevation={0}
+                            sx={{
+                                flex: '1 1 0',
+                                minWidth: 0,
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                borderLeft: '3px solid',
+                                borderLeftColor:
+                                    'secondary.main',
+                                borderRadius: 2,
+                            }}
+                        >
+                            <CardContent
+                                sx={{
+                                    p: 1.5,
+                                    '&:last-child': {
+                                        pb: 1.5,
+                                    },
+                                }}
+                            >
+                                <Typography
+                                    variant="caption"
+                                    color="secondary.main"
+                                    fontWeight="bold"
+                                    sx={{
+                                        textTransform:
+                                            'uppercase',
+                                        letterSpacing: 0.5,
+                                        mb: 0.5,
+                                        display: 'block',
+                                    }}
+                                >
+                                    Memory
+                                </Typography>
+                                <Grid
+                                    container
+                                    spacing={0.5}
+                                >
+                                    <StatColumn
+                                        label="Minimum"
+                                        value={fmtMemory(
+                                            usageData!
+                                                .min_mem
+                                        )}
+                                    />
+                                    <StatColumn
+                                        label="Maximum"
+                                        value={fmtMemory(
+                                            usageData!
+                                                .max_mem
+                                        )}
+                                    />
+                                    <StatColumn
+                                        label="Median"
+                                        value={fmtMemory(
+                                            usageData!
+                                                .median_mem
+                                        )}
+                                    />
+                                </Grid>
+                            </CardContent>
+                        </Card>
+                    )}
+            </Box>
+
+            {/* Resource error detail drawer */}
+            <Drawer
+                anchor="right"
+                open={selectedTiIdx !== null}
+                onClose={() => setSelectedTiIdx(null)}
+                PaperProps={{
+                    sx: {
+                        width: isMobile ? '100%' : 640,
+                    },
+                }}
+            >
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        px: 2,
+                        py: 1,
+                        borderBottom: '1px solid',
+                        borderColor: 'divider',
+                    }}
+                >
+                    <Typography variant="subtitle1" fontWeight="bold">
+                        Resource Error: TI{' '}
+                        {currentTiId ?? ''}
+                    </Typography>
+                    <Tooltip title="Close">
+                        <IconButton
+                            size="small"
+                            onClick={() =>
+                                setSelectedTiIdx(null)
+                            }
+                        >
+                            <CloseIcon fontSize="small" />
+                        </IconButton>
+                    </Tooltip>
+                </Box>
+                {/* Navigation */}
+                {tiIds.length > 1 && (
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            gap: 1,
+                            py: 0.5,
+                            borderBottom: '1px solid',
+                            borderColor: 'divider',
+                        }}
+                    >
+                        <Tooltip title="Previous">
+                            <span>
+                                <IconButton
+                                    size="small"
+                                    disabled={
+                                        selectedTiIdx === 0
+                                    }
+                                    onClick={() =>
+                                        setSelectedTiIdx(
+                                            i =>
+                                                i !== null
+                                                    ? i - 1
+                                                    : null
+                                        )
+                                    }
+                                >
+                                    <NavigateBeforeIcon fontSize="small" />
+                                </IconButton>
+                            </span>
+                        </Tooltip>
+                        <Typography variant="caption">
+                            {(selectedTiIdx ?? 0) + 1} of{' '}
+                            {tiIds.length}
+                        </Typography>
+                        <Tooltip title="Next">
+                            <span>
+                                <IconButton
+                                    size="small"
+                                    disabled={
+                                        selectedTiIdx ===
+                                        tiIds.length - 1
+                                    }
+                                    onClick={() =>
+                                        setSelectedTiIdx(
+                                            i =>
+                                                i !== null
+                                                    ? i + 1
+                                                    : null
+                                        )
+                                    }
+                                >
+                                    <NavigateNextIcon fontSize="small" />
+                                </IconButton>
+                            </span>
+                        </Tooltip>
+                    </Box>
+                )}
+                {drawerContent()}
+            </Drawer>
+        </>
+    );
+}

--- a/jobmon_gui/src/components/workflow_details/TaskConcurrencyTab.tsx
+++ b/jobmon_gui/src/components/workflow_details/TaskConcurrencyTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
-import Plotly from 'plotly.js-dist';
+import Plotly from 'plotly.js-cartesian-dist';
 import createPlotlyComponent from 'react-plotly.js/factory';
 
 const Plot = createPlotlyComponent(Plotly);

--- a/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
@@ -4,7 +4,6 @@ import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
-import CircularProgress from '@mui/material/CircularProgress';
 import Chip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
 import FormControl from '@mui/material/FormControl';
@@ -15,11 +14,13 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import BuildIcon from '@mui/icons-material/Build';
 import InfoIcon from '@mui/icons-material/Info';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import humanizeDuration from 'humanize-duration';
 import axios from 'axios';
 import { TTStatus } from '@jobmon_gui/types/TaskTemplateStatus';
 import { getClusteredErrorsFn } from '@jobmon_gui/queries/GetClusteredErrors';
 import { getWorkflowUsageQueryFn } from '@jobmon_gui/queries/GetWorkflowUsage';
+import ErrorClustersCard from '@jobmon_gui/components/task_template_details/usage/ErrorClustersCard';
+import ResourceCard from '@jobmon_gui/components/workflow_details/ResourceCard';
+import { getFatalErrorBreakdownFn } from '@jobmon_gui/queries/GetFatalErrorBreakdown';
 import {
     set_task_template_concurrency_url,
     task_table_url,
@@ -33,19 +34,6 @@ import {
 import TemplateStatusBar from '@jobmon_gui/components/common/TemplateStatusBar';
 
 const MAX_CONCURRENCY_SENTINEL = 2147483647;
-
-const INITIAL_ERROR_DISPLAY = 3;
-
-function formatRuntime(seconds: number | null | undefined): string {
-    if (seconds == null) return 'N/A';
-    return humanizeDuration(seconds * 1000, { largest: 1, round: true });
-}
-
-function formatMemory(bytes: number | null | undefined): string {
-    if (bytes == null) return 'N/A';
-    const gib = bytes / 1073741824;
-    return `${gib.toFixed(1)} GiB`;
-}
 
 interface TemplateDetailPanelProps {
     workflowId: string | number;
@@ -62,7 +50,6 @@ export default function TemplateDetailPanel({
     onNavigate,
     disabled,
 }: TemplateDetailPanelProps) {
-    const [showAllErrors, setShowAllErrors] = useState(false);
     const [concurrencyValue, setConcurrencyValue] = useState<
         number | string
     >(
@@ -82,7 +69,6 @@ export default function TemplateDetailPanel({
         );
         setStatusMsg('');
         setShowManage(false);
-        setShowAllErrors(false);
     }, [templateData.task_template_version_id]);
 
     const updateConcurrency = useMutation({
@@ -161,7 +147,7 @@ export default function TemplateDetailPanel({
             'workflow_details',
             'clustered_errors',
             workflowId,
-            templateData.task_template_version_id,
+            templateData.id,
         ],
         queryFn: getClusteredErrorsFn,
         enabled: templateData.FATAL > 0,
@@ -177,17 +163,19 @@ export default function TemplateDetailPanel({
         queryFn: getWorkflowUsageQueryFn,
     });
 
-    const usageData = usageQuery.data;
-    const hasUsageData =
-        usageData &&
-        (usageData.median_runtime != null ||
-            usageData.median_mem != null);
+    const breakdownQuery = useQuery({
+        queryKey: [
+            'workflow_details',
+            'fatal_breakdown',
+            workflowId,
+            templateData.task_template_version_id,
+        ],
+        queryFn: getFatalErrorBreakdownFn,
+        enabled: templateData.FATAL > 0,
+        staleTime: 120000,
+    });
 
     const errorClusters = errorsQuery.data?.error_logs ?? [];
-    const totalErrorClusters = errorClusters.length;
-    const visibleErrors = showAllErrors
-        ? errorClusters
-        : errorClusters.slice(0, INITIAL_ERROR_DISPLAY);
 
     return (
         <Box sx={{ p: 2, height: '100%', overflow: 'auto' }}>
@@ -320,175 +308,28 @@ export default function TemplateDetailPanel({
                 </Box>
             </Box>
 
-            {/* Errors section */}
+            {/* Errors */}
             {templateData.FATAL > 0 && (
-                <Box sx={{ mb: 2 }}>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 1,
-                            mb: 1,
-                        }}
-                    >
-                        <Typography variant="subtitle2">
-                            Errors
-                        </Typography>
-                        {errorsQuery.isSuccess && (
-                            <Chip
-                                label={`${totalErrorClusters} cluster${totalErrorClusters !== 1 ? 's' : ''}`}
-                                size="small"
-                                sx={{
-                                    height: 20,
-                                    fontSize: '0.75rem',
-                                    backgroundColor: TEMPLATE_STATUS_COLORS.FATAL,
-                                    color: '#fff',
-                                }}
-                            />
-                        )}
-                    </Box>
-
-                    {errorsQuery.isLoading && (
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <CircularProgress size={16} />
-                            <Typography variant="caption" color="text.secondary">
-                                Loading errors...
-                            </Typography>
-                        </Box>
-                    )}
-
-                    {errorsQuery.isError && (
-                        <Typography variant="caption" color="text.secondary">
-                            Could not load errors
-                        </Typography>
-                    )}
-
-                    {errorsQuery.isSuccess && (
-                        <>
-                            <Box
-                                sx={{
-                                    display: 'flex',
-                                    flexDirection: 'column',
-                                    gap: 1,
-                                }}
-                            >
-                                {visibleErrors.map((cluster, idx) => (
-                                    <Box
-                                        key={idx}
-                                        sx={{
-                                            display: 'flex',
-                                            gap: 1,
-                                            p: 1,
-                                            borderRadius: 1,
-                                            border: '1px solid',
-                                            borderColor: 'divider',
-                                        }}
-                                    >
-                                        <Chip
-                                            label={`\u00d7${cluster.group_instance_count}`}
-                                            size="small"
-                                            sx={{
-                                                height: 22,
-                                                fontSize: '0.75rem',
-                                                fontWeight: 'bold',
-                                                backgroundColor:
-                                                    TEMPLATE_STATUS_COLORS.FATAL,
-                                                color: '#fff',
-                                                flexShrink: 0,
-                                            }}
-                                        />
-                                        <Typography
-                                            variant="body2"
-                                            sx={{
-                                                fontSize: '0.8rem',
-                                                overflow: 'hidden',
-                                                display: '-webkit-box',
-                                                WebkitLineClamp: 3,
-                                                WebkitBoxOrient:
-                                                    'vertical',
-                                                wordBreak: 'break-all',
-                                                lineHeight: 1.3,
-                                            }}
-                                        >
-                                            {cluster.sample_error}
-                                        </Typography>
-                                    </Box>
-                                ))}
-                            </Box>
-
-                            {totalErrorClusters > INITIAL_ERROR_DISPLAY &&
-                                !showAllErrors && (
-                                    <Typography
-                                        variant="body2"
-                                        color="primary"
-                                        sx={{
-                                            mt: 1,
-                                            cursor: 'pointer',
-                                            '&:hover': {
-                                                textDecoration: 'underline',
-                                            },
-                                        }}
-                                        onClick={() => setShowAllErrors(true)}
-                                    >
-                                        Show all {totalErrorClusters} clusters ▸
-                                    </Typography>
-                                )}
-                        </>
-                    )}
+                <Box sx={{ mb: 1 }}>
+                    <ErrorClustersCard
+                        errorLogs={errorClusters}
+                        isLoading={errorsQuery.isLoading}
+                        workflowId={workflowId}
+                        taskTemplateId={templateData.id}
+                        maxListHeight={120}
+                    />
                 </Box>
             )}
 
-            {/* Resources section */}
-            {usageQuery.isLoading && (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-                    <CircularProgress size={16} />
-                    <Typography variant="caption" color="text.secondary">
-                        Loading resources...
-                    </Typography>
-                </Box>
-            )}
-
-            {hasUsageData && (
-                <Box
-                    sx={{
-                        display: 'grid',
-                        gridTemplateColumns: 'auto 1fr',
-                        gap: '2px 8px',
-                        mb: 1.5,
-                    }}
-                >
-                    <Typography variant="caption" color="text.secondary" fontWeight={600}>
-                        Resources
-                    </Typography>
-                    <Box />
-                    {usageData.median_runtime != null && (
-                        <>
-                            <Typography variant="caption" color="text.secondary">Runtime</Typography>
-                            <Typography variant="caption">
-                                {formatRuntime(usageData.median_runtime)}
-                                {' ('}
-                                {formatRuntime(usageData.min_runtime)}
-                                {' – '}
-                                {formatRuntime(usageData.max_runtime)}
-                                {')'}
-                            </Typography>
-                        </>
-                    )}
-                    {usageData.median_mem != null && (
-                        <>
-                            <Typography variant="caption" color="text.secondary">Memory</Typography>
-                            <Typography variant="caption">
-                                {formatMemory(usageData.median_mem)}
-                                {' ('}
-                                {formatMemory(usageData.min_mem)}
-                                {' – '}
-                                {formatMemory(usageData.max_mem)}
-                                {')'}
-                            </Typography>
-                        </>
-                    )}
-                </Box>
-            )}
+            {/* Resources card */}
+            <ResourceCard
+                workflowId={workflowId}
+                taskTemplateId={templateData.id}
+                usageData={usageQuery.data ?? null}
+                usageLoading={usageQuery.isLoading}
+                breakdown={breakdownQuery.data}
+                breakdownLoading={breakdownQuery.isLoading}
+            />
 
         </Box>
     );

--- a/jobmon_gui/src/components/workflow_details/TemplateListPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/TemplateListPanel.tsx
@@ -1,30 +1,154 @@
-import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
-import { TTStatusResponse } from '@jobmon_gui/types/TaskTemplateStatus';
-import { TEMPLATE_STATUS_COLORS } from '@jobmon_gui/constants/taskStatus';
+import Alert from '@mui/material/Alert';
+import MemoryIcon from '@mui/icons-material/Memory';
+import { useQuery } from '@tanstack/react-query';
+import { TTStatus, TTStatusResponse } from '@jobmon_gui/types/TaskTemplateStatus';
+import {
+    TEMPLATE_STATUS_COLORS,
+    RESOURCE_ERROR_COLORS,
+} from '@jobmon_gui/constants/taskStatus';
 import TemplateStatusBar from '@jobmon_gui/components/common/TemplateStatusBar';
+import { getFatalErrorBreakdownFn } from '@jobmon_gui/queries/GetFatalErrorBreakdown';
 
 const HOVER_BG = '#e3f2fd';
 
 interface TemplateListPanelProps {
+    workflowId: string | number;
     ttData: TTStatusResponse;
     hoveredTemplateName: string | null;
+    hasResourceErrors: boolean;
     onTemplateSelect: (name: string) => void;
     onTemplateHover: (name: string | null) => void;
     onPrefetch: (tt: {
+        id: string | number;
         task_template_version_id: string | number;
         name: string;
     }) => void;
 }
 
+/** Single failing template card with lazy error-type breakdown. */
+function FailingTemplateCard({
+    workflowId,
+    tt,
+    isHovered,
+    onSelect,
+    onHover,
+    onPrefetch,
+}: {
+    workflowId: string | number;
+    tt: TTStatus;
+    isHovered: boolean;
+    onSelect: () => void;
+    onHover: (name: string | null) => void;
+    onPrefetch: () => void;
+}) {
+    const { data: breakdown } = useQuery({
+        queryKey: [
+            'workflow_details',
+            'fatal_breakdown',
+            workflowId,
+            tt.task_template_version_id,
+        ],
+        queryFn: getFatalErrorBreakdownFn,
+        enabled: tt.FATAL > 0,
+        staleTime: 120000,
+    });
+
+    return (
+        <Box
+            onClick={onSelect}
+            onMouseEnter={() => {
+                onHover(tt.name);
+                onPrefetch();
+            }}
+            onMouseLeave={() => onHover(null)}
+            sx={{
+                p: 1,
+                borderRadius: 1,
+                border: '1px solid',
+                borderColor: 'divider',
+                cursor: 'pointer',
+                backgroundColor: isHovered ? HOVER_BG : undefined,
+                transition: 'background-color 0.15s ease',
+                '&:hover': { backgroundColor: HOVER_BG },
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                }}
+            >
+                <Typography
+                    variant="body2"
+                    sx={{
+                        fontWeight: 500,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        flex: 1,
+                        mr: 1,
+                    }}
+                >
+                    {tt.name}
+                </Typography>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        gap: 0.5,
+                        flexShrink: 0,
+                    }}
+                >
+                    {breakdown && breakdown.resource > 0 && (
+                        <Chip
+                            label={`${breakdown.resource} resource`}
+                            size="small"
+                            icon={
+                                <MemoryIcon
+                                    sx={{
+                                        fontSize: 12,
+                                        color: '#fff !important',
+                                    }}
+                                />
+                            }
+                            sx={{
+                                height: 20,
+                                fontSize: '0.65rem',
+                                fontWeight: 'bold',
+                                backgroundColor: RESOURCE_ERROR_COLORS.main,
+                                color: '#fff',
+                            }}
+                        />
+                    )}
+                    <Chip
+                        label={`${tt.FATAL} fatal`}
+                        size="small"
+                        sx={{
+                            height: 20,
+                            fontSize: '0.7rem',
+                            fontWeight: 'bold',
+                            backgroundColor:
+                                TEMPLATE_STATUS_COLORS.FATAL,
+                            color: '#fff',
+                        }}
+                    />
+                </Box>
+            </Box>
+        </Box>
+    );
+}
+
 export default function TemplateListPanel({
+    workflowId,
     ttData,
     hoveredTemplateName,
+    hasResourceErrors,
     onTemplateSelect,
     onTemplateHover,
     onPrefetch,
@@ -63,6 +187,31 @@ export default function TemplateListPanel({
                             }}
                         />
                     </Box>
+
+                    {/* Resource error callout */}
+                    {hasResourceErrors && (
+                        <Alert
+                            severity="warning"
+                            icon={
+                                <MemoryIcon fontSize="small" />
+                            }
+                            sx={{
+                                mb: 1,
+                                py: 0,
+                                '& .MuiAlert-message': {
+                                    py: 0.75,
+                                },
+                            }}
+                        >
+                            <Typography variant="caption">
+                                Resource errors detected in this
+                                workflow — check templates marked
+                                with resource chips below
+                            </Typography>
+                        </Alert>
+                    )}
+
+                    {/* Failing template cards */}
                     <Box
                         sx={{
                             display: 'flex',
@@ -71,66 +220,19 @@ export default function TemplateListPanel({
                         }}
                     >
                         {failingTemplates.map(tt => (
-                            <Box
+                            <FailingTemplateCard
                                 key={tt.id}
-                                onClick={() =>
+                                workflowId={workflowId}
+                                tt={tt}
+                                isHovered={
+                                    hoveredTemplateName === tt.name
+                                }
+                                onSelect={() =>
                                     onTemplateSelect(tt.name)
                                 }
-                                onMouseEnter={() => {
-                                    onTemplateHover(tt.name);
-                                    onPrefetch(tt);
-                                }}
-                                onMouseLeave={() =>
-                                    onTemplateHover(null)
-                                }
-                                sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    p: 1,
-                                    borderRadius: 1,
-                                    border: '1px solid',
-                                    borderColor: 'divider',
-                                    cursor: 'pointer',
-                                    backgroundColor:
-                                        hoveredTemplateName ===
-                                        tt.name
-                                            ? HOVER_BG
-                                            : undefined,
-                                    transition:
-                                        'background-color 0.15s ease',
-                                    '&:hover': {
-                                        backgroundColor: HOVER_BG,
-                                    },
-                                }}
-                            >
-                                <Typography
-                                    variant="body2"
-                                    sx={{
-                                        fontWeight: 500,
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        whiteSpace: 'nowrap',
-                                        flex: 1,
-                                        mr: 1,
-                                    }}
-                                >
-                                    {tt.name}
-                                </Typography>
-                                <Chip
-                                    label={`${tt.FATAL} fatal`}
-                                    size="small"
-                                    sx={{
-                                        height: 20,
-                                        fontSize: '0.7rem',
-                                        fontWeight: 'bold',
-                                        backgroundColor:
-                                            TEMPLATE_STATUS_COLORS.FATAL,
-                                        color: '#fff',
-                                        flexShrink: 0,
-                                    }}
-                                />
-                            </Box>
+                                onHover={onTemplateHover}
+                                onPrefetch={() => onPrefetch(tt)}
+                            />
                         ))}
                     </Box>
                 </Box>

--- a/jobmon_gui/src/components/workflow_details/TemplateTimelineTab.tsx
+++ b/jobmon_gui/src/components/workflow_details/TemplateTimelineTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useCallback } from 'react';
-import Plotly from 'plotly.js-dist';
+import Plotly from 'plotly.js-cartesian-dist';
 import createPlotlyComponent from 'react-plotly.js/factory';
 
 const Plot = createPlotlyComponent(Plotly);

--- a/jobmon_gui/src/components/workflow_details/WorkflowDAG.tsx
+++ b/jobmon_gui/src/components/workflow_details/WorkflowDAG.tsx
@@ -19,6 +19,7 @@ import ReactFlow, {
     useReactFlow,
     ReactFlowProvider,
 } from 'reactflow';
+import 'reactflow/dist/style.css';
 import dagre from 'dagre';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';

--- a/jobmon_gui/src/configs/ApiUrls.ts
+++ b/jobmon_gui/src/configs/ApiUrls.ts
@@ -44,6 +44,10 @@ export const get_task_template_details_url = (
     `/get_task_template_details?workflow_id=${workflowId}&task_template_id=${taskTemplateId}`;
 
 export const update_task_status_url = api_base_url + `/task/update_statuses`;
+export const workflow_has_resource_errors_url =
+    api_base_url + '/workflow_has_resource_errors/';
+export const fatal_error_breakdown_url =
+    api_base_url + '/fatal_error_breakdown/';
 export const get_task_template_id_url = (
     task_template_version_id: number | string
 ) => api_base_url + `/task_template/id/${task_template_version_id}`;

--- a/jobmon_gui/src/constants/taskStatus.ts
+++ b/jobmon_gui/src/constants/taskStatus.ts
@@ -30,7 +30,7 @@ export interface TaskStatusMeta {
 // Updated to reflect specific backend statuses and user preference for symbols
 // Using JobmonProgressBar colors from CSS variables for consistency
 export const taskStatusMeta: Record<string, TaskStatusMeta> = {
-    G: { label: 'Registered', symbol: 'diamond', color: '#e69f00' }, // --color-pending
+    G: { label: 'Registered', symbol: 'diamond', color: '#999999' }, // gray — distinguishable from Done for colorblind users
     Q: { label: 'Queued', symbol: 'diamond', color: '#e69f00' }, // --color-pending
     I: { label: 'Instantiated', symbol: 'diamond', color: '#e69f00' }, // --color-pending
     O: { label: 'Scheduled', symbol: 'square', color: '#f0e442' }, // --color-scheduled
@@ -44,6 +44,15 @@ export const taskStatusMeta: Record<string, TaskStatusMeta> = {
     E: { label: 'Error', symbol: 'x', color: '#d55e00' }, // Use fatal color for general errors
     UNKNOWN: { label: 'Unknown Status', symbol: 'asterisk', color: '#757575' }, // Gray fallback
 };
+
+// Resource error UI colors (distinct from FATAL to differentiate resource vs app errors)
+export const RESOURCE_ERROR_COLORS = {
+    main: '#e65100',
+    fatal: '#cc3311',
+    retried: '#2e7d32',
+    retriedBg: '#e8f5e9',
+    bannerBg: '#fff3e0',
+} as const;
 
 // Status codes that represent error/failure states
 export const ERROR_STATUSES = ['E', 'F', 'A', 'Z', 'X', 'U'] as const;

--- a/jobmon_gui/src/index.tsx
+++ b/jobmon_gui/src/index.tsx
@@ -1,19 +1,39 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HashRouter, Route } from 'react-router-dom';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
 import PageNavigation from '@jobmon_gui/components/navigation/PageNavigation';
 import CustomThemeProvider from '@jobmon_gui/contexts/CustomThemeProvider';
-import Help from '@jobmon_gui/screens/Help';
-import JobmonAtIHME from '@jobmon_gui/screens/JobmonAtIhme';
-import TaskDetails from '@jobmon_gui/screens/TaskDetails';
-import TaskTemplateDetails from '@jobmon_gui/screens/TaskTemplateDetails';
-import WorkflowDetails from '@jobmon_gui/screens/WorkflowDetails';
-import WorkflowOverview from '@jobmon_gui/screens/WorkflowOverview';
 import '@fontsource-variable/roboto-mono';
 import '@fontsource/archivo';
 import { ApmRoutes } from '@elastic/apm-rum-react';
 import { AuthProvider } from '@jobmon_gui/contexts/AuthContext.tsx';
+
+const Help = lazy(() => import('@jobmon_gui/screens/Help'));
+const JobmonAtIHME = lazy(() => import('@jobmon_gui/screens/JobmonAtIhme'));
+const TaskDetails = lazy(() => import('@jobmon_gui/screens/TaskDetails'));
+const TaskTemplateDetails = lazy(
+    () => import('@jobmon_gui/screens/TaskTemplateDetails')
+);
+const WorkflowDetails = lazy(
+    () => import('@jobmon_gui/screens/WorkflowDetails')
+);
+const WorkflowOverview = lazy(
+    () => import('@jobmon_gui/screens/WorkflowOverview')
+);
+
+const PageLoader = () => (
+    <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="60vh"
+    >
+        <CircularProgress />
+    </Box>
+);
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -34,6 +54,7 @@ root.render(
             <CustomThemeProvider>
                 <AuthProvider>
                     <PageNavigation>
+                        <Suspense fallback={<PageLoader />}>
                         <ApmRoutes>
                             <Route
                                 path="workflow/:workflowId"
@@ -62,6 +83,7 @@ root.render(
                                 }
                             />
                         </ApmRoutes>
+                        </Suspense>
                     </PageNavigation>
                 </AuthProvider>
             </CustomThemeProvider>

--- a/jobmon_gui/src/queries/GetFatalErrorBreakdown.ts
+++ b/jobmon_gui/src/queries/GetFatalErrorBreakdown.ts
@@ -7,6 +7,7 @@ export interface FatalErrorBreakdown {
     app: number;
     infra: number;
     resource_error_total: number;
+    resource_error_retried: number;
     resource_error_ti_ids: number[];
 }
 

--- a/jobmon_gui/src/queries/GetFatalErrorBreakdown.ts
+++ b/jobmon_gui/src/queries/GetFatalErrorBreakdown.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { fatal_error_breakdown_url } from '@jobmon_gui/configs/ApiUrls.ts';
+import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
+
+export interface FatalErrorBreakdown {
+    resource: number;
+    app: number;
+    infra: number;
+    resource_error_total: number;
+    resource_error_ti_ids: number[];
+}
+
+type QueryFnArgs = {
+    queryKey: readonly unknown[];
+};
+
+export const getFatalErrorBreakdownFn = async ({
+    queryKey,
+}: QueryFnArgs): Promise<FatalErrorBreakdown> => {
+    const workflowId = queryKey[2];
+    const ttVersionId = queryKey[3];
+    return axios
+        .get<FatalErrorBreakdown>(
+            `${fatal_error_breakdown_url}${workflowId}/${ttVersionId}`,
+            { ...jobmonAxiosConfig, data: null }
+        )
+        .then(r => r.data);
+};

--- a/jobmon_gui/src/queries/GetWorkflowHasResourceErrors.ts
+++ b/jobmon_gui/src/queries/GetWorkflowHasResourceErrors.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { workflow_has_resource_errors_url } from '@jobmon_gui/configs/ApiUrls.ts';
+import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
+
+type QueryFnArgs = {
+    queryKey: (string | number | undefined)[];
+};
+
+export interface WorkflowResourceErrorCheck {
+    has_resource_errors: boolean;
+}
+
+export const getWorkflowHasResourceErrorsFn = async ({
+    queryKey,
+}: QueryFnArgs) => {
+    if (!queryKey || queryKey.length !== 3) {
+        return { has_resource_errors: false };
+    }
+    const workflowId = queryKey[2];
+    return axios
+        .get<WorkflowResourceErrorCheck>(
+            workflow_has_resource_errors_url + workflowId,
+            { ...jobmonAxiosConfig, data: null }
+        )
+        .then(r => r.data);
+};

--- a/jobmon_gui/src/screens/WorkflowDetails.tsx
+++ b/jobmon_gui/src/screens/WorkflowDetails.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, {
+    useState,
+    useEffect,
+    useCallback,
+    useMemo,
+    Suspense,
+    lazy,
+} from 'react';
 import '@jobmon_gui/styles/jobmon_gui.css';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import WorkflowHeader from '@jobmon_gui/components/workflow_details/WorkflowHeader';
@@ -25,18 +32,42 @@ import { getWorkflowTTStatusQueryFn } from '@jobmon_gui/queries/GetWorkflowTTSta
 import { getWorkflowDetailsQueryFn } from '@jobmon_gui/queries/GetWorkflowDetails.ts';
 import { getWorkflowUsageQueryFn } from '@jobmon_gui/queries/GetWorkflowUsage.ts';
 import { getClusteredErrorsFn } from '@jobmon_gui/queries/GetClusteredErrors.ts';
+import { getWorkflowHasResourceErrorsFn } from '@jobmon_gui/queries/GetWorkflowHasResourceErrors.ts';
 import {
     AppBreadcrumbs,
     BreadcrumbItem,
 } from '@jobmon_gui/components/common/AppBreadcrumbs';
 import WorkflowDAG from '@jobmon_gui/components/workflow_details/WorkflowDAG.tsx';
-import TaskConcurrencyTab from '@jobmon_gui/components/workflow_details/TaskConcurrencyTab.tsx';
-import TemplateTimelineTab from '@jobmon_gui/components/workflow_details/TemplateTimelineTab.tsx';
 import TemplateDetailPanel from '@jobmon_gui/components/workflow_details/TemplateDetailPanel.tsx';
 import WorkflowSummaryBar from '@jobmon_gui/components/workflow_details/WorkflowSummaryBar.tsx';
 import TemplateListPanel from '@jobmon_gui/components/workflow_details/TemplateListPanel.tsx';
 import WorkflowManagePanel from '@jobmon_gui/components/workflow_details/WorkflowManagePanel.tsx';
 import ResizableSplitPane from '@jobmon_gui/components/common/ResizableSplitPane.tsx';
+
+const TaskConcurrencyTab = lazy(
+    () =>
+        import('@jobmon_gui/components/workflow_details/TaskConcurrencyTab.tsx')
+);
+const TemplateTimelineTab = lazy(
+    () =>
+        import(
+            '@jobmon_gui/components/workflow_details/TemplateTimelineTab.tsx'
+        )
+);
+
+const ChartLoader = () => (
+    <Box
+        sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+            minHeight: 200,
+        }}
+    >
+        <CircularProgress size={28} />
+    </Box>
+);
 import { getWorkflowFiltersForNavigation } from '@jobmon_gui/utils/workflowFilterPersistence';
 import { TTStatus } from '@jobmon_gui/types/TaskTemplateStatus';
 import { compare } from 'compare-versions';
@@ -97,6 +128,12 @@ function WorkflowDetails() {
         queryFn: getWorkflowTTStatusQueryFn,
         refetchOnMount: true,
         refetchOnWindowFocus: true,
+    });
+
+    const hasResourceErrorsQuery = useQuery({
+        queryKey: ['workflow_details', 'has_resource_errors', workflowId],
+        queryFn: getWorkflowHasResourceErrorsFn,
+        staleTime: 120000,
     });
 
     const ttStatusByName = useMemo(() => {
@@ -175,6 +212,7 @@ function WorkflowDetails() {
     };
 
     const prefetchTemplateData = (taskTemplate: {
+        id: string | number;
         task_template_version_id: string | number;
         name: string;
     }) => {
@@ -192,7 +230,7 @@ function WorkflowDetails() {
                 'workflow_details',
                 'clustered_errors',
                 workflowId,
-                taskTemplate.task_template_version_id,
+                taskTemplate.id,
             ],
             queryFn: getClusteredErrorsFn,
         });
@@ -232,8 +270,12 @@ function WorkflowDetails() {
         />
     ) : (
         <TemplateListPanel
+            workflowId={workflowId!}
             ttData={wfTTStatus.data}
             hoveredTemplateName={hoveredTemplateName}
+            hasResourceErrors={
+                hasResourceErrorsQuery.data?.has_resource_errors ?? false
+            }
             onTemplateSelect={handleTemplateSelect}
             onTemplateHover={setHoveredTemplateName}
             onPrefetch={prefetchTemplateData}
@@ -494,26 +536,28 @@ function WorkflowDetails() {
                             </Tooltip>
                         </Box>
                         <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-                            {bottomPanelView === 'concurrency' ? (
-                                <TaskConcurrencyTab
-                                    workflowId={workflowId}
-                                    highlightedTemplates={
-                                        selectedTemplateName
-                                            ? [selectedTemplateName]
-                                            : undefined
-                                    }
-                                />
-                            ) : (
-                                <TemplateTimelineTab
-                                    workflowId={workflowId}
-                                    highlightedTemplates={
-                                        selectedTemplateName
-                                            ? [selectedTemplateName]
-                                            : undefined
-                                    }
-                                    onTemplateClick={handleTemplateSelect}
-                                />
-                            )}
+                            <Suspense fallback={<ChartLoader />}>
+                                {bottomPanelView === 'concurrency' ? (
+                                    <TaskConcurrencyTab
+                                        workflowId={workflowId}
+                                        highlightedTemplates={
+                                            selectedTemplateName
+                                                ? [selectedTemplateName]
+                                                : undefined
+                                        }
+                                    />
+                                ) : (
+                                    <TemplateTimelineTab
+                                        workflowId={workflowId}
+                                        highlightedTemplates={
+                                            selectedTemplateName
+                                                ? [selectedTemplateName]
+                                                : undefined
+                                        }
+                                        onTemplateClick={handleTemplateSelect}
+                                    />
+                                )}
+                            </Suspense>
                         </Box>
                     </Box>
                 }
@@ -571,7 +615,7 @@ function WorkflowDetails() {
                             {fullscreenPanel === 'dag' && dagContent}
                             {fullscreenPanel === 'left' && leftPanel}
                             {fullscreenPanel === 'bottom' && (
-                                <>
+                                <Suspense fallback={<ChartLoader />}>
                                     {bottomPanelView === 'concurrency' ? (
                                         <TaskConcurrencyTab
                                             workflowId={workflowId}
@@ -594,7 +638,7 @@ function WorkflowDetails() {
                                             }
                                         />
                                     )}
-                                </>
+                                </Suspense>
                             )}
                         </Box>
                     </Box>

--- a/jobmon_gui/src/styles/jobmon_gui.css
+++ b/jobmon_gui/src/styles/jobmon_gui.css
@@ -395,28 +395,24 @@ h-1rem {
 }
 
 /* Color blindness palettes: https://davidmathlogic.com/colorblind/#%23D81B60-%231E88E5-%23FFC107-%23004D40 */
-/* Change pending progress bar to Bang Wong palette for color blindness */
-.pending-progress-bar {
+/* Higher specificity (.progress-bar.X) to override Bootstrap defaults */
+.progress-bar.pending-progress-bar {
     background-color: var(--color-pending);
 }
 
-/* Change scheduled progress bar to Bang Wong palette for color blindness */
-.scheduled-progress-bar {
+.progress-bar.scheduled-progress-bar {
     background-color: var(--color-scheduled);
 }
 
-/* Change running progress bar to Bang Wong palette for color blindness */
-.running-progress-bar {
+.progress-bar.running-progress-bar {
     background-color: var(--color-running);
 }
 
-/* Change done progress bar to Bang Wong palette for color blindness */
-.done-progress-bar {
+.progress-bar.done-progress-bar {
     background-color: var(--color-done);
 }
 
-/* Change fatal progress bar to Bang Wong palette for color blindness */
-.fatal-progress-bar {
+.progress-bar.fatal-progress-bar {
     background-color: var(--color-fatal);
 }
 

--- a/jobmon_gui/src/types/ClusteredErrors.ts
+++ b/jobmon_gui/src/types/ClusteredErrors.ts
@@ -31,9 +31,3 @@ export type ClusteredErrorList = {
     page: number;
     page_size: number;
 };
-
-export interface ErrorDetails {
-    data?: {
-        error_logs?: ErrorLog[];
-    };
-}

--- a/jobmon_gui/src/vite-env.d.ts
+++ b/jobmon_gui/src/vite-env.d.ts
@@ -1,2 +1,7 @@
 /// <reference types="vite/client" />
 declare const APP_VERSION: string;
+
+declare module 'plotly.js-cartesian-dist' {
+    import Plotly from 'plotly.js';
+    export default Plotly;
+}

--- a/jobmon_gui/vite.config.ts
+++ b/jobmon_gui/vite.config.ts
@@ -14,6 +14,28 @@ export default defineConfig({
     define: {
         APP_VERSION: JSON.stringify(process.env.npm_package_version),
     },
+    build: {
+        rollupOptions: {
+            output: {
+                manualChunks: {
+                    plotly: ['plotly.js-cartesian-dist'],
+                    mui: [
+                        '@mui/material',
+                        '@mui/icons-material',
+                        '@emotion/react',
+                        '@emotion/styled',
+                    ],
+                    reactflow: ['reactflow', 'dagre'],
+                    vendor: [
+                        'react',
+                        'react-dom',
+                        'react-router-dom',
+                        '@tanstack/react-query',
+                    ],
+                },
+            },
+        },
+    },
     resolve: {
         alias: {
             '@jobmon_gui': path.resolve(__dirname, './src'),

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -22,6 +22,7 @@ from jobmon.server.web.models.task_instance import TaskInstance
 from jobmon.server.web.models.task_instance_error_log import TaskInstanceErrorLog
 from jobmon.server.web.models.task_instance_status import TaskInstanceStatus
 from jobmon.server.web.models.task_resources import TaskResources
+from jobmon.server.web.models.task_status import TaskStatus
 from jobmon.server.web.models.task_template import TaskTemplate
 from jobmon.server.web.models.task_template_version import TaskTemplateVersion
 from jobmon.server.web.models.workflow_run import WorkflowRun
@@ -847,6 +848,90 @@ class TaskTemplateRepository:
 
         return result_dict
 
+    def get_fatal_error_breakdown_for_tt(
+        self,
+        workflow_id: int,
+        task_template_version_id: int,
+    ) -> Dict[str, Any]:
+        """Classify fatal tasks for one template by last TI status.
+
+        Scoped to workflow + template for fast indexed lookup.
+        Returns {resource: N, app: N, infra: N}.
+        """
+        latest_ti_id_subq = (
+            select(
+                TaskInstance.task_id,
+                func.max(TaskInstance.id).label("max_ti_id"),
+            )
+            .join(Task, TaskInstance.task_id == Task.id)
+            .join(Node, Task.node_id == Node.id)
+            .where(
+                Task.workflow_id == workflow_id,
+                Task.status == TaskStatus.ERROR_FATAL,
+                Node.task_template_version_id == task_template_version_id,
+            )
+            .group_by(TaskInstance.task_id)
+            .subquery()
+        )
+
+        sql = (
+            select(
+                TaskInstance.status.label("ti_status"),
+                func.count(TaskInstance.id).label("cnt"),
+            )
+            .join(
+                latest_ti_id_subq,
+                TaskInstance.id == latest_ti_id_subq.c.max_ti_id,
+            )
+            .group_by(TaskInstance.status)
+        )
+
+        result: Dict[str, Any] = {
+            "resource": 0,
+            "app": 0,
+            "infra": 0,
+            "resource_error_total": 0,
+        }
+        for row in self.session.execute(sql).all():
+            if row.ti_status == TaskInstanceStatus.RESOURCE_ERROR:
+                result["resource"] += row.cnt
+            elif row.ti_status == TaskInstanceStatus.ERROR:
+                result["app"] += row.cnt
+            else:
+                result["infra"] += row.cnt
+
+        z_count_sql = (
+            select(func.count(TaskInstance.id))
+            .join(Task, TaskInstance.task_id == Task.id)
+            .join(Node, Task.node_id == Node.id)
+            .where(
+                Task.workflow_id == workflow_id,
+                Node.task_template_version_id == task_template_version_id,
+                TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
+            )
+        )
+        result["resource_error_total"] = self.session.execute(z_count_sql).scalar() or 0
+
+        # Sample of Z-status TI IDs for drill-down UI
+        if result["resource_error_total"] > 0:
+            z_ids_sql = (
+                select(TaskInstance.id)
+                .join(Task, TaskInstance.task_id == Task.id)
+                .join(Node, Task.node_id == Node.id)
+                .where(
+                    Task.workflow_id == workflow_id,
+                    Node.task_template_version_id == task_template_version_id,
+                    TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
+                )
+                .order_by(TaskInstance.id.desc())
+                .limit(20)
+            )
+            result["resource_error_ti_ids"] = [
+                row[0] for row in self.session.execute(z_ids_sql).all()
+            ]
+
+        return result
+
     def get_tt_error_log_viz(
         self,
         workflow_id: int,
@@ -902,17 +987,61 @@ class TaskTemplateRepository:
                     TaskInstance,
                     TaskInstanceErrorLog.task_instance_id == TaskInstance.id,
                 )
-                .join_from(TaskInstance, Task, TaskInstance.task_id == Task.id)
+                .join_from(
+                    TaskInstance,
+                    Task,
+                    TaskInstance.task_id == Task.id,
+                )
                 .where(TaskInstance.id == task_instance_id)
             )
             rows = self.session.execute(sql).all()
+
+            # Fallback: no error log entries but TI exists —
+            # return stderr_log directly from the task instance.
             if len(rows) == 0:
+                fallback_sql = (
+                    select(
+                        TaskInstance.task_id,
+                        TaskInstance.id,
+                        TaskInstance.stderr_log,
+                        TaskInstance.stderr,
+                        TaskInstance.workflow_run_id,
+                        Task.workflow_id,
+                    )
+                    .join(
+                        Task,
+                        TaskInstance.task_id == Task.id,
+                    )
+                    .where(TaskInstance.id == task_instance_id)
+                )
+                fb_row = self.session.execute(fallback_sql).one_or_none()
+                if fb_row is None:
+                    return ErrorLogResponse(
+                        error_logs=[],
+                        total_count=0,
+                        page=page,
+                        page_size=page_size,
+                    )
+                stderr_text = fb_row.stderr_log or fb_row.stderr
+                error_logs.append(
+                    ErrorLogItem(
+                        task_id=fb_row.task_id,
+                        task_instance_id=task_instance_id,
+                        task_instance_err_id=None,
+                        error_time=None,
+                        error=stderr_text,
+                        task_instance_stderr_log=stderr_text,
+                        workflow_run_id=(fb_row.workflow_run_id),
+                        workflow_id=fb_row.workflow_id,
+                    )
+                )
                 return ErrorLogResponse(
-                    error_logs=[],
-                    total_count=0,
+                    error_logs=error_logs,
+                    total_count=1,
                     page=page,
                     page_size=page_size,
                 )
+
             total_count = len(rows)
 
             # Slice rows according to the requested page and page_size
@@ -1219,6 +1348,142 @@ class TaskTemplateRepository:
             )
 
             rows = self.session.execute(query).all()
+
+            # Fallback: no TaskInstanceErrorLog entries — read
+            # stderr directly from task instances for failed tasks.
+            if not rows:
+                fallback_query = (
+                    select(
+                        TaskInstance.id.label("task_instance_id"),
+                        TaskInstance.task_id,
+                        TaskInstance.stderr_log,
+                        TaskInstance.stderr,
+                        TaskInstance.status_date,
+                        TaskInstance.workflow_run_id,
+                    )
+                    .join(
+                        Task,
+                        TaskInstance.task_id == Task.id,
+                    )
+                    .join(Node, Task.node_id == Node.id)
+                    .where(
+                        Task.workflow_id == workflow_id,
+                        Node.task_template_version_id == ttv_id,
+                        Task.status == "F",
+                    )
+                    .order_by(TaskInstance.id.desc())
+                    .limit(1000)
+                )
+                fb_rows = self.session.execute(fallback_query).all()
+
+                if not fb_rows:
+                    return ErrorLogResponse(
+                        error_logs=[],
+                        total_count=0,
+                        page=page,
+                        page_size=page_size,
+                    )
+
+                if cluster_errors:
+                    df = pd.DataFrame(
+                        [
+                            {
+                                "task_instance_err_id": r.task_instance_id,
+                                "task_instance_id": r.task_instance_id,
+                                "error_time": r.status_date,
+                                "error": (
+                                    str(r.stderr_log or r.stderr)
+                                    if (r.stderr_log or r.stderr)
+                                    else None
+                                ),
+                                "task_instance_stderr_log": (
+                                    str(r.stderr_log or r.stderr)
+                                    if (r.stderr_log or r.stderr)
+                                    else None
+                                ),
+                                "workflow_run_id": r.workflow_run_id,
+                                "workflow_id": workflow_id,
+                                "task_id": r.task_id,
+                            }
+                            for r in fb_rows
+                        ]
+                    )
+
+                    clustered = cluster_error_logs(df)
+                    total_clusters = len(clustered)
+                    if total_clusters == 0:
+                        return ErrorLogResponse(
+                            error_logs=[],
+                            total_count=0,
+                            page=page,
+                            page_size=page_size,
+                        )
+
+                    paged_clusters = clustered.iloc[offset : offset + page_size]
+                    for _, crow in paged_clusters.iterrows():
+                        error_logs.append(
+                            ErrorLogItem(
+                                task_id=None,
+                                task_instance_id=None,
+                                task_instance_err_id=None,
+                                error_time=None,
+                                error=None,
+                                task_instance_stderr_log=None,
+                                workflow_run_id=int(crow["workflow_run_id"]),
+                                workflow_id=int(crow["workflow_id"]),
+                                error_score=float(crow["error_score"]),
+                                group_instance_count=int(crow["group_instance_count"]),
+                                task_instance_ids=list(
+                                    map(
+                                        int,
+                                        crow["task_instance_ids"],
+                                    )
+                                ),
+                                task_ids=list(
+                                    map(
+                                        int,
+                                        crow["task_ids"],
+                                    )
+                                ),
+                                sample_error=(
+                                    str(crow["sample_error"])
+                                    if crow["sample_error"] is not None
+                                    else None
+                                ),
+                                first_error_time=crow["first_error_time"],
+                            )
+                        )
+
+                    return ErrorLogResponse(
+                        error_logs=error_logs,
+                        total_count=total_clusters,
+                        page=page,
+                        page_size=page_size,
+                    )
+
+                # Non-clustered fallback
+                total_count = len(fb_rows)
+                paged = fb_rows[offset : offset + page_size]
+                for r in paged:
+                    stderr_text = str(r.stderr_log or r.stderr or "")
+                    error_logs.append(
+                        ErrorLogItem(
+                            task_id=r.task_id,
+                            task_instance_id=r.task_instance_id,
+                            task_instance_err_id=None,
+                            error_time=r.status_date,
+                            error=stderr_text,
+                            task_instance_stderr_log=stderr_text,
+                            workflow_run_id=r.workflow_run_id,
+                            workflow_id=workflow_id,
+                        )
+                    )
+                return ErrorLogResponse(
+                    error_logs=error_logs,
+                    total_count=total_count,
+                    page=page,
+                    page_size=page_size,
+                )
 
             if cluster_errors and rows:
                 df = pd.DataFrame(

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -909,6 +909,21 @@ class TaskTemplateRepository:
         )
         resource_error_total = self.session.execute(z_count_sql).scalar() or 0
 
+        # Count tasks that had a resource error TI but recovered
+        # (task is not in ERROR_FATAL state).
+        retried_sql = (
+            select(func.count(func.distinct(Task.id)))
+            .join(TaskInstance, TaskInstance.task_id == Task.id)
+            .join(Node, Task.node_id == Node.id)
+            .where(
+                Task.workflow_id == workflow_id,
+                Node.task_template_version_id == task_template_version_id,
+                TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
+                Task.status != TaskStatus.ERROR_FATAL,
+            )
+        )
+        resource_error_retried = self.session.execute(retried_sql).scalar() or 0
+
         resource_error_ti_ids: List[int] = []
         if resource_error_total > 0:
             z_ids_sql = (
@@ -932,6 +947,7 @@ class TaskTemplateRepository:
             app=app,
             infra=infra,
             resource_error_total=resource_error_total,
+            resource_error_retried=resource_error_retried,
             resource_error_ti_ids=resource_error_ti_ids,
         )
 

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -30,6 +30,7 @@ from jobmon.server.web.schemas.task_template import (
     CoreInfoItem,
     ErrorLogItem,
     ErrorLogResponse,
+    FatalErrorBreakdownResponse,
     MostPopularQueueResponse,
     QueueInfoItem,
     RequestedCoresResponse,
@@ -852,11 +853,10 @@ class TaskTemplateRepository:
         self,
         workflow_id: int,
         task_template_version_id: int,
-    ) -> Dict[str, Any]:
+    ) -> FatalErrorBreakdownResponse:
         """Classify fatal tasks for one template by last TI status.
 
         Scoped to workflow + template for fast indexed lookup.
-        Returns {resource: N, app: N, infra: N}.
         """
         latest_ti_id_subq = (
             select(
@@ -886,19 +886,16 @@ class TaskTemplateRepository:
             .group_by(TaskInstance.status)
         )
 
-        result: Dict[str, Any] = {
-            "resource": 0,
-            "app": 0,
-            "infra": 0,
-            "resource_error_total": 0,
-        }
+        resource = 0
+        app = 0
+        infra = 0
         for row in self.session.execute(sql).all():
             if row.ti_status == TaskInstanceStatus.RESOURCE_ERROR:
-                result["resource"] += row.cnt
+                resource += row.cnt
             elif row.ti_status == TaskInstanceStatus.ERROR:
-                result["app"] += row.cnt
+                app += row.cnt
             else:
-                result["infra"] += row.cnt
+                infra += row.cnt
 
         z_count_sql = (
             select(func.count(TaskInstance.id))
@@ -910,10 +907,10 @@ class TaskTemplateRepository:
                 TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
             )
         )
-        result["resource_error_total"] = self.session.execute(z_count_sql).scalar() or 0
+        resource_error_total = self.session.execute(z_count_sql).scalar() or 0
 
-        # Sample of Z-status TI IDs for drill-down UI
-        if result["resource_error_total"] > 0:
+        resource_error_ti_ids: List[int] = []
+        if resource_error_total > 0:
             z_ids_sql = (
                 select(TaskInstance.id)
                 .join(Task, TaskInstance.task_id == Task.id)
@@ -926,11 +923,17 @@ class TaskTemplateRepository:
                 .order_by(TaskInstance.id.desc())
                 .limit(20)
             )
-            result["resource_error_ti_ids"] = [
+            resource_error_ti_ids = [
                 row[0] for row in self.session.execute(z_ids_sql).all()
             ]
 
-        return result
+        return FatalErrorBreakdownResponse(
+            resource=resource,
+            app=app,
+            infra=infra,
+            resource_error_total=resource_error_total,
+            resource_error_ti_ids=resource_error_ti_ids,
+        )
 
     def get_tt_error_log_viz(
         self,

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
@@ -5,18 +5,24 @@ from typing import Any, Optional
 
 import structlog
 from fastapi import Depends, HTTPException, Query
+from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
 
 from jobmon.server.web.db import get_db, get_dialect
+from jobmon.server.web.models.task import Task
+from jobmon.server.web.models.task_instance import TaskInstance
+from jobmon.server.web.models.task_instance_status import TaskInstanceStatus
 from jobmon.server.web.repositories.task_template_repository import (
     TaskTemplateRepository,
 )
 from jobmon.server.web.routes.v3.cli import cli_router as api_v3_router
 from jobmon.server.web.schemas.task_template import (
+    FatalErrorBreakdownResponse,
     TaskResourceVizItem,
     TaskTemplateResourceUsageRequest,
     TaskTemplateResourceUsageResponse,
+    WorkflowResourceErrorCheckResponse,
 )
 
 # new structlog logger per flask request context. internally stored as flask.g.logger
@@ -193,6 +199,45 @@ def get_workflow_tt_status_viz(
     }
 
     return JSONResponse(content=result_dict_serializable, status_code=StatusCodes.OK)
+
+
+@api_v3_router.get("/workflow_has_resource_errors/{workflow_id}")
+def get_workflow_has_resource_errors(
+    workflow_id: int,
+    db: Session = Depends(get_db),
+) -> WorkflowResourceErrorCheckResponse:
+    """Check if any task instances in this workflow have resource errors."""
+    has_z = db.execute(
+        select(
+            exists(
+                select(TaskInstance.id)
+                .join(Task, TaskInstance.task_id == Task.id)
+                .where(
+                    Task.workflow_id == workflow_id,
+                    TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
+                )
+            )
+        )
+    ).scalar()
+
+    return WorkflowResourceErrorCheckResponse(
+        has_resource_errors=bool(has_z),
+    )
+
+
+@api_v3_router.get("/fatal_error_breakdown/{workflow_id}/{tt_version_id}")
+def get_fatal_error_breakdown(
+    workflow_id: int,
+    tt_version_id: int,
+    db: Session = Depends(get_db),
+) -> FatalErrorBreakdownResponse:
+    """Classify fatal errors for one template by type."""
+    tt_repo = TaskTemplateRepository(db)
+    breakdown = tt_repo.get_fatal_error_breakdown_for_tt(
+        workflow_id=workflow_id,
+        task_template_version_id=tt_version_id,
+    )
+    return FatalErrorBreakdownResponse(**breakdown)
 
 
 @api_v3_router.get("/tt_error_log_viz/{wf_id}/{tt_id}")

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
@@ -233,11 +233,10 @@ def get_fatal_error_breakdown(
 ) -> FatalErrorBreakdownResponse:
     """Classify fatal errors for one template by type."""
     tt_repo = TaskTemplateRepository(db)
-    breakdown = tt_repo.get_fatal_error_breakdown_for_tt(
+    return tt_repo.get_fatal_error_breakdown_for_tt(
         workflow_id=workflow_id,
         task_template_version_id=tt_version_id,
     )
-    return FatalErrorBreakdownResponse(**breakdown)
 
 
 @api_v3_router.get("/tt_error_log_viz/{wf_id}/{tt_id}")

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -177,6 +177,22 @@ class WorkflowTaskTemplateStatusItem(BaseModel):
     task_template_version_id: int
 
 
+class FatalErrorBreakdownResponse(BaseModel):
+    """Breakdown of fatal errors by type for a single template."""
+
+    resource: int = 0
+    app: int = 0
+    infra: int = 0
+    resource_error_total: int = 0
+    resource_error_ti_ids: List[int] = []
+
+
+class WorkflowResourceErrorCheckResponse(BaseModel):
+    """Response for checking if a workflow has any resource errors."""
+
+    has_resource_errors: bool
+
+
 class ErrorLogItem(BaseModel):
     """Error log item - can represent individual errors or clustered errors."""
 

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -184,6 +184,7 @@ class FatalErrorBreakdownResponse(BaseModel):
     app: int = 0
     infra: int = 0
     resource_error_total: int = 0
+    resource_error_retried: int = 0
     resource_error_ti_ids: List[int] = []
 
 

--- a/tests/integration/cli/test_cli_routes.py
+++ b/tests/integration/cli/test_cli_routes.py
@@ -1735,3 +1735,122 @@ def test_increase_resources_selective_update(client_env, db_engine, tool):
 
         assert task1_final_resources == {"memory": 2, "runtime": 120}  # Still unchanged
         assert task3_final_resources == {"memory": 3, "runtime": 180}  # Still unchanged
+
+
+def test_workflow_has_resource_errors(client_env, db_engine):
+    """Test the workflow_has_resource_errors endpoint."""
+    t = Tool(name="gui_resource_errors_test")
+    wf = t.create_workflow(name="test_resource_errors_wf")
+    tt = t.get_task_template(
+        template_name="tt_res",
+        command_template="echo {arg}",
+        node_args=["arg"],
+    )
+    task = tt.create_task(
+        arg=1,
+        cluster_name="sequential",
+        compute_resources={"queue": "null.q", "num_cores": 1},
+    )
+    wf.add_tasks([task])
+    wf.bind()
+    wf._bind_tasks()
+
+    # No resource errors yet
+    app_route = f"/workflow_has_resource_errors/{wf.workflow_id}"
+    return_code, msg = wf.requester.send_request(
+        app_route=app_route, message={}, request_type="get"
+    )
+    assert return_code == 200
+    assert msg["has_resource_errors"] is False
+
+    # Create a task instance with resource error status
+    with Session(bind=db_engine) as session:
+        session.execute(
+            text(
+                f"""
+                INSERT INTO task_instance
+                    (workflow_run_id, task_id, status, status_date)
+                SELECT wr.id, {task.task_id}, 'Z', datetime('now')
+                FROM workflow_run wr
+                WHERE wr.workflow_id = {wf.workflow_id}
+                LIMIT 1
+                """
+            )
+        )
+        session.commit()
+
+    return_code, msg = wf.requester.send_request(
+        app_route=app_route, message={}, request_type="get"
+    )
+    assert return_code == 200
+    assert msg["has_resource_errors"] is True
+
+
+def test_fatal_error_breakdown(client_env, db_engine):
+    """Test the fatal_error_breakdown endpoint classifies errors correctly."""
+    t = Tool(name="gui_fatal_breakdown_test")
+    wf = t.create_workflow(name="test_fatal_breakdown_wf")
+    tt = t.get_task_template(
+        template_name="tt_breakdown",
+        command_template="echo {arg}",
+        node_args=["arg"],
+    )
+    t1 = tt.create_task(
+        arg=1,
+        cluster_name="sequential",
+        compute_resources={"queue": "null.q", "num_cores": 1},
+    )
+    t2 = tt.create_task(
+        arg=2,
+        cluster_name="sequential",
+        compute_resources={"queue": "null.q", "num_cores": 1},
+    )
+    t3 = tt.create_task(
+        arg=3,
+        cluster_name="sequential",
+        compute_resources={"queue": "null.q", "num_cores": 1},
+    )
+    wf.add_tasks([t1, t2, t3])
+    wf.bind()
+    wf._bind_tasks()
+
+    # Set all tasks to fatal
+    with Session(bind=db_engine) as session:
+        for task in [t1, t2, t3]:
+            session.execute(text(f"UPDATE task SET status='F' WHERE id={task.task_id}"))
+        session.commit()
+
+    # Create TIs: t1 -> resource error (Z), t2 -> app error (E),
+    # t3 -> unknown error (U)
+    with Session(bind=db_engine) as session:
+        for task, ti_status in [
+            (t1, "Z"),
+            (t2, "E"),
+            (t3, "U"),
+        ]:
+            session.execute(
+                text(
+                    f"""
+                    INSERT INTO task_instance
+                        (workflow_run_id, task_id, status,
+                         status_date)
+                    SELECT wr.id, {task.task_id}, '{ti_status}',
+                           datetime('now')
+                    FROM workflow_run wr
+                    WHERE wr.workflow_id = {wf.workflow_id}
+                    LIMIT 1
+                    """
+                )
+            )
+        session.commit()
+
+    ttv_id = tt._active_task_template_version.id
+    app_route = f"/fatal_error_breakdown/{wf.workflow_id}/{ttv_id}"
+    return_code, msg = wf.requester.send_request(
+        app_route=app_route, message={}, request_type="get"
+    )
+    assert return_code == 200
+    assert msg["resource"] == 1
+    assert msg["app"] == 1
+    assert msg["infra"] == 1
+    assert msg["resource_error_total"] >= 1

--- a/tests/integration/cli/test_cli_routes.py
+++ b/tests/integration/cli/test_cli_routes.py
@@ -1737,6 +1737,50 @@ def test_increase_resources_selective_update(client_env, db_engine, tool):
         assert task3_final_resources == {"memory": 3, "runtime": 180}  # Still unchanged
 
 
+def _ensure_workflow_run(session, workflow_id):
+    """Ensure a workflow_run exists, creating one if needed. Return its id."""
+    wfr_id = session.execute(
+        text(
+            "SELECT id FROM workflow_run " f"WHERE workflow_id = {workflow_id} LIMIT 1"
+        )
+    ).scalar()
+    if wfr_id is None:
+        session.execute(
+            text(
+                "INSERT INTO workflow_run "
+                "(workflow_id, status, status_date) "
+                f"VALUES ({workflow_id}, 'O', datetime('now'))"
+            )
+        )
+        session.flush()
+        wfr_id = session.execute(
+            text(
+                "SELECT id FROM workflow_run "
+                f"WHERE workflow_id = {workflow_id} LIMIT 1"
+            )
+        ).scalar()
+    return wfr_id
+
+
+def _create_task_instance(session, workflow_id, task_id, status):
+    """Insert a task instance with the minimum required fields."""
+    wfr_id = _ensure_workflow_run(session, workflow_id)
+    row = session.execute(
+        text("SELECT task_resources_id, array_id FROM task " f"WHERE id = {task_id}")
+    ).one()
+    session.execute(
+        text(
+            "INSERT INTO task_instance "
+            "(workflow_run_id, task_id, task_resources_id, "
+            "array_id, array_batch_num, array_step_id, "
+            "status, status_date) "
+            f"VALUES ({wfr_id}, {task_id}, {row[0]}, "
+            f"{row[1]}, 0, 0, "
+            f"'{status}', datetime('now'))"
+        )
+    )
+
+
 def test_workflow_has_resource_errors(client_env, db_engine):
     """Test the workflow_has_resource_errors endpoint."""
     t = Tool(name="gui_resource_errors_test")
@@ -1765,18 +1809,7 @@ def test_workflow_has_resource_errors(client_env, db_engine):
 
     # Create a task instance with resource error status
     with Session(bind=db_engine) as session:
-        session.execute(
-            text(
-                f"""
-                INSERT INTO task_instance
-                    (workflow_run_id, task_id, status, status_date)
-                SELECT wr.id, {task.task_id}, 'Z', datetime('now')
-                FROM workflow_run wr
-                WHERE wr.workflow_id = {wf.workflow_id}
-                LIMIT 1
-                """
-            )
-        )
+        _create_task_instance(session, wf.workflow_id, task.task_id, "Z")
         session.commit()
 
     return_code, msg = wf.requester.send_request(
@@ -1828,19 +1861,11 @@ def test_fatal_error_breakdown(client_env, db_engine):
             (t2, "E"),
             (t3, "U"),
         ]:
-            session.execute(
-                text(
-                    f"""
-                    INSERT INTO task_instance
-                        (workflow_run_id, task_id, status,
-                         status_date)
-                    SELECT wr.id, {task.task_id}, '{ti_status}',
-                           datetime('now')
-                    FROM workflow_run wr
-                    WHERE wr.workflow_id = {wf.workflow_id}
-                    LIMIT 1
-                    """
-                )
+            _create_task_instance(
+                session,
+                wf.workflow_id,
+                task.task_id,
+                ti_status,
             )
         session.commit()
 


### PR DESCRIPTION
## Summary
- **Bundle size reduced from 7.1 MB → ~3.2 MB**: Switched `plotly.js-dist` to `plotly.js-cartesian-dist`, added route-level lazy loading (`React.lazy`), vendor chunking (plotly, MUI, reactflow), and lighter syntax highlighter (Prism → hljs Light with python/r/bash only)
- **Lazy chart tabs**: Workflow details Gantt/Status tabs lazy-load plotly via `Suspense`, so the page shell (DAG, template list, header) renders without waiting for the 1.4 MB chart library
- **CSS fixes from code splitting**: Added missing `reactflow/dist/style.css` import to `WorkflowDAG.tsx`; increased progress bar selector specificity to override Bootstrap regardless of chunk load order
- **Accessibility**: Changed Registered (`G`) status color from orange to gray (`#999999`) so colorblind users can distinguish it from Done (green)
- **Resource error UI**: New endpoints (`/workflow_has_resource_errors`, `/fatal_error_breakdown`), error log fallback for resource-killed tasks, resource error banners in task timeline
- **Copy buttons**: Added to task command displays in TaskDAG, TaskSummaryCard, and ErrorClustersCard
- **Type safety**: Fatal error breakdown returns Pydantic model directly instead of `Dict[str, Any]`

## Test plan
- [ ] Verify workflow details page loads quickly (DAG and template list appear before charts)
- [ ] Verify Gantt and Status chart tabs render correctly after clicking
- [ ] Verify progress bar colors show correct status breakdown (not all blue)
- [ ] Verify ReactFlow DAG renders on workflow details page
- [ ] Verify Registered tasks appear gray (not orange) on Gantt chart
- [ ] Run `uv run pytest -n 10` for backend integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new server endpoints and query logic for error classification/log fallback, plus significant GUI refactors for lazy loading and new resource-error UX; moderate risk of regressions in workflow details rendering and error/log display.
> 
> **Overview**
> **Improves workflow troubleshooting UX and front-end performance.** The GUI now code-splits routes and chart tabs with `React.lazy`/`Suspense`, swaps to `plotly.js-cartesian-dist`, and configures Vite `manualChunks` to shrink and better cache vendor bundles; also fixes code-splitting fallout by importing `reactflow` CSS in `WorkflowDAG` and increasing progress-bar CSS specificity.
> 
> **Adds resource-error diagnostics across server + UI.** Introduces `/workflow_has_resource_errors` and `/fatal_error_breakdown` endpoints (with new Pydantic schemas and integration tests) and updates the workflow template list/detail panels to highlight resource-related failures and allow drill-down into sample resource-error task instances via a new `ResourceCard` drawer.
> 
> **Makes error/output inspection more robust and usable.** Error-log queries now fall back to task-instance `stderr_log`/`stderr` when no `TaskInstanceErrorLog` rows exist, the task status timeline groups attempts starting at `A` and shows a resource-error banner/empty-stderr messaging, and task command views gain a reusable `CopyButton`; `ErrorClustersCard` also switches to a lighter `react-syntax-highlighter` setup with limited languages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52f5cfc0cb2a16d7e0b5e52293bd82120440a3a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->