### PR TITLE
Add task filters, workflow run scoping, and error/resource UX improvements

### DIFF
--- a/jobmon_gui/src/components/task_details/ResourceComparisonBar.tsx
+++ b/jobmon_gui/src/components/task_details/ResourceComparisonBar.tsx
@@ -11,7 +11,7 @@ type ResourceComparisonBarProps = {
     utilizedDisplay: string;
 };
 
-function getBarColor(percent: number): string {
+export function getBarColor(percent: number): string {
     if (percent > 95) return '#d32f2f';
     if (percent >= 80) return '#ed6c02';
     return '#2e7d32';

--- a/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
+++ b/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
@@ -7,6 +7,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Collapse from '@mui/material/Collapse';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
+import LinearProgress from '@mui/material/LinearProgress';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import humanizeDuration from 'humanize-duration';
@@ -24,8 +25,8 @@ import { components } from '@jobmon_gui/types/apiSchema';
 import { TaskInstance } from '@jobmon_gui/types/TaskInstance';
 import { formatBytes, bytes_to_gib } from '@jobmon_gui/utils/formatters';
 import { parseResourceJson } from '@jobmon_gui/utils/csvExport';
-import ResourceComparisonBar from './ResourceComparisonBar';
 import { JobmonModal } from '@jobmon_gui/components/JobmonModal';
+import { getBarColor } from './ResourceComparisonBar';
 import { ScrollableCodeBlock } from '@jobmon_gui/components/ScrollableTextArea';
 
 type AuditRecord = components['schemas']['TaskStatusAuditRecord'];
@@ -235,29 +236,65 @@ function AttemptDetailPanel({
         : null;
 
     // Metadata chips
-    const metaChips: { label: string; value: string }[] = [];
+    const metaRows: { label: string; value: string }[] = [];
+    if (instance.ti_workflow_run_id) {
+        metaRows.push({
+            label: 'WF Run',
+            value: String(instance.ti_workflow_run_id),
+        });
+    }
     if (instance.ti_distributor_id) {
-        metaChips.push({
+        metaRows.push({
             label: 'Job ID',
             value: String(instance.ti_distributor_id),
         });
     }
     if (instance.ti_nodename) {
-        metaChips.push({
+        metaRows.push({
             label: 'Node',
             value: instance.ti_nodename,
         });
     }
-    metaChips.push({
+    metaRows.push({
         label: 'Queue',
         value: instance.ti_queue_name || 'N/A',
     });
     if (instance.ti_cpu) {
-        metaChips.push({ label: 'CPU', value: instance.ti_cpu });
+        metaRows.push({ label: 'CPU', value: instance.ti_cpu });
     }
     if (instance.ti_io) {
-        metaChips.push({ label: 'I/O', value: instance.ti_io });
+        metaRows.push({ label: 'I/O', value: instance.ti_io });
     }
+    // Resource utilization (rendered as inline bars, not text rows)
+    const memoryPercent =
+        utilizedMemoryGiB != null &&
+        requestedMemoryGiB != null &&
+        requestedMemoryGiB > 0
+            ? Math.min(
+                  (utilizedMemoryGiB / requestedMemoryGiB) * 100,
+                  100
+              )
+            : null;
+    const runtimePercent =
+        utilizedRuntimeSec != null &&
+        requestedRuntimeSec != null &&
+        requestedRuntimeSec > 0
+            ? Math.min(
+                  (utilizedRuntimeSec / requestedRuntimeSec) * 100,
+                  100
+              )
+            : null;
+    const memoryText =
+        memoryDisplay && memoryDisplay !== 'N/A'
+            ? requestedMemoryGiB != null
+                ? `${memoryDisplay} / ${requestedMemoryGiB} GiB`
+                : memoryDisplay
+            : 'N/A';
+    const runtimeText = runtimeDisplay
+        ? requestedRuntimeSec != null
+            ? `${runtimeDisplay} / ${humanizeDuration(requestedRuntimeSec * 1000, { largest: 2, round: true })}`
+            : runtimeDisplay
+        : 'N/A';
 
     const isResourceError = instance.ti_status === 'RESOURCE_ERROR';
     const runtimeExceeded =
@@ -272,17 +309,19 @@ function AttemptDetailPanel({
         utilizedMemoryGiB / requestedMemoryGiB >= 0.95;
 
     return (
-        <Box sx={{ px: 2, py: 1 }}>
+        <Box sx={{ px: 2, py: 1.5 }}>
             {/* Resource error banner */}
             {isResourceError && (
                 <Box
                     sx={{
-                        backgroundColor: RESOURCE_ERROR_COLORS.bannerBg,
+                        backgroundColor:
+                            RESOURCE_ERROR_COLORS.bannerBg,
                         border: `1px solid ${RESOURCE_ERROR_COLORS.main}`,
+                        borderLeft: `3px solid ${RESOURCE_ERROR_COLORS.main}`,
                         borderRadius: 1,
                         px: 1.5,
                         py: 0.75,
-                        mb: 1,
+                        mb: 1.5,
                     }}
                 >
                     <Typography
@@ -316,116 +355,169 @@ function AttemptDetailPanel({
                 </Box>
             )}
 
-            {/* Metadata row */}
+            {/* Metadata key-value grid */}
             <Box
                 sx={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: 0.5,
+                    display: 'grid',
+                    gridTemplateColumns:
+                        'max-content 1fr',
+                    gap: '2px 12px',
+                    alignContent: 'start',
                     mb: 1,
-                    alignItems: 'baseline',
                 }}
             >
-                {metaChips.map(chip => (
-                    <Typography
-                        key={chip.label}
-                        variant="body2"
-                        sx={{ mr: 1.5, whiteSpace: 'nowrap' }}
-                    >
-                        <strong>{chip.label}:</strong> {chip.value}
-                    </Typography>
+                {metaRows.map(row => (
+                    <React.Fragment key={row.label}>
+                        <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            fontWeight={600}
+                        >
+                            {row.label}
+                        </Typography>
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                fontFamily:
+                                    'Roboto Mono Variable',
+                            }}
+                        >
+                            {row.value}
+                        </Typography>
+                    </React.Fragment>
                 ))}
             </Box>
 
-            {/* Resource bars */}
+            {/* Resource inline bars */}
             <Box
                 sx={{
-                    display: 'flex',
-                    gap: 3,
-                    mb: 1,
-                    flexWrap: 'wrap',
+                    display: 'grid',
+                    gridTemplateColumns:
+                        'max-content 1fr max-content',
+                    gap: '6px 10px',
+                    alignItems: 'center',
+                    mb: 1.5,
+                    maxWidth: 500,
                 }}
             >
-                <Box sx={{ flex: '1 1 200px', maxWidth: 350 }}>
-                    <ResourceComparisonBar
-                        label="Memory"
-                        requested={requestedMemoryGiB}
-                        utilized={utilizedMemoryGiB}
-                        requestedDisplay={
-                            requestedMemoryGiB != null
-                                ? `${requestedMemoryGiB} GiB`
-                                : 'N/A'
-                        }
-                        utilizedDisplay={memoryDisplay}
-                    />
-                </Box>
-                <Box sx={{ flex: '1 1 200px', maxWidth: 350 }}>
-                    <ResourceComparisonBar
-                        label="Runtime"
-                        requested={requestedRuntimeSec}
-                        utilized={utilizedRuntimeSec}
-                        requestedDisplay={
-                            requestedRuntimeSec != null
-                                ? humanizeDuration(requestedRuntimeSec * 1000, {
-                                      largest: 2,
-                                      round: true,
-                                  })
-                                : 'N/A'
-                        }
-                        utilizedDisplay={runtimeDisplay ?? 'N/A'}
-                    />
-                </Box>
-            </Box>
-
-            {/* Stderr preview */}
-            {stderrPreview && (
-                <Box sx={{ mb: 0.5 }}>
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 1,
-                            mb: 0.25,
-                        }}
-                    >
-                        <Typography variant="caption" fontWeight={700}>
-                            STDERR
+                {[
+                    { label: 'Memory', percent: memoryPercent, text: memoryText },
+                    { label: 'Runtime', percent: runtimePercent, text: runtimeText },
+                ].map(bar => (
+                    <React.Fragment key={bar.label}>
+                        <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            fontWeight={600}
+                        >
+                            {bar.label}
                         </Typography>
-                        <Button
-                            size="small"
-                            variant="outlined"
-                            onClick={onViewStderr}
+                        <LinearProgress
+                            variant="determinate"
+                            value={bar.percent ?? 0}
                             sx={{
-                                py: 0,
-                                px: 0.75,
-                                fontSize: '0.7rem',
-                                minHeight: 0,
-                                lineHeight: 1.5,
+                                height: 8,
+                                borderRadius: 4,
+                                bgcolor: 'grey.200',
+                                '& .MuiLinearProgress-bar': {
+                                    borderRadius: 4,
+                                    bgcolor:
+                                        bar.percent != null
+                                            ? getBarColor(bar.percent)
+                                            : 'grey.400',
+                                },
+                            }}
+                        />
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                fontFamily: 'Roboto Mono Variable',
+                                whiteSpace: 'nowrap',
                             }}
                         >
-                            View Full Log
-                        </Button>
-                    </Box>
+                            {bar.text}
+                        </Typography>
+                    </React.Fragment>
+                ))}
+            </Box>
+
+            {/* Divider */}
+            <Box
+                sx={{
+                    borderTop: '1px solid',
+                    borderColor: 'grey.200',
+                    mb: 1.5,
+                }}
+            />
+
+            {/* Stderr */}
+            <Box sx={{ mb: 1.5 }}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        mb: 0.5,
+                    }}
+                >
+                    <Typography
+                        variant="caption"
+                        fontWeight={700}
+                        sx={{
+                            textTransform: 'uppercase',
+                            letterSpacing: 0.5,
+                        }}
+                    >
+                        Stderr
+                    </Typography>
+                    <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={onViewStderr}
+                        sx={{
+                            py: 0,
+                            px: 0.75,
+                            fontSize: '0.7rem',
+                            minHeight: 0,
+                            lineHeight: 1.5,
+                        }}
+                    >
+                        View Full Log
+                    </Button>
+                </Box>
+                {stderrPreview ? (
                     <Box
                         sx={{
                             fontFamily: 'Roboto Mono Variable',
-                            fontSize: '0.75rem',
-                            backgroundColor: '#eee',
-                            px: 1,
-                            py: 0.5,
-                            borderRadius: 0.5,
-                            maxHeight: '80px',
+                            fontSize: '0.7rem',
+                            backgroundColor: '#f5f5f5',
+                            border: '1px solid',
+                            borderColor: 'grey.300',
+                            px: 1.5,
+                            py: 1,
+                            borderRadius: 1,
+                            maxHeight: 150,
                             overflow: 'auto',
                             whiteSpace: 'pre-wrap',
                             wordBreak: 'break-word',
+                            lineHeight: 1.6,
                         }}
                     >
                         {stderrPreview}
                     </Box>
-                </Box>
-            )}
+                ) : (
+                    <Typography
+                        variant="caption"
+                        color="text.secondary"
+                    >
+                        {isResourceError
+                            ? 'Killed by cluster (no stderr captured)'
+                            : 'No output'}
+                    </Typography>
+                )}
+            </Box>
 
-            {/* Stdout + stderr links */}
+            {/* Stdout */}
             <Box
                 sx={{
                     display: 'flex',
@@ -434,15 +526,29 @@ function AttemptDetailPanel({
                 }}
             >
                 <Typography
-                    variant="body2"
+                    variant="caption"
+                    fontWeight={700}
+                    sx={{
+                        textTransform: 'uppercase',
+                        letterSpacing: 0.5,
+                        flexShrink: 0,
+                    }}
+                >
+                    Stdout
+                </Typography>
+                <Typography
+                    variant="caption"
                     color="text.secondary"
                     sx={{
+                        fontFamily: 'Roboto Mono Variable',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
+                        flex: 1,
+                        minWidth: 0,
                     }}
                 >
-                    <strong>Stdout:</strong> {instance.ti_stdout || '/dev/null'}
+                    {instance.ti_stdout || '/dev/null'}
                 </Typography>
                 <Button
                     size="small"
@@ -459,35 +565,6 @@ function AttemptDetailPanel({
                 >
                     View Full Log
                 </Button>
-                {!stderrPreview && (
-                    <>
-                        <Typography
-                            variant="body2"
-                            color="text.secondary"
-                            sx={{ ml: 1 }}
-                        >
-                            <strong>Stderr:</strong>{' '}
-                            {isResourceError
-                                ? 'killed by cluster (no stderr captured)'
-                                : 'no output'}
-                        </Typography>
-                        <Button
-                            size="small"
-                            variant="outlined"
-                            onClick={onViewStderr}
-                            sx={{
-                                py: 0,
-                                px: 0.75,
-                                fontSize: '0.7rem',
-                                minHeight: 0,
-                                lineHeight: 1.5,
-                                flexShrink: 0,
-                            }}
-                        >
-                            View Full Log
-                        </Button>
-                    </>
-                )}
             </Box>
         </Box>
     );
@@ -931,19 +1008,16 @@ export default function TaskStatusTimeline({
         [attempts, tiQuery.data]
     );
 
-    // Auto-expand the latest failed attempt on first load
+    // Auto-expand the latest failed attempt, but only if the task
+    // is still in an error state (don't expand old failures for
+    // tasks that have since succeeded on a later attempt/resume).
     useEffect(() => {
         if (autoExpanded || attempts.length === 0) return;
-        for (let i = attempts.length - 1; i >= 0; i--) {
-            if (
-                (ERROR_STATUSES as readonly string[]).includes(
-                    attempts[i].outcome
-                )
-            ) {
-                setExpandedAttempt(i);
-                setAutoExpanded(true);
-                return;
-            }
+        const lastOutcome = attempts[attempts.length - 1].outcome;
+        if (
+            (ERROR_STATUSES as readonly string[]).includes(lastOutcome)
+        ) {
+            setExpandedAttempt(attempts.length - 1);
         }
         setAutoExpanded(true);
     }, [attempts, autoExpanded]);

--- a/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
+++ b/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -18,6 +18,7 @@ import {
     getStatusTextColor,
     taskStatusMeta,
     RESOURCE_ERROR_COLORS,
+    ERROR_STATUSES,
 } from '@jobmon_gui/constants/taskStatus';
 import { components } from '@jobmon_gui/types/apiSchema';
 import { TaskInstance } from '@jobmon_gui/types/TaskInstance';
@@ -81,11 +82,11 @@ function buildSegment(record: AuditRecord): Segment {
             ? 0
             : !hasValidEnteredMs
               ? 0
-            : active
-              ? Date.now() - enteredMs
-              : hasValidExitedMs
-                ? exitedMs - enteredMs
-                : 0;
+              : active
+                ? Date.now() - enteredMs
+                : hasValidExitedMs
+                  ? exitedMs - enteredMs
+                  : 0;
     const durationText = isTerminal
         ? ''
         : active
@@ -120,8 +121,7 @@ function groupIntoAttempts(records: AuditRecord[]): Attempt[] {
         // or A (Adjusting Resources — resource error retry),
         // except for the very first record which always starts attempt 1.
         const isNewAttempt =
-            (seg.status === 'G' || seg.status === 'A') &&
-            current.length > 0;
+            (seg.status === 'G' || seg.status === 'A') && current.length > 0;
         if (isNewAttempt) {
             attempts.push(finalizeAttempt(current));
             current = [];
@@ -185,7 +185,10 @@ function mapAttemptsToInstances(
     const sortedInstances = sortTaskInstancesById(instances);
     const mapped = attempts.map(() => null as TaskInstance | null);
     const attemptOffset = Math.max(0, attempts.length - sortedInstances.length);
-    const instanceOffset = Math.max(0, sortedInstances.length - attempts.length);
+    const instanceOffset = Math.max(
+        0,
+        sortedInstances.length - attempts.length
+    );
     const overlap = Math.min(attempts.length, sortedInstances.length);
 
     for (let i = 0; i < overlap; i += 1) {
@@ -228,11 +231,7 @@ function AttemptDetailPanel({
             : null;
 
     const stderrPreview = instance.ti_stderr_log
-        ? instance.ti_stderr_log
-              .trim()
-              .split('\n')
-              .slice(-10)
-              .join('\n')
+        ? instance.ti_stderr_log.trim().split('\n').slice(-10).join('\n')
         : null;
 
     // Metadata chips
@@ -260,8 +259,7 @@ function AttemptDetailPanel({
         metaChips.push({ label: 'I/O', value: instance.ti_io });
     }
 
-    const isResourceError =
-        instance.ti_status === 'RESOURCE_ERROR';
+    const isResourceError = instance.ti_status === 'RESOURCE_ERROR';
     const runtimeExceeded =
         utilizedRuntimeSec != null &&
         requestedRuntimeSec != null &&
@@ -368,10 +366,10 @@ function AttemptDetailPanel({
                         utilized={utilizedRuntimeSec}
                         requestedDisplay={
                             requestedRuntimeSec != null
-                                ? humanizeDuration(
-                                      requestedRuntimeSec * 1000,
-                                      { largest: 2, round: true }
-                                  )
+                                ? humanizeDuration(requestedRuntimeSec * 1000, {
+                                      largest: 2,
+                                      round: true,
+                                  })
                                 : 'N/A'
                         }
                         utilizedDisplay={runtimeDisplay ?? 'N/A'}
@@ -390,10 +388,7 @@ function AttemptDetailPanel({
                             mb: 0.25,
                         }}
                     >
-                        <Typography
-                            variant="caption"
-                            fontWeight={700}
-                        >
+                        <Typography variant="caption" fontWeight={700}>
                             STDERR
                         </Typography>
                         <Button
@@ -447,8 +442,7 @@ function AttemptDetailPanel({
                         whiteSpace: 'nowrap',
                     }}
                 >
-                    <strong>Stdout:</strong>{' '}
-                    {instance.ti_stdout || '/dev/null'}
+                    <strong>Stdout:</strong> {instance.ti_stdout || '/dev/null'}
                 </Typography>
                 <Button
                     size="small"
@@ -593,15 +587,12 @@ function AttemptRow({
                                     <br />
                                     Duration: {seg.durationText}
                                     <br />
-                                    Entered:{' '}
-                                    {formatTimestamp(seg.enteredAt)}
+                                    Entered: {formatTimestamp(seg.enteredAt)}
                                     {seg.exitedAt && (
                                         <>
                                             <br />
                                             Exited:{' '}
-                                            {formatTimestamp(
-                                                seg.exitedAt
-                                            )}
+                                            {formatTimestamp(seg.exitedAt)}
                                         </>
                                     )}
                                 </span>
@@ -620,15 +611,12 @@ function AttemptRow({
                                     overflow: 'hidden',
                                     whiteSpace: 'nowrap',
                                     borderRight:
-                                        segIdx <
-                                        attempt.segments.length - 1
+                                        segIdx < attempt.segments.length - 1
                                             ? '1px solid rgba(255,255,255,0.3)'
                                             : 'none',
                                 }}
                             >
-                                {widths[segIdx] > 12
-                                    ? seg.label
-                                    : ''}
+                                {widths[segIdx] > 12 ? seg.label : ''}
                             </Box>
                         </Tooltip>
                     ))}
@@ -647,16 +635,11 @@ function AttemptRow({
                             width: 8,
                             height: 8,
                             borderRadius: '50%',
-                            backgroundColor: outcomeColor(
-                                attempt.outcome
-                            ),
+                            backgroundColor: outcomeColor(attempt.outcome),
                             flexShrink: 0,
                         }}
                     />
-                    <Typography
-                        variant="caption"
-                        sx={{ fontWeight: 500 }}
-                    >
+                    <Typography variant="caption" sx={{ fontWeight: 500 }}>
                         {outcomeLabel(attempt.outcome)}
                     </Typography>
                 </Box>
@@ -669,9 +652,7 @@ function AttemptRow({
                         textAlign: 'right',
                     }}
                 >
-                    {attempt.totalMs > 0
-                        ? formatMs(attempt.totalMs)
-                        : ''}
+                    {attempt.totalMs > 0 ? formatMs(attempt.totalMs) : ''}
                 </Typography>
             </Box>
             <Collapse in={expanded}>
@@ -696,10 +677,7 @@ function AttemptRow({
                             onViewStderr={onViewStderr}
                         />
                     ) : (
-                        <Typography
-                            variant="caption"
-                            color="text.secondary"
-                        >
+                        <Typography variant="caption" color="text.secondary">
                             No instance data available.
                         </Typography>
                     )}
@@ -726,10 +704,7 @@ function FallbackInstanceList({
 
     return (
         <Box sx={{ py: 1 }}>
-            <Typography
-                variant="subtitle2"
-                sx={{ mb: 1, fontWeight: 600 }}
-            >
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
                 Task Instances
             </Typography>
             <Box
@@ -751,9 +726,7 @@ function FallbackInstanceList({
                         <Box key={inst.ti_id}>
                             <Box
                                 onClick={() =>
-                                    setExpandedIdx(
-                                        expanded ? -1 : idx
-                                    )
+                                    setExpandedIdx(expanded ? -1 : idx)
                                 }
                                 sx={{
                                     display: 'flex',
@@ -763,8 +736,7 @@ function FallbackInstanceList({
                                     borderRadius: '4px',
                                     px: 0.5,
                                     '&:hover': {
-                                        backgroundColor:
-                                            'action.hover',
+                                        backgroundColor: 'action.hover',
                                     },
                                 }}
                             >
@@ -805,8 +777,7 @@ function FallbackInstanceList({
                                             width: 8,
                                             height: 8,
                                             borderRadius: '50%',
-                                            backgroundColor:
-                                                statusColor,
+                                            backgroundColor: statusColor,
                                             flexShrink: 0,
                                         }}
                                     />
@@ -854,20 +825,13 @@ function FallbackInstanceList({
             {/* Stdout modal */}
             <JobmonModal
                 title="Standard Out"
-                open={
-                    modalState.type === 'stdout' &&
-                    !!modalInstance
-                }
-                onClose={() =>
-                    setModalState({ type: null, instance: null })
-                }
+                open={modalState.type === 'stdout' && !!modalInstance}
+                onClose={() => setModalState({ type: null, instance: null })}
                 width="80%"
             >
                 <Grid container spacing={2}>
                     <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Out Path:
-                        </Typography>
+                        <Typography variant="h6">Standard Out Path:</Typography>
                     </Grid>
                     <Grid item xs={12}>
                         <ScrollableCodeBlock>
@@ -875,15 +839,11 @@ function FallbackInstanceList({
                         </ScrollableCodeBlock>
                     </Grid>
                     <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Out Log:
-                        </Typography>
+                        <Typography variant="h6">Standard Out Log:</Typography>
                     </Grid>
                     <Grid item xs={12}>
                         <ScrollableCodeBlock>
-                            <pre>
-                                {modalInstance?.ti_stdout_log}
-                            </pre>
+                            <pre>{modalInstance?.ti_stdout_log}</pre>
                         </ScrollableCodeBlock>
                     </Grid>
                 </Grid>
@@ -892,13 +852,8 @@ function FallbackInstanceList({
             {/* Stderr modal */}
             <JobmonModal
                 title="Standard Error"
-                open={
-                    modalState.type === 'stderr' &&
-                    !!modalInstance
-                }
-                onClose={() =>
-                    setModalState({ type: null, instance: null })
-                }
+                open={modalState.type === 'stderr' && !!modalInstance}
+                onClose={() => setModalState({ type: null, instance: null })}
                 width="80%"
             >
                 <Grid container spacing={2}>
@@ -919,9 +874,7 @@ function FallbackInstanceList({
                     </Grid>
                     <Grid item xs={12}>
                         <ScrollableCodeBlock>
-                            <pre>
-                                {modalInstance?.ti_stderr_log}
-                            </pre>
+                            <pre>{modalInstance?.ti_stderr_log}</pre>
                         </ScrollableCodeBlock>
                     </Grid>
                     <Grid item xs={12}>
@@ -931,9 +884,7 @@ function FallbackInstanceList({
                     </Grid>
                     <Grid item xs={12}>
                         <ScrollableCodeBlock>
-                            {
-                                modalInstance?.ti_error_log_description
-                            }
+                            {modalInstance?.ti_error_log_description}
                         </ScrollableCodeBlock>
                     </Grid>
                 </Grid>
@@ -961,6 +912,8 @@ export default function TaskStatusTimeline({
     });
 
     const [expandedAttempt, setExpandedAttempt] = useState<number>(-1);
+    // Track whether we've auto-expanded once (don't override user interaction)
+    const [autoExpanded, setAutoExpanded] = useState(false);
     const [modalState, setModalState] = useState<ModalState>({
         type: null,
         instance: null,
@@ -978,11 +931,27 @@ export default function TaskStatusTimeline({
         [attempts, tiQuery.data]
     );
 
+    // Auto-expand the latest failed attempt on first load
+    useEffect(() => {
+        if (autoExpanded || attempts.length === 0) return;
+        for (let i = attempts.length - 1; i >= 0; i--) {
+            if (
+                (ERROR_STATUSES as readonly string[]).includes(
+                    attempts[i].outcome
+                )
+            ) {
+                setExpandedAttempt(i);
+                setAutoExpanded(true);
+                return;
+            }
+        }
+        setAutoExpanded(true);
+    }, [attempts, autoExpanded]);
+
     // Collect unique statuses across all attempts for the legend
     const legendItems = useMemo(() => {
         const seen = new Set<string>();
-        const items: { code: string; label: string; color: string }[] =
-            [];
+        const items: { code: string; label: string; color: string }[] = [];
         for (const attempt of attempts) {
             for (const seg of attempt.segments) {
                 const code = seg.status.toUpperCase();
@@ -1046,10 +1015,7 @@ export default function TaskStatusTimeline({
 
     return (
         <Box sx={{ py: 1 }}>
-            <Typography
-                variant="subtitle2"
-                sx={{ mb: 1, fontWeight: 600 }}
-            >
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
                 Status Timeline
             </Typography>
             <Box
@@ -1071,9 +1037,7 @@ export default function TaskStatusTimeline({
                             expanded={expandedAttempt === idx}
                             onToggle={() =>
                                 setExpandedAttempt(
-                                    expandedAttempt === idx
-                                        ? -1
-                                        : idx
+                                    expandedAttempt === idx ? -1 : idx
                                 )
                             }
                             onViewStdout={() =>
@@ -1119,10 +1083,7 @@ export default function TaskStatusTimeline({
                                 flexShrink: 0,
                             }}
                         />
-                        <Typography
-                            variant="caption"
-                            color="text.secondary"
-                        >
+                        <Typography variant="caption" color="text.secondary">
                             {item.label}
                         </Typography>
                     </Box>
@@ -1133,16 +1094,12 @@ export default function TaskStatusTimeline({
             <JobmonModal
                 title="Standard Out"
                 open={modalState.type === 'stdout' && !!modalInstance}
-                onClose={() =>
-                    setModalState({ type: null, instance: null })
-                }
+                onClose={() => setModalState({ type: null, instance: null })}
                 width="80%"
             >
                 <Grid container spacing={2}>
                     <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Out Path:
-                        </Typography>
+                        <Typography variant="h6">Standard Out Path:</Typography>
                     </Grid>
                     <Grid item xs={12}>
                         <ScrollableCodeBlock>
@@ -1150,9 +1107,7 @@ export default function TaskStatusTimeline({
                         </ScrollableCodeBlock>
                     </Grid>
                     <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Out Log:
-                        </Typography>
+                        <Typography variant="h6">Standard Out Log:</Typography>
                     </Grid>
                     <Grid item xs={12}>
                         <ScrollableCodeBlock>
@@ -1166,9 +1121,7 @@ export default function TaskStatusTimeline({
             <JobmonModal
                 title="Standard Error"
                 open={modalState.type === 'stderr' && !!modalInstance}
-                onClose={() =>
-                    setModalState({ type: null, instance: null })
-                }
+                onClose={() => setModalState({ type: null, instance: null })}
                 width="80%"
             >
                 <Grid container spacing={2}>

--- a/jobmon_gui/src/components/task_details/TaskSummaryCard.tsx
+++ b/jobmon_gui/src/components/task_details/TaskSummaryCard.tsx
@@ -10,13 +10,11 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { alpha } from '@mui/material/styles';
 import CopyButton from '@jobmon_gui/components/common/CopyButton';
 import { BiRun } from 'react-icons/bi';
 import { IoMdCloseCircle, IoMdCloseCircleOutline } from 'react-icons/io';
-import {
-    AiFillSchedule,
-    AiFillCheckCircle,
-} from 'react-icons/ai';
+import { AiFillSchedule, AiFillCheckCircle } from 'react-icons/ai';
 import { HiRocketLaunch } from 'react-icons/hi2';
 import { TaskDetails } from '@jobmon_gui/types/TaskDetails';
 import {
@@ -26,8 +24,7 @@ import {
     ERROR_STATUSES,
 } from '@jobmon_gui/constants/taskStatus';
 import { formatJobmonDate } from '@jobmon_gui/utils/DayTime';
-import { ScrollableCodeBlock } from
-    '@jobmon_gui/components/ScrollableTextArea';
+import { ScrollableCodeBlock } from '@jobmon_gui/components/ScrollableTextArea';
 
 const STATUS_ICONS: Record<string, React.ReactNode> = {
     G: <AiFillSchedule />,
@@ -45,9 +42,7 @@ interface TaskSummaryCardProps {
     taskDetails: TaskDetails;
 }
 
-export default function TaskSummaryCard({
-    taskDetails,
-}: TaskSummaryCardProps) {
+export default function TaskSummaryCard({ taskDetails }: TaskSummaryCardProps) {
     const [commandOpen, setCommandOpen] = useState(false);
 
     const status = taskDetails.task_status;
@@ -56,13 +51,11 @@ export default function TaskSummaryCard({
     const statusLabel = getStatusLabel(status);
     const statusIcon = STATUS_ICONS[status] || null;
 
-    const showAttempts =
-        taskDetails.max_attempts > 1 ||
-        (ERROR_STATUSES as readonly string[]).includes(status);
+    const isError = (ERROR_STATUSES as readonly string[]).includes(status);
+    const showAttempts = taskDetails.max_attempts > 1 || isError;
     const attemptProgress =
         taskDetails.max_attempts > 0
-            ? (taskDetails.num_attempts / taskDetails.max_attempts) *
-              100
+            ? (taskDetails.num_attempts / taskDetails.max_attempts) * 100
             : 0;
 
     return (
@@ -70,10 +63,11 @@ export default function TaskSummaryCard({
             elevation={0}
             sx={{
                 border: '1px solid',
-                borderColor: 'divider',
+                borderColor: isError ? statusColor : 'divider',
                 borderLeft: `4px solid ${statusColor}`,
                 borderRadius: 2,
                 mb: 2,
+                bgcolor: isError ? alpha(statusColor, 0.03) : undefined,
                 '&:hover': {
                     boxShadow: 2,
                 },
@@ -130,8 +124,7 @@ export default function TaskSummaryCard({
                     color="text.secondary"
                     sx={{ mb: 1 }}
                 >
-                    Updated:{' '}
-                    {formatJobmonDate(taskDetails.task_status_date)}
+                    Updated: {formatJobmonDate(taskDetails.task_status_date)}
                 </Typography>
 
                 {/* Row 3: Attempts progress (conditional) */}
@@ -207,16 +200,12 @@ export default function TaskSummaryCard({
                         )}
                         <Tooltip
                             title={
-                                commandOpen
-                                    ? 'Hide command'
-                                    : 'Show command'
+                                commandOpen ? 'Hide command' : 'Show command'
                             }
                         >
                             <IconButton
                                 size="small"
-                                onClick={() =>
-                                    setCommandOpen(!commandOpen)
-                                }
+                                onClick={() => setCommandOpen(!commandOpen)}
                             >
                                 {commandOpen ? (
                                     <ExpandLessIcon fontSize="small" />

--- a/jobmon_gui/src/components/task_template_details/TaskTable.tsx
+++ b/jobmon_gui/src/components/task_template_details/TaskTable.tsx
@@ -7,7 +7,17 @@ import {
     MRT_RowData,
     useMaterialReactTable,
 } from 'material-react-table';
-import { Box, Button, TextField } from '@mui/material';
+import {
+    Box,
+    Button,
+    FormControl,
+    FormControlLabel,
+    InputLabel,
+    MenuItem,
+    Select,
+    Switch,
+    TextField,
+} from '@mui/material';
 import { mkConfig, generateCsv, download } from 'export-to-csv';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -52,6 +62,11 @@ export default function TaskTable({
     taskTemplateName,
     workflowId,
     onFilteredInstanceIdsChange,
+    showLatestOnly,
+    onShowLatestOnlyChange,
+    selectedWorkflowRunId,
+    availableWorkflowRunIds,
+    onSelectedWorkflowRunIdChange,
 }: TaskTableProps) {
     dayjs.extend(utc);
     const queryClient = useQueryClient();
@@ -378,7 +393,68 @@ export default function TaskTable({
         },
         renderTopToolbarCustomActions: _table => {
             return (
-                <Box>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        flexWrap: 'wrap',
+                    }}
+                >
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={showLatestOnly}
+                                onChange={(_e, checked) =>
+                                    onShowLatestOnlyChange(checked)
+                                }
+                                size="small"
+                            />
+                        }
+                        label="Latest attempt only"
+                        slotProps={{
+                            typography: {
+                                variant: 'body2',
+                            },
+                        }}
+                    />
+                    {availableWorkflowRunIds.length > 1 && (
+                        <FormControl
+                            size="small"
+                            sx={{ minWidth: 140 }}
+                        >
+                            <InputLabel id="wfr-filter-label">
+                                Workflow Run
+                            </InputLabel>
+                            <Select
+                                labelId="wfr-filter-label"
+                                label="Workflow Run"
+                                value={
+                                    selectedWorkflowRunId ?? ''
+                                }
+                                onChange={e => {
+                                    const val = e.target.value;
+                                    onSelectedWorkflowRunIdChange(
+                                        val === ''
+                                            ? null
+                                            : Number(val)
+                                    );
+                                }}
+                            >
+                                <MenuItem value="">All</MenuItem>
+                                {availableWorkflowRunIds.map(
+                                    id => (
+                                        <MenuItem
+                                            key={id}
+                                            value={id}
+                                        >
+                                            {id}
+                                        </MenuItem>
+                                    )
+                                )}
+                            </Select>
+                        </FormControl>
+                    )}
                     <Button
                         onClick={exportToCSV}
                         startIcon={<FileDownloadIcon />}

--- a/jobmon_gui/src/components/task_template_details/TaskTable.tsx
+++ b/jobmon_gui/src/components/task_template_details/TaskTable.tsx
@@ -30,6 +30,22 @@ import {
 } from '@jobmon_gui/constants/taskStatus';
 import humanizeDuration from 'humanize-duration';
 
+/** Priority order for status sorting — error statuses first. */
+const STATUS_SORT_PRIORITY: Record<string, number> = {
+    F: 0, // Fatal Error
+    E: 1, // Error
+    Z: 2, // Resource Error
+    X: 3, // No Heartbeat
+    U: 4, // Unknown Error
+    A: 5, // Adjusting
+    R: 6, // Running
+    O: 7, // Scheduled
+    Q: 8, // Queued
+    I: 9, // Instantiated
+    G: 10, // Registered
+    D: 11, // Done
+};
+
 export default function TaskTable({
     data,
     isLoading,
@@ -99,6 +115,13 @@ export default function TaskTable({
             header: 'Status',
             size: 140,
             grow: false,
+            sortingFn: (rowA, rowB) => {
+                const a = rowA.original.instance_status;
+                const b = rowB.original.instance_status;
+                const pa = STATUS_SORT_PRIORITY[a] ?? 99;
+                const pb = STATUS_SORT_PRIORITY[b] ?? 99;
+                return pa - pb;
+            },
             Cell: ({ row }) => {
                 const status = row.original.instance_status;
                 const label = getStatusLabel(status);
@@ -162,21 +185,12 @@ export default function TaskTable({
             grow: false,
             enableColumnFilterModes: false,
             filterFn: (row, _columnId, filterValue) => {
-                const rowDate = row.getValue<dayjs.Dayjs>(
-                    'task_status_date'
-                );
+                const rowDate = row.getValue<dayjs.Dayjs>('task_status_date');
                 if (!filterValue || !rowDate || !dayjs.isDayjs(rowDate))
                     return true;
-                if (
-                    Array.isArray(filterValue) &&
-                    filterValue.length === 2
-                ) {
+                if (Array.isArray(filterValue) && filterValue.length === 2) {
                     const [from, to] = filterValue;
-                    if (
-                        from &&
-                        dayjs.isDayjs(from) &&
-                        rowDate.isBefore(from)
-                    )
+                    if (from && dayjs.isDayjs(from) && rowDate.isBefore(from))
                         return false;
                     if (to && dayjs.isDayjs(to) && rowDate.isAfter(to))
                         return false;
@@ -192,12 +206,8 @@ export default function TaskTable({
                 let currentFrom: dayjs.Dayjs | undefined;
                 let currentTo: dayjs.Dayjs | undefined;
                 if (Array.isArray(raw) && raw.length === 2) {
-                    currentFrom = dayjs.isDayjs(raw[0])
-                        ? raw[0]
-                        : undefined;
-                    currentTo = dayjs.isDayjs(raw[1])
-                        ? raw[1]
-                        : undefined;
+                    currentFrom = dayjs.isDayjs(raw[0]) ? raw[0] : undefined;
+                    currentTo = dayjs.isDayjs(raw[1]) ? raw[1] : undefined;
                 } else if (dayjs.isDayjs(raw)) {
                     currentFrom = raw;
                 }
@@ -216,9 +226,7 @@ export default function TaskTable({
                             label="From"
                             value={
                                 currentFrom
-                                    ? currentFrom.format(
-                                          'YYYY-MM-DDTHH:mm'
-                                      )
+                                    ? currentFrom.format('YYYY-MM-DDTHH:mm')
                                     : ''
                             }
                             onChange={e => {
@@ -247,9 +255,7 @@ export default function TaskTable({
                             label="To"
                             value={
                                 currentTo
-                                    ? currentTo.format(
-                                          'YYYY-MM-DDTHH:mm'
-                                      )
+                                    ? currentTo.format('YYYY-MM-DDTHH:mm')
                                     : ''
                             }
                             onChange={e => {
@@ -402,9 +408,7 @@ export default function TaskTable({
 
         const filteredRows = table.getFilteredRowModel().rows;
         const ids = new Set(
-            filteredRows.map(
-                row => row.original.task_instance_id
-            )
+            filteredRows.map(row => row.original.task_instance_id)
         );
         const key = [...ids].sort().join(',');
         if (key !== prevFilteredKeyRef.current) {

--- a/jobmon_gui/src/components/task_template_details/usage/ErrorClustersCard.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/ErrorClustersCard.tsx
@@ -1,18 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import {
-    Box,
-    Button,
-    Card,
-    CardContent,
-    Chip,
-    CircularProgress,
-    Divider,
-    Drawer,
-    Grid,
-    IconButton,
-    Skeleton,
-    Typography,
-} from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
 import CloseIcon from '@mui/icons-material/Close';
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
@@ -33,13 +31,16 @@ SyntaxHighlighter.registerLanguage('bash', bash);
 import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios';
 import HtmlTooltip from '@jobmon_gui/components/HtmlToolTip';
 import { formatJobmonDate } from '@jobmon_gui/utils/DayTime.ts';
-import { getTaskDetailsQueryFn } from
-    '@jobmon_gui/queries/GetTaskDetails.ts';
+import { getTaskDetailsQueryFn } from '@jobmon_gui/queries/GetTaskDetails.ts';
+import MemoryIcon from '@mui/icons-material/Memory';
+import Tooltip from '@mui/material/Tooltip';
 import {
     ClusteredError,
     ErrorLog,
     ErrorSampleDetails,
 } from '@jobmon_gui/types/ClusteredErrors.ts';
+import { RESOURCE_ERROR_COLORS } from '@jobmon_gui/constants/taskStatus';
+import { FatalErrorBreakdown } from '@jobmon_gui/queries/GetFatalErrorBreakdown';
 
 interface ErrorClustersCardProps {
     errorLogs: ClusteredError[];
@@ -51,6 +52,10 @@ interface ErrorClustersCardProps {
     scatterInstanceIds?: Set<number>;
     onFilterByInstanceIds?: (instanceIds: number[]) => void;
     maxListHeight?: number;
+    /** Layout mode: 'sidebar' for compact 280px sidebar, 'fullwidth' for prominent full-width display */
+    layout?: 'sidebar' | 'fullwidth';
+    /** Fatal error breakdown with resource error counts — when present, renders a resource error banner */
+    resourceErrorBreakdown?: FatalErrorBreakdown | null;
 }
 
 const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
@@ -62,18 +67,22 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
     scatterInstanceIds,
     onFilterByInstanceIds,
     maxListHeight = 180,
+    layout = 'sidebar',
+    resourceErrorBreakdown,
 }) => {
     const queryClient = useQueryClient();
     const location = useLocation();
-    const [errorDetailIndex, setErrorDetailIndex] = useState<
-        ErrorSampleDetails | null
-    >(null);
+    const [errorDetailIndex, setErrorDetailIndex] =
+        useState<ErrorSampleDetails | null>(null);
     const [language, setLanguage] = useState('python');
 
     // --- Error detail query ---
-    const errorDetails = useQuery<{
-        error_logs: ErrorLog[];
-    } | undefined>({
+    const errorDetails = useQuery<
+        | {
+              error_logs: ErrorLog[];
+          }
+        | undefined
+    >({
         queryKey: [
             'workflow_details',
             'error_details',
@@ -92,11 +101,11 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 return undefined;
             }
             const ti_id =
-                errorDetailIndex.sample_ids[
-                    errorDetailIndex.sample_index
-                ];
+                errorDetailIndex.sample_ids[errorDetailIndex.sample_index];
             return axios
-                .get<{ error_logs: ErrorLog[] }>(
+                .get<{
+                    error_logs: ErrorLog[];
+                }>(
                     `${error_log_viz_url}${workflowId}/${taskTemplateId}/${ti_id}`,
                     { ...jobmonAxiosConfig, data: null }
                 )
@@ -105,8 +114,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
         enabled: !!taskTemplateId && errorDetailIndex !== null,
     });
 
-    const currentError =
-        errorDetails.data?.error_logs?.[0] ?? null;
+    const currentError = errorDetails.data?.error_logs?.[0] ?? null;
     const taskDetailsQuery = useQuery({
         queryKey: ['task_details', currentError?.task_id],
         queryFn: getTaskDetailsQueryFn,
@@ -115,9 +123,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
     });
 
     // Prefetch next sample
-    const prefetchErrorDetails = async (
-        nextIdx: ErrorSampleDetails
-    ) => {
+    const prefetchErrorDetails = async (nextIdx: ErrorSampleDetails) => {
         await queryClient.prefetchQuery({
             queryKey: [
                 'workflow_details',
@@ -127,14 +133,10 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 nextIdx,
             ],
             queryFn: async () => {
-                if (
-                    nextIdx.sample_index >=
-                    nextIdx.sample_ids.length
-                ) {
+                if (nextIdx.sample_index >= nextIdx.sample_ids.length) {
                     return;
                 }
-                const ti_id =
-                    nextIdx.sample_ids[nextIdx.sample_index];
+                const ti_id = nextIdx.sample_ids[nextIdx.sample_index];
                 return axios
                     .get(
                         `${error_log_viz_url}${workflowId}/${taskTemplateId}/${ti_id}`,
@@ -169,6 +171,12 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
     );
     const hasErrors = errorClusterCount > 0 || totalFailures > 0;
 
+    // --- Resource error TI lookup ---
+    const resourceErrorTiIdSet = useMemo(
+        () => new Set(resourceErrorBreakdown?.resource_error_ti_ids ?? []),
+        [resourceErrorBreakdown]
+    );
+
     // --- Sample navigation ---
     const nextSample = () => {
         if (errorDetailIndex === null) {
@@ -181,10 +189,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
     };
 
     const previousSample = () => {
-        if (
-            errorDetailIndex === null ||
-            errorDetailIndex.sample_index === 0
-        ) {
+        if (errorDetailIndex === null || errorDetailIndex.sample_index === 0) {
             return;
         }
         setErrorDetailIndex({
@@ -199,9 +204,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
 
     const currentTiID = () => {
         if (errorDetailIndex === null) return '';
-        return errorDetailIndex.sample_ids[
-            errorDetailIndex.sample_index
-        ];
+        return errorDetailIndex.sample_ids[errorDetailIndex.sample_index];
     };
 
     // --- Drawer content ---
@@ -213,13 +216,12 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 </Box>
             );
         }
-        const error =
-            errorDetails.data?.error_logs?.[0] ?? null;
+        const error = errorDetails.data?.error_logs?.[0] ?? null;
         if (errorDetails.isError || !error) {
             return (
                 <Typography sx={{ p: 2 }}>
-                    Failed to retrieve error details. Please
-                    refresh and try again
+                    Failed to retrieve error details. Please refresh and try
+                    again
                 </Typography>
             );
         }
@@ -233,24 +235,22 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
         return (
             <Box sx={{ p: 2, overflow: 'auto' }}>
                 {/* Metadata */}
-                <Box sx={{
-                    display: 'grid',
-                    gridTemplateColumns: '1fr 1fr',
-                    gap: 1.5,
-                    mb: 2,
-                }}>
+                <Box
+                    sx={{
+                        display: 'grid',
+                        gridTemplateColumns: '1fr 1fr',
+                        gap: 1.5,
+                        mb: 2,
+                    }}
+                >
                     <Box>
-                        <Typography sx={labelStyles}>
-                            Error Time
-                        </Typography>
+                        <Typography sx={labelStyles}>Error Time</Typography>
                         <Typography variant="body2">
                             {formatJobmonDate(error.error_time)}
                         </Typography>
                     </Box>
                     <Box>
-                        <Typography sx={labelStyles}>
-                            Task ID
-                        </Typography>
+                        <Typography sx={labelStyles}>Task ID</Typography>
                         {error.task_id ? (
                             <Link
                                 to={{
@@ -267,31 +267,24 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                                             'task_details',
                                             error.task_id,
                                         ],
-                                        queryFn:
-                                            getTaskDetailsQueryFn,
+                                        queryFn: getTaskDetailsQueryFn,
                                     });
                                 }}
                             >
                                 {error.task_id}
                             </Link>
                         ) : (
-                            <Typography variant="body2">
-                                —
-                            </Typography>
+                            <Typography variant="body2">—</Typography>
                         )}
                     </Box>
                     <Box>
-                        <Typography sx={labelStyles}>
-                            Error ID
-                        </Typography>
+                        <Typography sx={labelStyles}>Error ID</Typography>
                         <Typography variant="body2">
                             {error.task_instance_err_id}
                         </Typography>
                     </Box>
                     <Box>
-                        <Typography sx={labelStyles}>
-                            WF Run ID
-                        </Typography>
+                        <Typography sx={labelStyles}>WF Run ID</Typography>
                         <Typography variant="body2">
                             {error.workflow_run_id}
                         </Typography>
@@ -301,16 +294,15 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 <Divider sx={{ mb: 2 }} />
 
                 {/* Error Message */}
-                <Box sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    mb: 1,
-                }}>
-                    <Typography
-                        variant="subtitle2"
-                        fontWeight="bold"
-                    >
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        mb: 1,
+                    }}
+                >
+                    <Typography variant="subtitle2" fontWeight="bold">
                         Error Message
                     </Typography>
                     <Button
@@ -322,22 +314,21 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                         {language === 'python' ? 'R' : 'Python'}
                     </Button>
                 </Box>
-                <Box sx={{
-                    maxHeight: '40vh',
-                    overflow: 'auto',
-                    bgcolor: '#eee',
-                    borderRadius: 1,
-                    fontSize: '0.75rem',
-                    '& pre': {
-                        whiteSpace: 'pre-wrap !important',
-                        wordBreak: 'break-word !important',
-                        m: '0 !important',
-                    },
-                }}>
-                    <SyntaxHighlighter
-                        language={language}
-                        wrapLongLines
-                    >
+                <Box
+                    sx={{
+                        maxHeight: '40vh',
+                        overflow: 'auto',
+                        bgcolor: '#eee',
+                        borderRadius: 1,
+                        fontSize: '0.75rem',
+                        '& pre': {
+                            whiteSpace: 'pre-wrap !important',
+                            wordBreak: 'break-word !important',
+                            m: '0 !important',
+                        },
+                    }}
+                >
+                    <SyntaxHighlighter language={language} wrapLongLines>
                         {error.error}
                     </SyntaxHighlighter>
                 </Box>
@@ -350,22 +341,21 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 >
                     Task Instance stderr
                 </Typography>
-                <Box sx={{
-                    maxHeight: '40vh',
-                    overflow: 'auto',
-                    bgcolor: '#eee',
-                    borderRadius: 1,
-                    fontSize: '0.75rem',
-                    '& pre': {
-                        whiteSpace: 'pre-wrap !important',
-                        wordBreak: 'break-word !important',
-                        m: '0 !important',
-                    },
-                }}>
-                    <SyntaxHighlighter
-                        language={language}
-                        wrapLongLines
-                    >
+                <Box
+                    sx={{
+                        maxHeight: '40vh',
+                        overflow: 'auto',
+                        bgcolor: '#eee',
+                        borderRadius: 1,
+                        fontSize: '0.75rem',
+                        '& pre': {
+                            whiteSpace: 'pre-wrap !important',
+                            wordBreak: 'break-word !important',
+                            m: '0 !important',
+                        },
+                    }}
+                >
+                    <SyntaxHighlighter language={language} wrapLongLines>
                         {error.task_instance_stderr_log ||
                             'No stderr output found'}
                     </SyntaxHighlighter>
@@ -378,23 +368,16 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                             sx={{
                                 display: 'flex',
                                 alignItems: 'center',
-                                justifyContent:
-                                    'space-between',
+                                justifyContent: 'space-between',
                                 mt: 2,
                                 mb: 1,
                             }}
                         >
-                            <Typography
-                                variant="subtitle2"
-                                fontWeight="bold"
-                            >
+                            <Typography variant="subtitle2" fontWeight="bold">
                                 Command
                             </Typography>
                             <CopyButton
-                                text={
-                                    taskDetailsQuery.data
-                                        .task_command
-                                }
+                                text={taskDetailsQuery.data.task_command}
                                 tooltip="Copy command"
                             />
                         </Box>
@@ -406,22 +389,14 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                                 borderRadius: 1,
                                 fontSize: '0.75rem',
                                 '& pre': {
-                                    whiteSpace:
-                                        'pre-wrap !important',
-                                    wordBreak:
-                                        'break-word !important',
+                                    whiteSpace: 'pre-wrap !important',
+                                    wordBreak: 'break-word !important',
                                     m: '0 !important',
                                 },
                             }}
                         >
-                            <SyntaxHighlighter
-                                language="bash"
-                                wrapLongLines
-                            >
-                                {
-                                    taskDetailsQuery.data
-                                        .task_command
-                                }
+                            <SyntaxHighlighter language="bash" wrapLongLines>
+                                {taskDetailsQuery.data.task_command}
                             </SyntaxHighlighter>
                         </Box>
                     </>
@@ -442,13 +417,9 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 sx={{
                     height: '100%',
                     border: '1px solid',
-                    borderColor: hasErrors
-                        ? 'error.light'
-                        : 'divider',
+                    borderColor: hasErrors ? 'error.light' : 'divider',
                     borderLeft: '3px solid',
-                    borderLeftColor: hasErrors
-                        ? 'error.main'
-                        : 'grey.400',
+                    borderLeftColor: hasErrors ? 'error.main' : 'grey.400',
                     borderRadius: 2,
                     transition: 'all 0.2s ease-in-out',
                     '&:hover': { boxShadow: 3 },
@@ -468,11 +439,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 >
                     <Typography
                         variant="caption"
-                        color={
-                            hasErrors
-                                ? 'error.main'
-                                : 'text.secondary'
-                        }
+                        color={hasErrors ? 'error.main' : 'text.secondary'}
                         fontWeight="bold"
                         sx={{
                             textTransform: 'uppercase',
@@ -501,9 +468,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                                 variant="body2"
                                 fontWeight="bold"
                                 color={
-                                    hasErrors
-                                        ? 'error.main'
-                                        : 'text.primary'
+                                    hasErrors ? 'error.main' : 'text.primary'
                                 }
                                 sx={{ mt: 0.5 }}
                             >
@@ -526,9 +491,7 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                                 variant="body2"
                                 fontWeight="bold"
                                 color={
-                                    hasErrors
-                                        ? 'error.main'
-                                        : 'text.primary'
+                                    hasErrors ? 'error.main' : 'text.primary'
                                 }
                                 sx={{ mt: 0.5 }}
                             >
@@ -542,7 +505,10 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                         <Box
                             sx={{
                                 flex: 1,
-                                maxHeight: maxListHeight,
+                                maxHeight:
+                                    layout === 'fullwidth'
+                                        ? '50vh'
+                                        : maxListHeight,
                                 overflow: 'auto',
                                 border: '1px solid',
                                 borderColor: 'grey.200',
@@ -551,17 +517,25 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                             }}
                         >
                             {errorLogs.map((cluster, idx) => {
+                                const truncLen =
+                                    layout === 'fullwidth' ? 200 : 80;
                                 const truncated =
-                                    cluster.sample_error.length >
-                                    80
-                                        ? `...${cluster.sample_error.slice(-80)}`
+                                    cluster.sample_error.length > truncLen
+                                        ? `...${cluster.sample_error.slice(-truncLen)}`
                                         : cluster.sample_error;
+                                // Count how many of this cluster's TIs are resource errors
+                                const resourceCount =
+                                    resourceErrorTiIdSet.size > 0
+                                        ? cluster.task_instance_ids.filter(id =>
+                                              resourceErrorTiIdSet.has(id)
+                                          ).length
+                                        : 0;
+                                const isResourceCluster = resourceCount > 0;
                                 // Only cluster instances with scatter data can be selected; compare against that subset so clusters with missing usage data still highlight when their scatter-visible instances are selected.
                                 const clusterIdsInScatter =
                                     scatterInstanceIds != null
-                                        ? cluster.task_instance_ids.filter(
-                                              id =>
-                                                  scatterInstanceIds.has(id)
+                                        ? cluster.task_instance_ids.filter(id =>
+                                              scatterInstanceIds.has(id)
                                           )
                                         : cluster.task_instance_ids;
                                 const isActive =
@@ -582,23 +556,19 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                                             px: 1,
                                             py: 0.5,
                                             borderBottom:
-                                                idx <
-                                                errorLogs.length -
-                                                    1
+                                                idx < errorLogs.length - 1
                                                     ? '1px solid'
                                                     : 'none',
-                                            borderColor:
-                                                'grey.200',
+                                            borderColor: 'grey.200',
                                             bgcolor: isActive
                                                 ? 'primary.50'
                                                 : 'transparent',
                                             borderLeft: isActive
                                                 ? '3px solid'
                                                 : '3px solid transparent',
-                                            borderLeftColor:
-                                                isActive
-                                                    ? 'primary.main'
-                                                    : 'transparent',
+                                            borderLeftColor: isActive
+                                                ? 'primary.main'
+                                                : 'transparent',
                                             '&:hover': {
                                                 bgcolor: isActive
                                                     ? 'primary.100'
@@ -608,52 +578,77 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                                     >
                                         <Button
                                             sx={{
-                                                textTransform:
-                                                    'none',
+                                                textTransform: 'none',
                                                 textAlign: 'left',
                                                 flex: 1,
                                                 minWidth: 0,
-                                                justifyContent:
-                                                    'flex-start',
+                                                justifyContent: 'flex-start',
                                                 px: 0.5,
                                                 py: 0,
                                             }}
                                             size="small"
                                             onClick={() =>
-                                                setErrorDetailIndex(
-                                                    {
-                                                        sample_index: 0,
-                                                        sample_ids:
-                                                            cluster.task_instance_ids,
-                                                    }
-                                                )
+                                                setErrorDetailIndex({
+                                                    sample_index: 0,
+                                                    sample_ids:
+                                                        cluster.task_instance_ids,
+                                                })
                                             }
                                         >
                                             <Typography
                                                 variant="caption"
                                                 noWrap
                                                 sx={{
-                                                    fontFamily:
-                                                        'monospace',
-                                                    fontSize:
-                                                        '0.75rem',
+                                                    fontFamily: 'monospace',
+                                                    fontSize: '0.75rem',
                                                 }}
                                             >
                                                 {truncated}
                                             </Typography>
                                         </Button>
+                                        {isResourceCluster && (
+                                            <Tooltip
+                                                title={`${resourceCount} resource error${resourceCount > 1 ? 's' : ''}`}
+                                                arrow
+                                                placement="top"
+                                            >
+                                                <Chip
+                                                    icon={
+                                                        <MemoryIcon
+                                                            sx={{
+                                                                fontSize:
+                                                                    '12px !important',
+                                                                color: '#fff !important',
+                                                            }}
+                                                        />
+                                                    }
+                                                    label={resourceCount}
+                                                    size="small"
+                                                    sx={{
+                                                        mx: 0.25,
+                                                        height: 20,
+                                                        fontSize: '0.65rem',
+                                                        fontWeight: 'bold',
+                                                        backgroundColor:
+                                                            RESOURCE_ERROR_COLORS.main,
+                                                        color: '#fff',
+                                                        '& .MuiChip-icon': {
+                                                            ml: 0.5,
+                                                            mr: -0.25,
+                                                        },
+                                                    }}
+                                                />
+                                            </Tooltip>
+                                        )}
                                         <Chip
-                                            label={
-                                                cluster.group_instance_count
-                                            }
+                                            label={cluster.group_instance_count}
                                             size="small"
                                             color="error"
                                             variant="outlined"
                                             sx={{
                                                 mx: 0.5,
                                                 height: 20,
-                                                fontSize:
-                                                    '0.7rem',
+                                                fontSize: '0.7rem',
                                             }}
                                         />
                                         {onFilterByInstanceIds && (
@@ -726,14 +721,16 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 }}
             >
                 {/* Header */}
-                <Box sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    pt: 3,
-                    px: 2,
-                    pb: 1,
-                }}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        pt: 3,
+                        px: 2,
+                        pb: 1,
+                    }}
+                >
                     <Typography variant="subtitle1" fontWeight="bold">
                         Error Sample: TI {currentTiID()}
                     </Typography>
@@ -746,12 +743,14 @@ const ErrorClustersCard: React.FC<ErrorClustersCardProps> = ({
                 </Box>
 
                 {/* Sample navigation */}
-                <Box sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    px: 2,
-                    pb: 1,
-                }}>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        px: 2,
+                        pb: 1,
+                    }}
+                >
                     <IconButton
                         onClick={previousSample}
                         size="small"

--- a/jobmon_gui/src/components/task_template_details/usage/ResourceSummaryBar.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/ResourceSummaryBar.tsx
@@ -1,0 +1,298 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import FormControl from '@mui/material/FormControl';
+import IconButton from '@mui/material/IconButton';
+import InputLabel from '@mui/material/InputLabel';
+import LinearProgress from '@mui/material/LinearProgress';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Paper from '@mui/material/Paper';
+import Select from '@mui/material/Select';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { ResourceEfficiencyMetrics } from '@jobmon_gui/types/Usage';
+import { ResourceCluster, getEfficiencyStatus } from './usageCalculations';
+
+interface ResourceSummaryBarProps {
+    resourceEfficiency: ResourceEfficiencyMetrics;
+    expanded: boolean;
+    onToggleExpanded: () => void;
+    selectedDataCount: number;
+    availableResourceClusters: ResourceCluster[];
+    selectedResourceClusters: Set<string>;
+    onSelectedResourceClustersChange: (clusters: Set<string>) => void;
+    onResetFilters: () => void;
+    hasActiveSelection: boolean;
+    onClearSelection: () => void;
+    hasData: boolean;
+}
+
+const ResourceSummaryBar: React.FC<ResourceSummaryBarProps> = ({
+    resourceEfficiency,
+    expanded,
+    onToggleExpanded,
+    selectedDataCount,
+    availableResourceClusters,
+    selectedResourceClusters,
+    onSelectedResourceClustersChange,
+    onResetFilters,
+    hasActiveSelection,
+    onClearSelection,
+    hasData,
+}) => {
+    const runtimeStatus = getEfficiencyStatus(
+        resourceEfficiency.runtimeUtilization
+    );
+    const memoryStatus = getEfficiencyStatus(
+        resourceEfficiency.memoryUtilization
+    );
+    const isResourceFiltered =
+        selectedResourceClusters.size < availableResourceClusters.length;
+
+    return (
+        <Paper
+            elevation={0}
+            sx={{
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 2,
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    flexWrap: 'wrap',
+                    gap: 1.5,
+                    px: 1.5,
+                    py: 0.75,
+                    minHeight: 48,
+                }}
+            >
+                {/* Runtime utilization */}
+                {hasData && (
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 0.75,
+                            minWidth: 180,
+                        }}
+                    >
+                        <Typography
+                            variant="caption"
+                            fontWeight="bold"
+                            color="text.secondary"
+                            sx={{ whiteSpace: 'nowrap' }}
+                        >
+                            Runtime
+                        </Typography>
+                        <LinearProgress
+                            variant="determinate"
+                            value={Math.min(
+                                resourceEfficiency.runtimeUtilization,
+                                100
+                            )}
+                            sx={{
+                                flex: 1,
+                                height: 8,
+                                borderRadius: 4,
+                                minWidth: 60,
+                                bgcolor: 'grey.200',
+                                '& .MuiLinearProgress-bar': {
+                                    bgcolor: runtimeStatus.color,
+                                    borderRadius: 4,
+                                },
+                            }}
+                        />
+                        <Typography
+                            variant="caption"
+                            fontWeight="bold"
+                            sx={{
+                                whiteSpace: 'nowrap',
+                                color: runtimeStatus.color,
+                            }}
+                        >
+                            {Math.round(resourceEfficiency.runtimeUtilization)}%
+                        </Typography>
+                        <Chip
+                            label={runtimeStatus.shortLabel}
+                            size="small"
+                            sx={{
+                                height: 20,
+                                fontSize: '0.65rem',
+                                fontWeight: 'bold',
+                                bgcolor: runtimeStatus.bgColor,
+                                color: runtimeStatus.color,
+                            }}
+                        />
+                    </Box>
+                )}
+
+                {/* Memory utilization */}
+                {hasData && (
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 0.75,
+                            minWidth: 180,
+                        }}
+                    >
+                        <Typography
+                            variant="caption"
+                            fontWeight="bold"
+                            color="text.secondary"
+                            sx={{ whiteSpace: 'nowrap' }}
+                        >
+                            Memory
+                        </Typography>
+                        <LinearProgress
+                            variant="determinate"
+                            value={Math.min(
+                                resourceEfficiency.memoryUtilization,
+                                100
+                            )}
+                            sx={{
+                                flex: 1,
+                                height: 8,
+                                borderRadius: 4,
+                                minWidth: 60,
+                                bgcolor: 'grey.200',
+                                '& .MuiLinearProgress-bar': {
+                                    bgcolor: memoryStatus.color,
+                                    borderRadius: 4,
+                                },
+                            }}
+                        />
+                        <Typography
+                            variant="caption"
+                            fontWeight="bold"
+                            sx={{
+                                whiteSpace: 'nowrap',
+                                color: memoryStatus.color,
+                            }}
+                        >
+                            {Math.round(resourceEfficiency.memoryUtilization)}%
+                        </Typography>
+                        <Chip
+                            label={memoryStatus.shortLabel}
+                            size="small"
+                            sx={{
+                                height: 20,
+                                fontSize: '0.65rem',
+                                fontWeight: 'bold',
+                                bgcolor: memoryStatus.bgColor,
+                                color: memoryStatus.color,
+                            }}
+                        />
+                    </Box>
+                )}
+
+                {/* Resource cluster dropdown */}
+                {availableResourceClusters.length > 1 && (
+                    <FormControl size="small" sx={{ minWidth: 150 }}>
+                        <InputLabel id="resource-cluster-filter-label">
+                            Resource Clusters
+                        </InputLabel>
+                        <Select
+                            labelId="resource-cluster-filter-label"
+                            multiple
+                            value={Array.from(selectedResourceClusters)}
+                            onChange={event => {
+                                const {
+                                    target: { value },
+                                } = event;
+                                onSelectedResourceClustersChange(
+                                    new Set(
+                                        typeof value === 'string'
+                                            ? value.split(',')
+                                            : (value as string[])
+                                    )
+                                );
+                            }}
+                            input={<OutlinedInput label="Resource Clusters" />}
+                            renderValue={selected =>
+                                selected.length ===
+                                availableResourceClusters.length
+                                    ? 'All'
+                                    : `${selected.length} selected`
+                            }
+                            MenuProps={{
+                                PaperProps: {
+                                    style: { maxHeight: 300 },
+                                },
+                            }}
+                        >
+                            {availableResourceClusters.map(cluster => (
+                                <MenuItem
+                                    key={cluster.id}
+                                    value={cluster.id}
+                                    dense
+                                >
+                                    <Checkbox
+                                        checked={selectedResourceClusters.has(
+                                            cluster.id
+                                        )}
+                                        size="small"
+                                    />
+                                    <ListItemText
+                                        primary={cluster.label}
+                                        primaryTypographyProps={{
+                                            fontSize: '0.875rem',
+                                        }}
+                                    />
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                )}
+
+                {/* Active filter chips */}
+                {hasActiveSelection && (
+                    <Chip
+                        label={`${selectedDataCount} selected`}
+                        size="small"
+                        onDelete={onClearSelection}
+                        color="primary"
+                        variant="outlined"
+                        sx={{ height: 24 }}
+                    />
+                )}
+                {isResourceFiltered && (
+                    <Chip
+                        label="Reset filters"
+                        size="small"
+                        onClick={onResetFilters}
+                        variant="outlined"
+                        color="default"
+                        sx={{ height: 24 }}
+                    />
+                )}
+
+                {/* Spacer */}
+                <Box sx={{ flex: 1 }} />
+
+                {/* Expand/collapse toggle */}
+                <Tooltip
+                    title={
+                        expanded
+                            ? 'Collapse resource profiling'
+                            : 'Expand resource profiling'
+                    }
+                >
+                    <IconButton size="small" onClick={onToggleExpanded}>
+                        {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                    </IconButton>
+                </Tooltip>
+            </Box>
+        </Paper>
+    );
+};
+
+export default ResourceSummaryBar;

--- a/jobmon_gui/src/components/task_template_details/usage/UsageKPICards.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/UsageKPICards.tsx
@@ -16,6 +16,7 @@ import {
     UsageKPIStats,
     ResourceEfficiencyMetrics,
 } from '@jobmon_gui/types/Usage';
+import { getEfficiencyStatus } from './usageCalculations';
 
 interface UsageKPICardsProps {
     kpiStats: UsageKPIStats;
@@ -34,35 +35,6 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
 }) => {
     const isShowingSelection =
         selectedDataCount !== undefined && selectedDataCount > 0;
-
-    // Helper function to get efficiency status
-    const getEfficiencyStatus = (utilization: number) => {
-        if (utilization > 90) {
-            return {
-                label: 'UNDER-ALLOCATED',
-                description: 'High Risk',
-                color: 'error' as const,
-                bgColor: 'error.50',
-                textColor: 'error.main',
-            };
-        } else if (utilization < 50) {
-            return {
-                label: 'OVER-ALLOCATED',
-                description: 'Wasteful',
-                color: 'warning' as const,
-                bgColor: 'warning.50',
-                textColor: 'warning.main',
-            };
-        } else {
-            return {
-                label: 'WELL-ALLOCATED',
-                description: 'Optimal',
-                color: 'success' as const,
-                bgColor: 'success.50',
-                textColor: 'success.main',
-            };
-        }
-    };
 
     const runtimeStatus = getEfficiencyStatus(
         resourceEfficiency.runtimeUtilization
@@ -137,7 +109,10 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                 Runtime
                             </Typography>
 
-                            <Grid container spacing={layout === 'vertical' ? 0.5 : 1.5}>
+                            <Grid
+                                container
+                                spacing={layout === 'vertical' ? 0.5 : 1.5}
+                            >
                                 <Grid item xs={4}>
                                     <Typography
                                         variant="caption"
@@ -157,12 +132,12 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                     >
                                         {kpiStats.minRuntime !== undefined
                                             ? humanizeDuration(
-                                                kpiStats.minRuntime * 1000,
-                                                {
-                                                    largest: 1,
-                                                    round: true,
-                                                }
-                                            )
+                                                  kpiStats.minRuntime * 1000,
+                                                  {
+                                                      largest: 1,
+                                                      round: true,
+                                                  }
+                                              )
                                             : 'N/A'}
                                     </Typography>
                                 </Grid>
@@ -185,12 +160,12 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                     >
                                         {kpiStats.maxRuntime !== undefined
                                             ? humanizeDuration(
-                                                kpiStats.maxRuntime * 1000,
-                                                {
-                                                    largest: 1,
-                                                    round: true,
-                                                }
-                                            )
+                                                  kpiStats.maxRuntime * 1000,
+                                                  {
+                                                      largest: 1,
+                                                      round: true,
+                                                  }
+                                              )
                                             : 'N/A'}
                                     </Typography>
                                 </Grid>
@@ -213,12 +188,12 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                     >
                                         {kpiStats.medianRuntime !== undefined
                                             ? humanizeDuration(
-                                                kpiStats.medianRuntime * 1000,
-                                                {
-                                                    largest: 1,
-                                                    round: true,
-                                                }
-                                            )
+                                                  kpiStats.medianRuntime * 1000,
+                                                  {
+                                                      largest: 1,
+                                                      round: true,
+                                                  }
+                                              )
                                             : 'N/A'}
                                     </Typography>
                                 </Grid>
@@ -259,7 +234,7 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                                     height: 18,
                                                     backgroundColor:
                                                         runtimeStatus.bgColor,
-                                                    color: runtimeStatus.textColor,
+                                                    color: runtimeStatus.color,
                                                     fontWeight: 'bold',
                                                 }}
                                             />
@@ -276,7 +251,7 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                                     variant="body2"
                                                     fontWeight="bold"
                                                     sx={{
-                                                        color: runtimeStatus.textColor,
+                                                        color: runtimeStatus.color,
                                                     }}
                                                 >
                                                     {resourceEfficiency.runtimeUtilization.toFixed(
@@ -305,7 +280,7 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                                         {
                                                             borderRadius: 3,
                                                             backgroundColor:
-                                                                runtimeStatus.textColor,
+                                                                runtimeStatus.color,
                                                         },
                                                 }}
                                             />
@@ -330,13 +305,13 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                                 {kpiStats.medianRequestedRuntime !==
                                                 undefined
                                                     ? humanizeDuration(
-                                                        kpiStats.medianRequestedRuntime *
+                                                          kpiStats.medianRequestedRuntime *
                                                               1000,
-                                                        {
-                                                            largest: 1,
-                                                            round: true,
-                                                        }
-                                                    )
+                                                          {
+                                                              largest: 1,
+                                                              round: true,
+                                                          }
+                                                      )
                                                     : 'N/A'}
                                             </Typography>
                                         </Box>
@@ -384,7 +359,10 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                 Memory
                             </Typography>
 
-                            <Grid container spacing={layout === 'vertical' ? 0.5 : 1.5}>
+                            <Grid
+                                container
+                                spacing={layout === 'vertical' ? 0.5 : 1.5}
+                            >
                                 <Grid item xs={4}>
                                     <Typography
                                         variant="caption"
@@ -488,7 +466,7 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                                     height: 18,
                                                     backgroundColor:
                                                         memoryStatus.bgColor,
-                                                    color: memoryStatus.textColor,
+                                                    color: memoryStatus.color,
                                                     fontWeight: 'bold',
                                                 }}
                                             />
@@ -505,7 +483,7 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                                     variant="body2"
                                                     fontWeight="bold"
                                                     sx={{
-                                                        color: memoryStatus.textColor,
+                                                        color: memoryStatus.color,
                                                     }}
                                                 >
                                                     {resourceEfficiency.memoryUtilization.toFixed(
@@ -534,7 +512,7 @@ const UsageKPICards: React.FC<UsageKPICardsProps> = ({
                                                         {
                                                             borderRadius: 3,
                                                             backgroundColor:
-                                                                memoryStatus.textColor,
+                                                                memoryStatus.color,
                                                         },
                                                 }}
                                             />

--- a/jobmon_gui/src/components/task_template_details/usage/UsagePlotSection.tsx
+++ b/jobmon_gui/src/components/task_template_details/usage/UsagePlotSection.tsx
@@ -5,17 +5,9 @@ import {
     Box,
     Button,
     ButtonGroup,
-    Checkbox,
-    Chip,
-    FormControl,
     FormControlLabel,
     IconButton,
-    InputLabel,
-    ListItemText,
-    MenuItem,
-    OutlinedInput,
     Paper,
-    Select,
     Skeleton,
     Switch,
     Tooltip,
@@ -36,7 +28,6 @@ import RuntimeMemoryScatterPlot, {
     ScatterPlotHandle,
 } from './RuntimeMemoryScatterPlot';
 import { ScatterDataPoint } from '@jobmon_gui/types/Usage';
-import { ResourceCluster } from './usageCalculations';
 
 interface UsagePlotSectionProps {
     isLoading: boolean;
@@ -51,12 +42,6 @@ interface UsagePlotSectionProps {
     onShowResourceZonesChange: (show: boolean) => void;
     onDownloadCSV?: () => void;
     hasData?: boolean;
-    availableResourceClusters: ResourceCluster[];
-    selectedResourceClusters: Set<string>;
-    onSelectedResourceClustersChange: (clusters: Set<string>) => void;
-    onResetFilters: () => void;
-    hasActiveSelection?: boolean;
-    onClearSelection?: () => void;
 }
 
 const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
@@ -72,16 +57,7 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
     onShowResourceZonesChange,
     onDownloadCSV,
     hasData = false,
-    availableResourceClusters,
-    selectedResourceClusters,
-    onSelectedResourceClustersChange,
-    onResetFilters,
-    hasActiveSelection,
-    onClearSelection,
 }) => {
-    const isResourceFiltered =
-        selectedResourceClusters.size <
-        availableResourceClusters.length;
     const [dragMode, setDragMode] = useState<
         'zoom' | 'pan' | 'select' | 'lasso'
     >('zoom');
@@ -117,9 +93,7 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     <Tooltip title="Zoom mode">
                         <Button
                             variant={
-                                dragMode === 'zoom'
-                                    ? 'contained'
-                                    : 'outlined'
+                                dragMode === 'zoom' ? 'contained' : 'outlined'
                             }
                             onClick={() => setDragMode('zoom')}
                             sx={{ minWidth: 0, px: 0.75 }}
@@ -130,9 +104,7 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     <Tooltip title="Pan mode">
                         <Button
                             variant={
-                                dragMode === 'pan'
-                                    ? 'contained'
-                                    : 'outlined'
+                                dragMode === 'pan' ? 'contained' : 'outlined'
                             }
                             onClick={() => setDragMode('pan')}
                             sx={{ minWidth: 0, px: 0.75 }}
@@ -143,13 +115,9 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     <Tooltip title="Box select">
                         <Button
                             variant={
-                                dragMode === 'select'
-                                    ? 'contained'
-                                    : 'outlined'
+                                dragMode === 'select' ? 'contained' : 'outlined'
                             }
-                            onClick={() =>
-                                setDragMode('select')
-                            }
+                            onClick={() => setDragMode('select')}
                             sx={{ minWidth: 0, px: 0.75 }}
                         >
                             <SelectIcon fontSize="small" />
@@ -158,13 +126,9 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     <Tooltip title="Lasso select">
                         <Button
                             variant={
-                                dragMode === 'lasso'
-                                    ? 'contained'
-                                    : 'outlined'
+                                dragMode === 'lasso' ? 'contained' : 'outlined'
                             }
-                            onClick={() =>
-                                setDragMode('lasso')
-                            }
+                            onClick={() => setDragMode('lasso')}
                             sx={{ minWidth: 0, px: 0.75 }}
                         >
                             <LassoIcon fontSize="small" />
@@ -172,9 +136,7 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     </Tooltip>
                     <Tooltip title="Zoom in">
                         <Button
-                            onClick={() =>
-                                plotHandleRef.current?.zoomIn()
-                            }
+                            onClick={() => plotHandleRef.current?.zoomIn()}
                             sx={{ minWidth: 0, px: 0.75 }}
                         >
                             <AddIcon fontSize="small" />
@@ -182,9 +144,7 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     </Tooltip>
                     <Tooltip title="Zoom out">
                         <Button
-                            onClick={() =>
-                                plotHandleRef.current?.zoomOut()
-                            }
+                            onClick={() => plotHandleRef.current?.zoomOut()}
                             sx={{ minWidth: 0, px: 0.75 }}
                         >
                             <RemoveIcon fontSize="small" />
@@ -192,9 +152,7 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     </Tooltip>
                     <Tooltip title="Reset zoom">
                         <Button
-                            onClick={() =>
-                                plotHandleRef.current?.resetZoom()
-                            }
+                            onClick={() => plotHandleRef.current?.resetZoom()}
                             sx={{ minWidth: 0, px: 0.75 }}
                         >
                             <RestartAltIcon fontSize="small" />
@@ -202,95 +160,7 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                     </Tooltip>
                 </ButtonGroup>
 
-                <Box
-                    sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 1,
-                        flex: 1,
-                        justifyContent: 'center',
-                    }}
-                >
-                    <FormControl size="small" sx={{ minWidth: 150 }}>
-                        <InputLabel id="resource-cluster-filter-label">
-                            Resource Clusters
-                        </InputLabel>
-                        <Select
-                            labelId="resource-cluster-filter-label"
-                            multiple
-                            value={Array.from(
-                                selectedResourceClusters
-                            )}
-                            onChange={event => {
-                                const {
-                                    target: { value },
-                                } = event;
-                                onSelectedResourceClustersChange(
-                                    new Set(
-                                        typeof value === 'string'
-                                            ? value.split(',')
-                                            : (value as string[])
-                                    )
-                                );
-                            }}
-                            input={
-                                <OutlinedInput label="Resource Clusters" />
-                            }
-                            renderValue={selected =>
-                                selected.length ===
-                                availableResourceClusters.length
-                                    ? 'All'
-                                    : `${selected.length} selected`
-                            }
-                            MenuProps={{
-                                PaperProps: {
-                                    style: { maxHeight: 300 },
-                                },
-                            }}
-                        >
-                            {availableResourceClusters.map(cluster => (
-                                <MenuItem
-                                    key={cluster.id}
-                                    value={cluster.id}
-                                    dense
-                                >
-                                    <Checkbox
-                                        checked={selectedResourceClusters.has(
-                                            cluster.id
-                                        )}
-                                        size="small"
-                                    />
-                                    <ListItemText
-                                        primary={cluster.label}
-                                        primaryTypographyProps={{
-                                            fontSize: '0.875rem',
-                                        }}
-                                    />
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    </FormControl>
-                    {hasActiveSelection && onClearSelection && (
-                        <Chip
-                            label="Clear selection"
-                            size="small"
-                            onDelete={onClearSelection}
-                            color="primary"
-                            variant="outlined"
-                            sx={{ height: 28 }}
-                        />
-                    )}
-                    {isResourceFiltered && (
-                        <Chip
-                            label="Reset filters"
-                            size="small"
-                            onClick={onResetFilters}
-                            variant="outlined"
-                            color="default"
-                            sx={{ height: 28 }}
-                        />
-                    )}
-                </Box>
+                <Box sx={{ flex: 1 }} />
 
                 <Box
                     sx={{
@@ -368,12 +238,8 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                             ref={plotHandleRef}
                             data={filteredScatterData}
                             onTaskClick={onTaskClick}
-                            medianRequestedRuntime={
-                                medianRequestedRuntime
-                            }
-                            medianRequestedMemory={
-                                medianRequestedMemoryGiB
-                            }
+                            medianRequestedRuntime={medianRequestedRuntime}
+                            medianRequestedMemory={medianRequestedMemoryGiB}
                             taskTemplateName={taskTemplateName}
                             showResourceZones={showResourceZones}
                             selectedInstanceIds={selectedInstanceIds}
@@ -411,10 +277,9 @@ const UsagePlotSection: React.FC<UsagePlotSectionProps> = ({
                             textAlign="center"
                             sx={{ maxWidth: 400 }}
                         >
-                            No data matches the current filter
-                            criteria. Try adjusting your filters
-                            or check if data exists for this task
-                            template.
+                            No data matches the current filter criteria. Try
+                            adjusting your filters or check if data exists for
+                            this task template.
                         </Typography>
                     </Box>
                 )}

--- a/jobmon_gui/src/components/task_template_details/usage/usageCalculations.ts
+++ b/jobmon_gui/src/components/task_template_details/usage/usageCalculations.ts
@@ -568,3 +568,57 @@ export const getResourceClusterKey = (
 
     return null;
 };
+
+/**
+ * Efficiency status classification for resource utilization.
+ */
+export type EfficiencyLevel = 'under' | 'over' | 'ok';
+
+export interface EfficiencyStatus {
+    level: EfficiencyLevel;
+    label: string;
+    shortLabel: string;
+    description: string;
+    color: string;
+    bgColor: string;
+    muiColor: 'error' | 'warning' | 'success';
+}
+
+const EFFICIENCY_STATUSES: Record<EfficiencyLevel, EfficiencyStatus> = {
+    under: {
+        level: 'under',
+        label: 'UNDER-ALLOCATED',
+        shortLabel: 'UNDER-ALLOC',
+        description: 'High Risk',
+        color: '#d32f2f',
+        bgColor: '#ffebee',
+        muiColor: 'error',
+    },
+    over: {
+        level: 'over',
+        label: 'OVER-ALLOCATED',
+        shortLabel: 'OVER-ALLOC',
+        description: 'Wasteful',
+        color: '#ed6c02',
+        bgColor: '#fff3e0',
+        muiColor: 'warning',
+    },
+    ok: {
+        level: 'ok',
+        label: 'WELL-ALLOCATED',
+        shortLabel: 'OK',
+        description: 'Optimal',
+        color: '#2e7d32',
+        bgColor: '#e8f5e9',
+        muiColor: 'success',
+    },
+};
+
+/**
+ * Classify resource utilization into efficiency status.
+ */
+export const getEfficiencyStatus = (utilization: number): EfficiencyStatus => {
+    if (utilization > 90) return EFFICIENCY_STATUSES.under;
+    if (utilization < 50) return EFFICIENCY_STATUSES.over;
+    return EFFICIENCY_STATUSES.ok;
+};

--- a/jobmon_gui/src/components/workflow_details/ResourceCard.tsx
+++ b/jobmon_gui/src/components/workflow_details/ResourceCard.tsx
@@ -1,34 +1,10 @@
-import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
-import Drawer from '@mui/material/Drawer';
-import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useTheme } from '@mui/material/styles';
-import CloseIcon from '@mui/icons-material/Close';
-import MemoryIcon from '@mui/icons-material/Memory';
-import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 import humanizeDuration from 'humanize-duration';
-import axios from 'axios';
-import { useQuery } from '@tanstack/react-query';
-import { Link, useLocation } from 'react-router-dom';
-import { FatalErrorBreakdown } from '@jobmon_gui/queries/GetFatalErrorBreakdown';
-import { getTaskDetailsQueryFn } from '@jobmon_gui/queries/GetTaskDetails';
-import { RESOURCE_ERROR_COLORS } from '@jobmon_gui/constants/taskStatus';
-import { error_log_viz_url } from '@jobmon_gui/configs/ApiUrls';
-import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios';
-import { ErrorLog } from '@jobmon_gui/types/ClusteredErrors';
-import CopyButton from '@jobmon_gui/components/common/CopyButton';
-import ResourceComparisonBar from '@jobmon_gui/components/task_details/ResourceComparisonBar';
-import { formatBytes, bytes_to_gib } from '@jobmon_gui/utils/formatters';
-import { parseResourceJson } from '@jobmon_gui/utils/csvExport';
 
 function fmtRuntime(seconds: number | null | undefined): string {
     if (seconds == null) return 'N/A';
@@ -45,8 +21,6 @@ function fmtMemory(bytes: number | null | undefined): string {
 }
 
 interface ResourceCardProps {
-    workflowId: string | number;
-    taskTemplateId: string | number;
     usageData: {
         median_runtime?: number | null;
         min_runtime?: number | null;
@@ -56,17 +30,9 @@ interface ResourceCardProps {
         max_mem?: number | null;
     } | null;
     usageLoading: boolean;
-    breakdown: FatalErrorBreakdown | null | undefined;
-    breakdownLoading: boolean;
 }
 
-function StatColumn({
-    label,
-    value,
-}: {
-    label: string;
-    value: string;
-}) {
+function StatColumn({ label, value }: { label: string; value: string }) {
     return (
         <Grid item xs={12} sm={4}>
             <Typography
@@ -81,11 +47,7 @@ function StatColumn({
             >
                 {label}
             </Typography>
-            <Typography
-                variant="body2"
-                fontWeight="bold"
-                sx={{ mt: 0.25 }}
-            >
+            <Typography variant="body2" fontWeight="bold" sx={{ mt: 0.25 }}>
                 {value}
             </Typography>
         </Grid>
@@ -93,86 +55,12 @@ function StatColumn({
 }
 
 export default function ResourceCard({
-    workflowId,
-    taskTemplateId,
     usageData,
     usageLoading,
-    breakdown,
-    breakdownLoading: _breakdownLoading,
 }: ResourceCardProps) {
-    const theme = useTheme();
-    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-    const location = useLocation();
-    const [selectedTiIdx, setSelectedTiIdx] = useState<
-        number | null
-    >(null);
-
     const hasUsage =
         usageData &&
-        (usageData.median_runtime != null ||
-            usageData.median_mem != null);
-    const hasResourceErrors =
-        breakdown && breakdown.resource_error_total > 0;
-    const tiIds = breakdown?.resource_error_ti_ids ?? [];
-    const currentTiId =
-        selectedTiIdx !== null ? tiIds[selectedTiIdx] : null;
-
-    const retried = breakdown?.resource_error_retried ?? 0;
-
-    const errorDetailQuery = useQuery<{
-        error_logs: ErrorLog[];
-    }>({
-        queryKey: [
-            'workflow_details',
-            'resource_error_detail',
-            workflowId,
-            taskTemplateId,
-            currentTiId,
-        ],
-        queryFn: async () => {
-            return axios
-                .get<{ error_logs: ErrorLog[] }>(
-                    `${error_log_viz_url}${workflowId}/${taskTemplateId}/${currentTiId}`,
-                    { ...jobmonAxiosConfig, data: null }
-                )
-                .then(r => r.data);
-        },
-        enabled: currentTiId != null,
-        staleTime: 120000,
-    });
-
-    const errorLog =
-        errorDetailQuery.data?.error_logs?.[0] ?? null;
-    const taskDetailsQuery = useQuery({
-        queryKey: ['task_details', errorLog?.task_id],
-        queryFn: getTaskDetailsQueryFn,
-        enabled: errorLog?.task_id != null,
-        staleTime: 300000,
-    });
-
-    const tiDetailsQuery = useQuery({
-        queryKey: ['ti_details', errorLog?.task_id],
-        queryFn: async () => {
-            const resp = await axios.get<{
-                taskinstances: Array<{
-                    ti_id: number;
-                    ti_maxrss: string | null;
-                    ti_wallclock: string | null;
-                    ti_resources: string | null;
-                }>;
-            }>(
-                `${import.meta.env.VITE_APP_BASE_URL}/task/get_ti_details_viz/${errorLog!.task_id}`,
-                { ...jobmonAxiosConfig, data: null }
-            );
-            return resp.data.taskinstances;
-        },
-        enabled: errorLog?.task_id != null,
-        staleTime: 120000,
-    });
-
-    const tiDetail = tiDetailsQuery.data?.find(
-        ti => ti.ti_id === currentTiId
-    );
+        (usageData.median_runtime != null || usageData.median_mem != null);
 
     if (usageLoading) {
         return (
@@ -185,665 +73,124 @@ export default function ResourceCard({
                 }}
             >
                 <CircularProgress size={16} />
-                <Typography
-                    variant="caption"
-                    color="text.secondary"
-                >
+                <Typography variant="caption" color="text.secondary">
                     Loading resources...
                 </Typography>
             </Box>
         );
     }
 
-    if (!hasUsage && !hasResourceErrors && !usageLoading) return null;
-
-    const drawerContent = () => {
-        if (errorDetailQuery.isLoading) {
-            return (
-                <Box
-                    sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        p: 4,
-                    }}
-                >
-                    <CircularProgress />
-                </Box>
-            );
-        }
-        if (!errorLog) {
-            return (
-                <Typography sx={{ p: 2 }}>
-                    No error details available.
-                </Typography>
-            );
-        }
-
-        const resources = tiDetail
-            ? parseResourceJson(tiDetail.ti_resources)
-            : null;
-        const requestedMemGiB = resources?.memory ?? null;
-        const utilizedMemGiB = tiDetail
-            ? bytes_to_gib(
-                  parseInt(
-                      String(tiDetail.ti_maxrss ?? '0'),
-                      10
-                  ) || 0
-              )
-            : null;
-        const requestedRuntimeSec =
-            resources?.runtime ?? null;
-        const utilizedRuntimeSec = tiDetail?.ti_wallclock
-            ? parseInt(String(tiDetail.ti_wallclock), 10)
-            : null;
-
-        return (
-            <Box sx={{ p: 2, overflow: 'auto' }}>
-                {/* Metadata */}
-                <Box
-                    sx={{
-                        display: 'grid',
-                        gridTemplateColumns: '1fr 1fr',
-                        gap: 1.5,
-                        mb: 2,
-                    }}
-                >
-                    <Box>
-                        <Typography
-                            variant="caption"
-                            color="text.secondary"
-                            fontWeight="bold"
-                        >
-                            Task ID
-                        </Typography>
-                        {errorLog.task_id ? (
-                            <Link
-                                to={{
-                                    pathname: `/task_details/${errorLog.task_id}`,
-                                    search: location.search,
-                                }}
-                                style={{
-                                    color: '#1976d2',
-                                    fontSize: '0.875rem',
-                                    display: 'block',
-                                }}
-                            >
-                                {errorLog.task_id}
-                            </Link>
-                        ) : (
-                            <Typography variant="body2">
-                                —
-                            </Typography>
-                        )}
-                    </Box>
-                    <Box>
-                        <Typography
-                            variant="caption"
-                            color="text.secondary"
-                            fontWeight="bold"
-                        >
-                            TI Status
-                        </Typography>
-                        <Typography variant="body2">
-                            Resource Error
-                        </Typography>
-                    </Box>
-                </Box>
-
-                {/* Resource comparison bars */}
-                {tiDetail && (
-                    <Box sx={{ mb: 2 }}>
-                        <Typography
-                            variant="subtitle2"
-                            fontWeight="bold"
-                            sx={{ mb: 1 }}
-                        >
-                            Resource Usage
-                        </Typography>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                gap: 3,
-                                flexWrap: 'wrap',
-                            }}
-                        >
-                            <Box
-                                sx={{
-                                    flex: '1 1 200px',
-                                    maxWidth: 300,
-                                }}
-                            >
-                                <ResourceComparisonBar
-                                    label="Memory"
-                                    requested={requestedMemGiB}
-                                    utilized={utilizedMemGiB}
-                                    requestedDisplay={
-                                        requestedMemGiB != null
-                                            ? `${requestedMemGiB} GiB`
-                                            : 'N/A'
-                                    }
-                                    utilizedDisplay={formatBytes(
-                                        tiDetail.ti_maxrss
-                                    )}
-                                />
-                            </Box>
-                            <Box
-                                sx={{
-                                    flex: '1 1 200px',
-                                    maxWidth: 300,
-                                }}
-                            >
-                                <ResourceComparisonBar
-                                    label="Runtime"
-                                    requested={
-                                        requestedRuntimeSec
-                                    }
-                                    utilized={
-                                        utilizedRuntimeSec
-                                    }
-                                    requestedDisplay={
-                                        requestedRuntimeSec !=
-                                        null
-                                            ? humanizeDuration(
-                                                  requestedRuntimeSec *
-                                                      1000,
-                                                  {
-                                                      largest: 2,
-                                                      round: true,
-                                                  }
-                                              )
-                                            : 'N/A'
-                                    }
-                                    utilizedDisplay={
-                                        utilizedRuntimeSec !=
-                                        null
-                                            ? humanizeDuration(
-                                                  utilizedRuntimeSec *
-                                                      1000,
-                                                  {
-                                                      largest: 2,
-                                                      round: true,
-                                                  }
-                                              )
-                                            : 'N/A'
-                                    }
-                                />
-                            </Box>
-                        </Box>
-                    </Box>
-                )}
-
-                {/* Error message / stderr */}
-                {errorLog.error && (
-                    <Box sx={{ mb: 2 }}>
-                        <Typography
-                            variant="subtitle2"
-                            fontWeight="bold"
-                            sx={{ mb: 0.5 }}
-                        >
-                            Error
-                        </Typography>
-                        <Box
-                            sx={{
-                                maxHeight: '20vh',
-                                overflow: 'auto',
-                                bgcolor: '#eee',
-                                borderRadius: 1,
-                                px: 1.5,
-                                py: 1,
-                                fontFamily: 'monospace',
-                                fontSize: '0.75rem',
-                                whiteSpace: 'pre-wrap',
-                                wordBreak: 'break-word',
-                            }}
-                        >
-                            {errorLog.error}
-                        </Box>
-                    </Box>
-                )}
-
-                {/* Command */}
-                {taskDetailsQuery.data?.task_command && (
-                    <Box>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent:
-                                    'space-between',
-                                mb: 0.5,
-                            }}
-                        >
-                            <Typography
-                                variant="subtitle2"
-                                fontWeight="bold"
-                            >
-                                Command
-                            </Typography>
-                            <CopyButton
-                                text={
-                                    taskDetailsQuery.data
-                                        .task_command
-                                }
-                                tooltip="Copy command"
-                            />
-                        </Box>
-                        <Box
-                            sx={{
-                                maxHeight: '15vh',
-                                overflow: 'auto',
-                                bgcolor: '#eee',
-                                borderRadius: 1,
-                                px: 1.5,
-                                py: 1,
-                                fontFamily: 'monospace',
-                                fontSize: '0.75rem',
-                                whiteSpace: 'pre-wrap',
-                                wordBreak: 'break-word',
-                            }}
-                        >
-                            {
-                                taskDetailsQuery.data
-                                    .task_command
-                            }
-                        </Box>
-                    </Box>
-                )}
-            </Box>
-        );
-    };
+    if (!hasUsage) return null;
 
     return (
-        <>
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    gap: 1,
-                }}
-            >
-                {/* Resource error card */}
-                {hasResourceErrors && (
-                    <Card
-                        elevation={0}
-                        sx={{
-                            flex: '1 1 0',
-                            minWidth: 0,
-                            border: '1px solid',
-                            borderColor:
-                                RESOURCE_ERROR_COLORS.main,
-                            borderLeft: '3px solid',
-                            borderLeftColor:
-                                RESOURCE_ERROR_COLORS.main,
-                            borderRadius: 2,
-                        }}
-                    >
-                        <CardContent
-                            sx={{
-                                p: 1.5,
-                                '&:last-child': { pb: 1.5 },
-                            }}
-                        >
-                            <Typography
-                                variant="caption"
-                                sx={{
-                                    color: RESOURCE_ERROR_COLORS.main,
-                                    fontWeight: 'bold',
-                                    textTransform: 'uppercase',
-                                    letterSpacing: 0.5,
-                                    mb: 0.5,
-                                    display: 'block',
-                                }}
-                            >
-                                Resource Errors
-                            </Typography>
-                            <Box
-                                sx={{
-                                    display: 'flex',
-                                    flexWrap: 'wrap',
-                                    gap: 0.5,
-                                    mb:
-                                        tiIds.length > 0
-                                            ? 1
-                                            : 0,
-                                }}
-                            >
-                                <Chip
-                                    icon={
-                                        <MemoryIcon
-                                            sx={{
-                                                fontSize: 12,
-                                                color: '#fff !important',
-                                            }}
-                                        />
-                                    }
-                                    label={`${breakdown!.resource_error_total} total`}
-                                    size="small"
-                                    sx={{
-                                        height: 22,
-                                        fontSize: '0.7rem',
-                                        fontWeight: 'bold',
-                                        backgroundColor:
-                                            RESOURCE_ERROR_COLORS.main,
-                                        color: '#fff',
-                                    }}
-                                />
-                                {retried > 0 && (
-                                    <Chip
-                                        label={`${retried} retried`}
-                                        size="small"
-                                        sx={{
-                                            height: 22,
-                                            fontSize: '0.7rem',
-                                            backgroundColor:
-                                                RESOURCE_ERROR_COLORS.retriedBg,
-                                            color: RESOURCE_ERROR_COLORS.retried,
-                                            fontWeight: 600,
-                                        }}
-                                    />
-                                )}
-                                {breakdown!.resource > 0 && (
-                                    <Chip
-                                        label={`${breakdown!.resource} fatal`}
-                                        size="small"
-                                        sx={{
-                                            height: 22,
-                                            fontSize: '0.7rem',
-                                            backgroundColor:
-                                                RESOURCE_ERROR_COLORS.fatal,
-                                            color: '#fff',
-                                            fontWeight: 600,
-                                        }}
-                                    />
-                                )}
-                            </Box>
-                            {/* Clickable TI sample list */}
-                            {tiIds.length > 0 && (
-                                <Box
-                                    sx={{
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        gap: 0.25,
-                                        maxHeight: 100,
-                                        overflow: 'auto',
-                                    }}
-                                >
-                                    {tiIds
-                                        .slice(0, 5)
-                                        .map((tiId, idx) => (
-                                            <Typography
-                                                key={tiId}
-                                                variant="caption"
-                                                onClick={() =>
-                                                    setSelectedTiIdx(
-                                                        idx
-                                                    )
-                                                }
-                                                sx={{
-                                                    fontFamily:
-                                                        'monospace',
-                                                    cursor: 'pointer',
-                                                    color: 'primary.main',
-                                                    '&:hover': {
-                                                        textDecoration:
-                                                            'underline',
-                                                    },
-                                                }}
-                                            >
-                                                TI {tiId}
-                                            </Typography>
-                                        ))}
-                                    {tiIds.length > 5 && (
-                                        <Typography
-                                            variant="caption"
-                                            color="text.secondary"
-                                        >
-                                            +{tiIds.length - 5}{' '}
-                                            more
-                                        </Typography>
-                                    )}
-                                </Box>
-                            )}
-                        </CardContent>
-                    </Card>
-                )}
-
-                {/* Runtime card */}
-                {hasUsage &&
-                    usageData!.median_runtime != null && (
-                        <Card
-                            elevation={0}
-                            sx={{
-                                flex: '1 1 0',
-                                minWidth: 0,
-                                border: '1px solid',
-                                borderColor: 'divider',
-                                borderLeft: '3px solid',
-                                borderLeftColor:
-                                    'primary.main',
-                                borderRadius: 2,
-                            }}
-                        >
-                            <CardContent
-                                sx={{
-                                    p: 1.5,
-                                    '&:last-child': {
-                                        pb: 1.5,
-                                    },
-                                }}
-                            >
-                                <Typography
-                                    variant="caption"
-                                    color="primary.main"
-                                    fontWeight="bold"
-                                    sx={{
-                                        textTransform:
-                                            'uppercase',
-                                        letterSpacing: 0.5,
-                                        mb: 0.5,
-                                        display: 'block',
-                                    }}
-                                >
-                                    Runtime
-                                </Typography>
-                                <Grid
-                                    container
-                                    spacing={0.5}
-                                >
-                                    <StatColumn
-                                        label="Minimum"
-                                        value={fmtRuntime(
-                                            usageData!
-                                                .min_runtime
-                                        )}
-                                    />
-                                    <StatColumn
-                                        label="Maximum"
-                                        value={fmtRuntime(
-                                            usageData!
-                                                .max_runtime
-                                        )}
-                                    />
-                                    <StatColumn
-                                        label="Median"
-                                        value={fmtRuntime(
-                                            usageData!
-                                                .median_runtime
-                                        )}
-                                    />
-                                </Grid>
-                            </CardContent>
-                        </Card>
-                    )}
-
-                {/* Memory card */}
-                {hasUsage &&
-                    usageData!.median_mem != null && (
-                        <Card
-                            elevation={0}
-                            sx={{
-                                flex: '1 1 0',
-                                minWidth: 0,
-                                border: '1px solid',
-                                borderColor: 'divider',
-                                borderLeft: '3px solid',
-                                borderLeftColor:
-                                    'secondary.main',
-                                borderRadius: 2,
-                            }}
-                        >
-                            <CardContent
-                                sx={{
-                                    p: 1.5,
-                                    '&:last-child': {
-                                        pb: 1.5,
-                                    },
-                                }}
-                            >
-                                <Typography
-                                    variant="caption"
-                                    color="secondary.main"
-                                    fontWeight="bold"
-                                    sx={{
-                                        textTransform:
-                                            'uppercase',
-                                        letterSpacing: 0.5,
-                                        mb: 0.5,
-                                        display: 'block',
-                                    }}
-                                >
-                                    Memory
-                                </Typography>
-                                <Grid
-                                    container
-                                    spacing={0.5}
-                                >
-                                    <StatColumn
-                                        label="Minimum"
-                                        value={fmtMemory(
-                                            usageData!
-                                                .min_mem
-                                        )}
-                                    />
-                                    <StatColumn
-                                        label="Maximum"
-                                        value={fmtMemory(
-                                            usageData!
-                                                .max_mem
-                                        )}
-                                    />
-                                    <StatColumn
-                                        label="Median"
-                                        value={fmtMemory(
-                                            usageData!
-                                                .median_mem
-                                        )}
-                                    />
-                                </Grid>
-                            </CardContent>
-                        </Card>
-                    )}
-            </Box>
-
-            {/* Resource error detail drawer */}
-            <Drawer
-                anchor="right"
-                open={selectedTiIdx !== null}
-                onClose={() => setSelectedTiIdx(null)}
-                PaperProps={{
-                    sx: {
-                        width: isMobile ? '100%' : 640,
-                    },
-                }}
-            >
-                <Box
+        <Box
+            sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 1,
+            }}
+        >
+            {/* Runtime card */}
+            {usageData!.median_runtime != null && (
+                <Card
+                    elevation={0}
                     sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        px: 2,
-                        py: 1,
-                        borderBottom: '1px solid',
+                        flex: '1 1 0',
+                        minWidth: 0,
+                        border: '1px solid',
                         borderColor: 'divider',
+                        borderLeft: '3px solid',
+                        borderLeftColor: 'primary.main',
+                        borderRadius: 2,
                     }}
                 >
-                    <Typography variant="subtitle1" fontWeight="bold">
-                        Resource Error: TI{' '}
-                        {currentTiId ?? ''}
-                    </Typography>
-                    <Tooltip title="Close">
-                        <IconButton
-                            size="small"
-                            onClick={() =>
-                                setSelectedTiIdx(null)
-                            }
-                        >
-                            <CloseIcon fontSize="small" />
-                        </IconButton>
-                    </Tooltip>
-                </Box>
-                {/* Navigation */}
-                {tiIds.length > 1 && (
-                    <Box
+                    <CardContent
                         sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            gap: 1,
-                            py: 0.5,
-                            borderBottom: '1px solid',
-                            borderColor: 'divider',
+                            p: 1.5,
+                            '&:last-child': { pb: 1.5 },
                         }}
                     >
-                        <Tooltip title="Previous">
-                            <span>
-                                <IconButton
-                                    size="small"
-                                    disabled={
-                                        selectedTiIdx === 0
-                                    }
-                                    onClick={() =>
-                                        setSelectedTiIdx(
-                                            i =>
-                                                i !== null
-                                                    ? i - 1
-                                                    : null
-                                        )
-                                    }
-                                >
-                                    <NavigateBeforeIcon fontSize="small" />
-                                </IconButton>
-                            </span>
-                        </Tooltip>
-                        <Typography variant="caption">
-                            {(selectedTiIdx ?? 0) + 1} of{' '}
-                            {tiIds.length}
+                        <Typography
+                            variant="caption"
+                            color="primary.main"
+                            fontWeight="bold"
+                            sx={{
+                                textTransform: 'uppercase',
+                                letterSpacing: 0.5,
+                                mb: 0.5,
+                                display: 'block',
+                            }}
+                        >
+                            Runtime
                         </Typography>
-                        <Tooltip title="Next">
-                            <span>
-                                <IconButton
-                                    size="small"
-                                    disabled={
-                                        selectedTiIdx ===
-                                        tiIds.length - 1
-                                    }
-                                    onClick={() =>
-                                        setSelectedTiIdx(
-                                            i =>
-                                                i !== null
-                                                    ? i + 1
-                                                    : null
-                                        )
-                                    }
-                                >
-                                    <NavigateNextIcon fontSize="small" />
-                                </IconButton>
-                            </span>
-                        </Tooltip>
-                    </Box>
-                )}
-                {drawerContent()}
-            </Drawer>
-        </>
+                        <Grid container spacing={0.5}>
+                            <StatColumn
+                                label="Minimum"
+                                value={fmtRuntime(usageData!.min_runtime)}
+                            />
+                            <StatColumn
+                                label="Maximum"
+                                value={fmtRuntime(usageData!.max_runtime)}
+                            />
+                            <StatColumn
+                                label="Median"
+                                value={fmtRuntime(usageData!.median_runtime)}
+                            />
+                        </Grid>
+                    </CardContent>
+                </Card>
+            )}
+
+            {/* Memory card */}
+            {usageData!.median_mem != null && (
+                <Card
+                    elevation={0}
+                    sx={{
+                        flex: '1 1 0',
+                        minWidth: 0,
+                        border: '1px solid',
+                        borderColor: 'divider',
+                        borderLeft: '3px solid',
+                        borderLeftColor: 'secondary.main',
+                        borderRadius: 2,
+                    }}
+                >
+                    <CardContent
+                        sx={{
+                            p: 1.5,
+                            '&:last-child': { pb: 1.5 },
+                        }}
+                    >
+                        <Typography
+                            variant="caption"
+                            color="secondary.main"
+                            fontWeight="bold"
+                            sx={{
+                                textTransform: 'uppercase',
+                                letterSpacing: 0.5,
+                                mb: 0.5,
+                                display: 'block',
+                            }}
+                        >
+                            Memory
+                        </Typography>
+                        <Grid container spacing={0.5}>
+                            <StatColumn
+                                label="Minimum"
+                                value={fmtMemory(usageData!.min_mem)}
+                            />
+                            <StatColumn
+                                label="Maximum"
+                                value={fmtMemory(usageData!.max_mem)}
+                            />
+                            <StatColumn
+                                label="Median"
+                                value={fmtMemory(usageData!.median_mem)}
+                            />
+                        </Grid>
+                    </CardContent>
+                </Card>
+            )}
+        </Box>
     );
 }

--- a/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
@@ -50,12 +50,8 @@ export default function TemplateDetailPanel({
     onNavigate,
     disabled,
 }: TemplateDetailPanelProps) {
-    const [concurrencyValue, setConcurrencyValue] = useState<
-        number | string
-    >(
-        templateData.MAXC >= MAX_CONCURRENCY_SENTINEL
-            ? ''
-            : templateData.MAXC
+    const [concurrencyValue, setConcurrencyValue] = useState<number | string>(
+        templateData.MAXC >= MAX_CONCURRENCY_SENTINEL ? '' : templateData.MAXC
     );
     const [statusMsg, setStatusMsg] = useState('');
     const [showManage, setShowManage] = useState(false);
@@ -90,8 +86,7 @@ export default function TemplateDetailPanel({
     const handleConcurrencyChange = (
         e: React.ChangeEvent<HTMLInputElement>
     ) => {
-        const val =
-            e.target.value === '' ? '' : Number(e.target.value);
+        const val = e.target.value === '' ? '' : Number(e.target.value);
         if (val === '' || (val >= 0 && val <= 2147483647)) {
             setConcurrencyValue(val);
         }
@@ -219,19 +214,38 @@ export default function TemplateDetailPanel({
             {/* Manage controls (toggled by wrench icon) */}
             {showManage && (
                 <Box sx={{ mb: 1.5 }}>
-                    <Typography variant="caption" color="text.secondary" sx={{ mb: 0.5, display: 'block' }}>
+                    <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ mb: 0.5, display: 'block' }}
+                    >
                         Manage Template
                     </Typography>
-                    <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-                        <FormControl variant="outlined" size="small" sx={{ flex: 1 }} disabled={disabled}>
-                            <InputLabel id="tt-status-label">Set Status</InputLabel>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            gap: 1,
+                            alignItems: 'flex-start',
+                        }}
+                    >
+                        <FormControl
+                            variant="outlined"
+                            size="small"
+                            sx={{ flex: 1 }}
+                            disabled={disabled}
+                        >
+                            <InputLabel id="tt-status-label">
+                                Set Status
+                            </InputLabel>
                             <Select
                                 labelId="tt-status-label"
                                 label="Set Status"
                                 onChange={e => {
                                     const val = e.target.value as string;
-                                    if (val === 'G') handleStatusUpdate('rerun');
-                                    else if (val === 'D') handleStatusUpdate('skip');
+                                    if (val === 'G')
+                                        handleStatusUpdate('rerun');
+                                    else if (val === 'D')
+                                        handleStatusUpdate('skip');
                                 }}
                             >
                                 <MenuItem value="G">Re-run</MenuItem>
@@ -259,13 +273,21 @@ export default function TemplateDetailPanel({
                             title="Skip to Done: mark tasks as done. Re-run: reset tasks and downstream."
                             placement="right"
                         >
-                            <InfoIcon fontSize="small" color="action" sx={{ mt: 1, cursor: 'help' }} />
+                            <InfoIcon
+                                fontSize="small"
+                                color="action"
+                                sx={{ mt: 1, cursor: 'help' }}
+                            />
                         </Tooltip>
                     </Box>
                     {statusMsg && (
                         <Typography
                             variant="caption"
-                            color={statusMsg === 'Success' ? 'success.main' : 'error'}
+                            color={
+                                statusMsg === 'Success'
+                                    ? 'success.main'
+                                    : 'error'
+                            }
                             sx={{ display: 'block', mt: 0.5 }}
                         >
                             {statusMsg}
@@ -276,7 +298,11 @@ export default function TemplateDetailPanel({
 
             {/* Status bar + breakdown */}
             <Box sx={{ mb: 1.5 }}>
-                <TemplateStatusBar counts={templateData} height={18} showLabels />
+                <TemplateStatusBar
+                    counts={templateData}
+                    height={18}
+                    showLabels
+                />
                 <Typography
                     variant="body2"
                     color="text.secondary"
@@ -299,8 +325,10 @@ export default function TemplateDetailPanel({
                                     height: 20,
                                     fontSize: '0.7rem',
                                     fontWeight: 600,
-                                    backgroundColor: TEMPLATE_STATUS_COLORS[key],
-                                    color: key === 'SCHEDULED' ? '#333' : '#fff',
+                                    backgroundColor:
+                                        TEMPLATE_STATUS_COLORS[key],
+                                    color:
+                                        key === 'SCHEDULED' ? '#333' : '#fff',
                                 }}
                             />
                         );
@@ -317,20 +345,16 @@ export default function TemplateDetailPanel({
                         workflowId={workflowId}
                         taskTemplateId={templateData.id}
                         maxListHeight={120}
+                        resourceErrorBreakdown={breakdownQuery.data}
                     />
                 </Box>
             )}
 
             {/* Resources card */}
             <ResourceCard
-                workflowId={workflowId}
-                taskTemplateId={templateData.id}
                 usageData={usageQuery.data ?? null}
                 usageLoading={usageQuery.isLoading}
-                breakdown={breakdownQuery.data}
-                breakdownLoading={breakdownQuery.isLoading}
             />
-
         </Box>
     );
 }

--- a/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
@@ -41,6 +41,7 @@ interface TemplateDetailPanelProps {
     onBack: () => void;
     onNavigate: () => void;
     disabled?: boolean;
+    workflowRunId?: number | null;
 }
 
 export default function TemplateDetailPanel({
@@ -49,6 +50,7 @@ export default function TemplateDetailPanel({
     onBack,
     onNavigate,
     disabled,
+    workflowRunId,
 }: TemplateDetailPanelProps) {
     const [concurrencyValue, setConcurrencyValue] = useState<number | string>(
         templateData.MAXC >= MAX_CONCURRENCY_SENTINEL ? '' : templateData.MAXC
@@ -143,9 +145,13 @@ export default function TemplateDetailPanel({
             'clustered_errors',
             workflowId,
             templateData.id,
+            workflowRunId,
         ],
         queryFn: getClusteredErrorsFn,
-        enabled: templateData.FATAL > 0,
+        enabled:
+            (templateData.FATAL > 0 ||
+                templateData.resource_error_count > 0) &&
+            workflowRunId != null,
     });
 
     const usageQuery = useQuery({
@@ -164,9 +170,13 @@ export default function TemplateDetailPanel({
             'fatal_breakdown',
             workflowId,
             templateData.task_template_version_id,
+            workflowRunId,
         ],
         queryFn: getFatalErrorBreakdownFn,
-        enabled: templateData.FATAL > 0,
+        enabled:
+            (templateData.FATAL > 0 ||
+                templateData.resource_error_count > 0) &&
+            workflowRunId != null,
         staleTime: 120000,
     });
 
@@ -337,7 +347,8 @@ export default function TemplateDetailPanel({
             </Box>
 
             {/* Errors */}
-            {templateData.FATAL > 0 && (
+            {(templateData.FATAL > 0 ||
+                templateData.resource_error_count > 0) && (
                 <Box sx={{ mb: 1 }}>
                     <ErrorClustersCard
                         errorLogs={errorClusters}

--- a/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/TemplateDetailPanel.tsx
@@ -348,11 +348,12 @@ export default function TemplateDetailPanel({
 
             {/* Errors */}
             {(templateData.FATAL > 0 ||
-                templateData.resource_error_count > 0) && (
+                templateData.resource_error_count > 0) &&
+                workflowRunId != null && (
                 <Box sx={{ mb: 1 }}>
                     <ErrorClustersCard
                         errorLogs={errorClusters}
-                        isLoading={errorsQuery.isLoading}
+                        isLoading={errorsQuery.isLoading || errorsQuery.isPending}
                         workflowId={workflowId}
                         taskTemplateId={templateData.id}
                         maxListHeight={120}

--- a/jobmon_gui/src/components/workflow_details/TemplateListPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/TemplateListPanel.tsx
@@ -1,27 +1,23 @@
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
-import Alert from '@mui/material/Alert';
 import MemoryIcon from '@mui/icons-material/Memory';
-import { useQuery } from '@tanstack/react-query';
 import { TTStatus, TTStatusResponse } from '@jobmon_gui/types/TaskTemplateStatus';
 import {
     TEMPLATE_STATUS_COLORS,
     RESOURCE_ERROR_COLORS,
 } from '@jobmon_gui/constants/taskStatus';
 import TemplateStatusBar from '@jobmon_gui/components/common/TemplateStatusBar';
-import { getFatalErrorBreakdownFn } from '@jobmon_gui/queries/GetFatalErrorBreakdown';
 
 const HOVER_BG = '#e3f2fd';
 
 interface TemplateListPanelProps {
-    workflowId: string | number;
     ttData: TTStatusResponse;
     hoveredTemplateName: string | null;
-    hasResourceErrors: boolean;
     onTemplateSelect: (name: string) => void;
     onTemplateHover: (name: string | null) => void;
     onPrefetch: (tt: {
@@ -31,152 +27,180 @@ interface TemplateListPanelProps {
     }) => void;
 }
 
-/** Single failing template card with lazy error-type breakdown. */
-function FailingTemplateCard({
-    workflowId,
+function TemplateRow({
     tt,
     isHovered,
     onSelect,
     onHover,
     onPrefetch,
 }: {
-    workflowId: string | number;
     tt: TTStatus;
     isHovered: boolean;
     onSelect: () => void;
     onHover: (name: string | null) => void;
     onPrefetch: () => void;
 }) {
-    const { data: breakdown } = useQuery({
-        queryKey: [
-            'workflow_details',
-            'fatal_breakdown',
-            workflowId,
-            tt.task_template_version_id,
-        ],
-        queryFn: getFatalErrorBreakdownFn,
-        enabled: tt.FATAL > 0,
-        staleTime: 120000,
-    });
+    const pct =
+        tt.tasks === 0
+            ? 0
+            : Math.floor((tt.DONE / tt.tasks) * 100);
 
     return (
-        <Box
-            onClick={onSelect}
-            onMouseEnter={() => {
-                onHover(tt.name);
-                onPrefetch();
-            }}
-            onMouseLeave={() => onHover(null)}
-            sx={{
-                p: 1,
-                borderRadius: 1,
-                border: '1px solid',
-                borderColor: 'divider',
-                cursor: 'pointer',
-                backgroundColor: isHovered ? HOVER_BG : undefined,
-                transition: 'background-color 0.15s ease',
-                '&:hover': { backgroundColor: HOVER_BG },
-            }}
-        >
-            <Box
+        <ListItem disablePadding>
+            <ListItemButton
+                onClick={onSelect}
+                onMouseEnter={() => {
+                    onHover(tt.name);
+                    onPrefetch();
+                }}
+                onMouseLeave={() => onHover(null)}
                 sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
+                    py: 0.75,
+                    px: 1.5,
+                    backgroundColor: isHovered
+                        ? `${HOVER_BG} !important`
+                        : undefined,
+                    transition: 'background-color 0.15s ease',
                 }}
             >
-                <Typography
-                    variant="body2"
-                    sx={{
-                        fontWeight: 500,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        flex: 1,
-                        mr: 1,
-                    }}
-                >
-                    {tt.name}
-                </Typography>
-                <Box
-                    sx={{
-                        display: 'flex',
-                        gap: 0.5,
-                        flexShrink: 0,
-                    }}
-                >
-                    {breakdown && breakdown.resource > 0 && (
-                        <Chip
-                            label={`${breakdown.resource} resource`}
-                            size="small"
-                            icon={
-                                <MemoryIcon
-                                    sx={{
-                                        fontSize: 12,
-                                        color: '#fff !important',
-                                    }}
-                                />
-                            }
-                            sx={{
-                                height: 20,
-                                fontSize: '0.65rem',
-                                fontWeight: 'bold',
-                                backgroundColor: RESOURCE_ERROR_COLORS.main,
-                                color: '#fff',
-                            }}
-                        />
-                    )}
-                    <Chip
-                        label={`${tt.FATAL} fatal`}
-                        size="small"
+                <Box sx={{ width: '100%' }}>
+                    <Box
                         sx={{
-                            height: 20,
-                            fontSize: '0.7rem',
-                            fontWeight: 'bold',
-                            backgroundColor:
-                                TEMPLATE_STATUS_COLORS.FATAL,
-                            color: '#fff',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            mb: 0.25,
                         }}
+                    >
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                fontWeight: 500,
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                flex: 1,
+                                minWidth: 0,
+                            }}
+                        >
+                            {tt.name}
+                        </Typography>
+                        {(tt.resource_error_count > 0 ||
+                            tt.FATAL > 0) && (
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    gap: 0.5,
+                                    flexShrink: 0,
+                                }}
+                            >
+                                {tt.resource_error_count > 0 && (
+                                    <Tooltip
+                                        title={`${tt.resource_error_count} task instance${tt.resource_error_count > 1 ? 's' : ''} hit resource limits (memory or runtime exceeded)`}
+                                        arrow
+                                    >
+                                        <Chip
+                                            icon={
+                                                <MemoryIcon
+                                                    sx={{
+                                                        fontSize:
+                                                            '10px !important',
+                                                        color: '#fff !important',
+                                                    }}
+                                                />
+                                            }
+                                            label={`${tt.resource_error_count} resource`}
+                                            size="small"
+                                            sx={{
+                                                height: 18,
+                                                fontSize: '0.6rem',
+                                                fontWeight: 'bold',
+                                                backgroundColor:
+                                                    RESOURCE_ERROR_COLORS.main,
+                                                color: '#fff',
+                                                '& .MuiChip-icon':
+                                                    {
+                                                        ml: 0.5,
+                                                        mr: -0.25,
+                                                    },
+                                            }}
+                                        />
+                                    </Tooltip>
+                                )}
+                                {tt.FATAL > 0 && (
+                                    <Chip
+                                        label={`${tt.FATAL} fatal`}
+                                        size="small"
+                                        sx={{
+                                            height: 18,
+                                            fontSize: '0.6rem',
+                                            fontWeight: 'bold',
+                                            backgroundColor:
+                                                TEMPLATE_STATUS_COLORS.FATAL,
+                                            color: '#fff',
+                                        }}
+                                    />
+                                )}
+                            </Box>
+                        )}
+                        <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{ flexShrink: 0 }}
+                        >
+                            {pct}%
+                        </Typography>
+                    </Box>
+                    <TemplateStatusBar
+                        counts={tt}
+                        height={4}
+                        borderRadius={0.5}
                     />
                 </Box>
-            </Box>
-        </Box>
+            </ListItemButton>
+        </ListItem>
     );
 }
 
 export default function TemplateListPanel({
-    workflowId,
     ttData,
     hoveredTemplateName,
-    hasResourceErrors,
     onTemplateSelect,
     onTemplateHover,
     onPrefetch,
 }: TemplateListPanelProps) {
     const templates = Object.values(ttData);
 
-    const failingTemplates = templates
+    const needsAttention = templates
         .filter(tt => tt.FATAL > 0)
         .sort((a, b) => b.FATAL - a.FATAL);
+
+    const needsAttentionIds = new Set(
+        needsAttention.map(tt => tt.id)
+    );
+
+    const otherTemplates = templates.filter(
+        tt => !needsAttentionIds.has(tt.id)
+    );
 
     return (
         <Box sx={{ p: 2, height: '100%', overflow: 'auto' }}>
             {/* Needs Attention section */}
-            {failingTemplates.length > 0 && (
+            {needsAttention.length > 0 && (
                 <Box sx={{ mb: 2 }}>
                     <Box
                         sx={{
                             display: 'flex',
                             alignItems: 'center',
                             gap: 1,
-                            mb: 1,
+                            mb: 0.5,
                         }}
                     >
                         <Typography variant="subtitle2">
                             Needs Attention
                         </Typography>
                         <Chip
-                            label={`${failingTemplates.length}`}
+                            label={`${needsAttention.length}`}
                             size="small"
                             sx={{
                                 height: 20,
@@ -187,137 +211,49 @@ export default function TemplateListPanel({
                             }}
                         />
                     </Box>
-
-                    {/* Resource error callout */}
-                    {hasResourceErrors && (
-                        <Alert
-                            severity="warning"
-                            icon={
-                                <MemoryIcon fontSize="small" />
-                            }
-                            sx={{
-                                mb: 1,
-                                py: 0,
-                                '& .MuiAlert-message': {
-                                    py: 0.75,
-                                },
-                            }}
-                        >
-                            <Typography variant="caption">
-                                Resource errors detected in this
-                                workflow — check templates marked
-                                with resource chips below
-                            </Typography>
-                        </Alert>
-                    )}
-
-                    {/* Failing template cards */}
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 0.5,
-                        }}
-                    >
-                        {failingTemplates.map(tt => (
-                            <FailingTemplateCard
+                    <List sx={{ padding: 0 }}>
+                        {needsAttention.map(tt => (
+                            <TemplateRow
                                 key={tt.id}
-                                workflowId={workflowId}
                                 tt={tt}
                                 isHovered={
-                                    hoveredTemplateName === tt.name
+                                    hoveredTemplateName ===
+                                    tt.name
                                 }
                                 onSelect={() =>
                                     onTemplateSelect(tt.name)
                                 }
                                 onHover={onTemplateHover}
-                                onPrefetch={() => onPrefetch(tt)}
+                                onPrefetch={() =>
+                                    onPrefetch(tt)
+                                }
                             />
                         ))}
-                    </Box>
+                    </List>
                 </Box>
             )}
 
-            {/* All Templates list with mini status bars */}
-            <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                All Templates
+            {/* Remaining templates */}
+            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                {needsAttention.length > 0
+                    ? 'Other Templates'
+                    : 'All Templates'}
             </Typography>
             <List sx={{ padding: 0 }}>
-                {templates.map(tt => {
-                    const isHovered =
-                        hoveredTemplateName === tt.name;
-                    return (
-                        <ListItem key={tt.id} disablePadding>
-                            <ListItemButton
-                                onClick={() =>
-                                    onTemplateSelect(tt.name)
-                                }
-                                onMouseEnter={() => {
-                                    onTemplateHover(tt.name);
-                                    onPrefetch(tt);
-                                }}
-                                onMouseLeave={() =>
-                                    onTemplateHover(null)
-                                }
-                                sx={{
-                                    py: 0.75,
-                                    px: 1.5,
-                                    backgroundColor: isHovered
-                                        ? '#e3f2fd !important'
-                                        : undefined,
-                                    transition:
-                                        'background-color 0.15s ease',
-                                }}
-                            >
-                                <Box sx={{ width: '100%' }}>
-                                    <Box
-                                        sx={{
-                                            display: 'flex',
-                                            alignItems: 'center',
-                                            justifyContent:
-                                                'space-between',
-                                            mb: 0.25,
-                                        }}
-                                    >
-                                        <Typography
-                                            variant="body2"
-                                            sx={{
-                                                fontWeight: 500,
-                                                overflow: 'hidden',
-                                                textOverflow:
-                                                    'ellipsis',
-                                                whiteSpace: 'nowrap',
-                                                flex: 1,
-                                                mr: 1,
-                                            }}
-                                        >
-                                            {tt.name}
-                                        </Typography>
-                                        <Typography
-                                            variant="caption"
-                                            color="text.secondary"
-                                            sx={{ flexShrink: 0 }}
-                                        >
-                                            {tt.tasks === 0
-                                                ? 0
-                                                : Math.floor(
-                                                      (tt.DONE /
-                                                          tt.tasks) *
-                                                          100
-                                                  )}
-                                            %
-                                        </Typography>
-                                    </Box>
-                                    <TemplateStatusBar
-                                        counts={tt}
-                                        height={4}
-                                        borderRadius={0.5}
-                                    />
-                                </Box>
-                            </ListItemButton>
-                        </ListItem>
-                    );
-                })}
+                {otherTemplates.map(tt => (
+                    <TemplateRow
+                        key={tt.id}
+                        tt={tt}
+                        isHovered={
+                            hoveredTemplateName === tt.name
+                        }
+                        onSelect={() =>
+                            onTemplateSelect(tt.name)
+                        }
+                        onHover={onTemplateHover}
+                        onPrefetch={() => onPrefetch(tt)}
+                    />
+                ))}
             </List>
         </Box>
     );

--- a/jobmon_gui/src/queries/GetClusteredErrors.ts
+++ b/jobmon_gui/src/queries/GetClusteredErrors.ts
@@ -3,25 +3,29 @@ import { error_log_viz_url } from '@jobmon_gui/configs/ApiUrls.ts';
 import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
 import dayjs from 'dayjs';
 import { ClusteredErrorList } from '@jobmon_gui/types/ClusteredErrors.ts';
+import { extractNumericParam, wfrParams } from './queryKeyUtils';
 
 type getClusteredErrorsFnArgs = {
-    queryKey: (string | number | undefined)[];
+    queryKey: (string | number | undefined | null)[];
 };
 export const getClusteredErrorsFn = async ({
     queryKey,
 }: getClusteredErrorsFnArgs) => {
-    if (!queryKey || queryKey.length != 4) {
+    if (!queryKey || queryKey.length < 4) {
         return;
     }
     const workflowId = queryKey[2];
     const taskTemplateId = queryKey[3];
+    const workflowRunId = extractNumericParam(queryKey, 4);
     return axios
         .get<ClusteredErrorList>(
             `${error_log_viz_url}${workflowId}/${taskTemplateId}#`,
             {
                 ...jobmonAxiosConfig,
                 data: null,
-                params: { cluster_errors: 'true' },
+                params: wfrParams(workflowRunId, {
+                    cluster_errors: 'true',
+                }),
             }
         )
         .then(r => {

--- a/jobmon_gui/src/queries/GetFatalErrorBreakdown.ts
+++ b/jobmon_gui/src/queries/GetFatalErrorBreakdown.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { fatal_error_breakdown_url } from '@jobmon_gui/configs/ApiUrls.ts';
 import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
+import { extractNumericParam, wfrParams } from './queryKeyUtils';
 
 export interface FatalErrorBreakdown {
     resource: number;
@@ -20,10 +21,15 @@ export const getFatalErrorBreakdownFn = async ({
 }: QueryFnArgs): Promise<FatalErrorBreakdown> => {
     const workflowId = queryKey[2];
     const ttVersionId = queryKey[3];
+    const workflowRunId = extractNumericParam(queryKey, 4);
     return axios
         .get<FatalErrorBreakdown>(
             `${fatal_error_breakdown_url}${workflowId}/${ttVersionId}`,
-            { ...jobmonAxiosConfig, data: null }
+            {
+                ...jobmonAxiosConfig,
+                data: null,
+                params: wfrParams(workflowRunId),
+            }
         )
         .then(r => r.data);
 };

--- a/jobmon_gui/src/queries/GetTaskInstanceDetails.ts
+++ b/jobmon_gui/src/queries/GetTaskInstanceDetails.ts
@@ -38,6 +38,7 @@ export const getTaskInstanceDetailsQueryFn = async ({
                 ti_queue_name: data.ti_queue_name,
                 ti_cpu: data.ti_cpu,
                 ti_io: data.ti_io,
+                ti_workflow_run_id: data.ti_workflow_run_id ?? null,
             }));
         });
 };

--- a/jobmon_gui/src/queries/GetWorkflowTTStatus.ts
+++ b/jobmon_gui/src/queries/GetWorkflowTTStatus.ts
@@ -2,23 +2,24 @@ import axios from 'axios';
 import { workflow_tt_status_url } from '@jobmon_gui/configs/ApiUrls.ts';
 import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
 import { TTStatusResponse } from '@jobmon_gui/types/TaskTemplateStatus.ts';
+import { extractNumericParam, wfrParams } from './queryKeyUtils';
 
 type getWorkflowTTStatusQueryFnArgs = {
-    queryKey: (string | number | undefined)[];
+    queryKey: (string | number | undefined | null)[];
 };
 export const getWorkflowTTStatusQueryFn = async ({
     queryKey,
 }: getWorkflowTTStatusQueryFnArgs) => {
-    if (!queryKey || queryKey.length != 3) {
+    if (!queryKey || queryKey.length < 3) {
         return;
     }
     const workflowId = queryKey[2];
+    const workflowRunId = extractNumericParam(queryKey, 3);
     return axios
         .get<TTStatusResponse>(workflow_tt_status_url + workflowId, {
             ...jobmonAxiosConfig,
             data: null,
+            params: wfrParams(workflowRunId),
         })
-        .then(r => {
-            return r.data;
-        });
+        .then(r => r.data);
 };

--- a/jobmon_gui/src/queries/queryKeyUtils.ts
+++ b/jobmon_gui/src/queries/queryKeyUtils.ts
@@ -1,0 +1,29 @@
+/**
+ * Extract a numeric value from a query key at a given index.
+ * Returns null if the index is out of bounds or the value is nullish.
+ */
+export function extractNumericParam(
+    queryKey: readonly unknown[],
+    index: number
+): number | null {
+    if (index >= queryKey.length) return null;
+    const val = queryKey[index];
+    if (val == null) return null;
+    return typeof val === 'number' ? val : Number(val) || null;
+}
+
+/**
+ * Build axios params with an optional workflow_run_id.
+ * Returns undefined when wfrId is null (no param sent).
+ */
+export function wfrParams(
+    wfrId: number | null,
+    extra?: Record<string, string>
+): Record<string, string> | undefined {
+    if (wfrId == null && !extra) return undefined;
+    const params: Record<string, string> = { ...extra };
+    if (wfrId != null) {
+        params.workflow_run_id = String(wfrId);
+    }
+    return Object.keys(params).length > 0 ? params : undefined;
+}

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -137,6 +137,10 @@ export default function TaskTemplateDetails() {
     // --- Plot interaction state ---
     const [selectedData, setSelectedData] = useState<ScatterDataPoint[]>([]);
     const [showResourceZones, setShowResourceZones] = useState(false);
+    const [showLatestOnly, setShowLatestOnly] = useState(true);
+    const [selectedWorkflowRunId, setSelectedWorkflowRunId] = useState<
+        number | null
+    >(null);
     const [tableFilteredInstanceIds, setTableFilteredInstanceIds] =
         useState<Set<number> | null>(null);
 
@@ -182,8 +186,39 @@ export default function TaskTemplateDetails() {
                 runtime_seconds: typeof item.r === 'number' ? item.r : null,
                 memory_gib:
                     typeof item.m === 'number' ? bytes_to_gib(item.m) : null,
+                workflow_run_id: item.workflow_run_id ?? null,
             }));
     }, [rawTaskNodesFromApi, passesResourceClusterFilter]);
+
+    // --- Available workflow run IDs (sorted descending) ---
+    const availableWorkflowRunIds = useMemo(() => {
+        const ids = new Set<number>();
+        for (const row of filteredInstanceData) {
+            if (row.workflow_run_id != null) {
+                ids.add(row.workflow_run_id);
+            }
+        }
+        return Array.from(ids).sort((a, b) => b - a);
+    }, [filteredInstanceData]);
+
+    // --- Latest attempt + workflow run filters ---
+    const latestFilteredData = useMemo(() => {
+        let data = filteredInstanceData;
+        if (selectedWorkflowRunId != null) {
+            data = data.filter(
+                r => r.workflow_run_id === selectedWorkflowRunId
+            );
+        }
+        if (!showLatestOnly) return data;
+        const latest = new Map<number, TaskInstanceRow>();
+        for (const row of data) {
+            const existing = latest.get(row.task_id);
+            if (!existing || row.attempt_number > existing.attempt_number) {
+                latest.set(row.task_id, row);
+            }
+        }
+        return Array.from(latest.values());
+    }, [filteredInstanceData, showLatestOnly, selectedWorkflowRunId]);
 
     // --- Helper: filtered requested resource values ---
     const getFilteredRequestedResourceValues = useMemo(() => {
@@ -223,7 +258,7 @@ export default function TaskTemplateDetails() {
     }, [rawTaskNodesFromApi]);
 
     const filteredScatterData = useMemo(() => {
-        return filteredInstanceData
+        return latestFilteredData
             .filter(
                 d =>
                     d.runtime_seconds !== null &&
@@ -245,7 +280,7 @@ export default function TaskTemplateDetails() {
                     requestedMemory: req?.requestedMemory,
                 };
             });
-    }, [filteredInstanceData, requestedResourcesById]);
+    }, [latestFilteredData, requestedResourcesById]);
 
     // --- Effective scatter data (narrowed by table column filters) ---
     const effectiveScatterData = useMemo(() => {
@@ -460,7 +495,13 @@ export default function TaskTemplateDetails() {
     }, [selectedResourceClusters, availableResourceClusters]);
 
     const errorLogsForCard = useMemo(() => {
-        if (!isDataFiltered && !tableFilteredInstanceIds) return errorLogs;
+        if (
+            !isDataFiltered &&
+            !tableFilteredInstanceIds &&
+            !showLatestOnly &&
+            selectedWorkflowRunId == null
+        )
+            return errorLogs;
         let effectiveIds = dataFilterInstanceIds;
         if (tableFilteredInstanceIds) {
             effectiveIds = new Set(
@@ -485,16 +526,18 @@ export default function TaskTemplateDetails() {
         dataFilterInstanceIds,
         isDataFiltered,
         tableFilteredInstanceIds,
+        showLatestOnly,
+        selectedWorkflowRunId,
     ]);
 
     // Table data: pre-filtered by scatter selection
     const tableData = useMemo(() => {
-        if (selectedData.length === 0) return filteredInstanceData;
+        if (selectedData.length === 0) return latestFilteredData;
         const selectedIds = new Set(selectedData.map(d => d.task_instance_id));
-        return filteredInstanceData.filter(d =>
+        return latestFilteredData.filter(d =>
             selectedIds.has(d.task_instance_id)
         );
-    }, [filteredInstanceData, selectedData]);
+    }, [latestFilteredData, selectedData]);
 
     // Clear brush selection and table filter feedback when filters change
     useEffect(() => {
@@ -729,6 +772,11 @@ export default function TaskTemplateDetails() {
                     onFilteredInstanceIdsChange={
                         handleTableFilteredInstanceIdsChange
                     }
+                    showLatestOnly={showLatestOnly}
+                    onShowLatestOnlyChange={setShowLatestOnly}
+                    selectedWorkflowRunId={selectedWorkflowRunId}
+                    availableWorkflowRunIds={availableWorkflowRunIds}
+                    onSelectedWorkflowRunIdChange={setSelectedWorkflowRunId}
                 />
             </Box>
         </Box>

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import Collapse from '@mui/material/Collapse';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
@@ -18,6 +19,7 @@ import JobmonProgressBar from '@jobmon_gui/components/JobmonProgressBar';
 import TaskTable from '@jobmon_gui/components/task_template_details/TaskTable';
 import UsageKPICards from '@jobmon_gui/components/task_template_details/usage/UsageKPICards';
 import UsagePlotSection from '@jobmon_gui/components/task_template_details/usage/UsagePlotSection';
+import ResourceSummaryBar from '@jobmon_gui/components/task_template_details/usage/ResourceSummaryBar';
 import ErrorClustersCard from '@jobmon_gui/components/task_template_details/usage/ErrorClustersCard';
 import { useTaskTemplateDetails } from '@jobmon_gui/queries/GetTaskTemplateDetails.ts';
 import { getWorkflowDetailsQueryFn } from '@jobmon_gui/queries/GetWorkflowDetails.ts';
@@ -27,6 +29,7 @@ import {
     WorkflowUsageQueryKey,
 } from '@jobmon_gui/queries/GetWorkflowUsage.ts';
 import { getClusteredErrorsFn } from '@jobmon_gui/queries/GetClusteredErrors.ts';
+import { getFatalErrorBreakdownFn } from '@jobmon_gui/queries/GetFatalErrorBreakdown';
 import { getWorkflowFiltersForNavigation } from '@jobmon_gui/utils/workflowFilterPersistence';
 import { bytes_to_gib } from '@jobmon_gui/utils/formatters';
 import {
@@ -110,6 +113,19 @@ export default function TaskTemplateDetails() {
 
     const errorLogs = clusteredErrorsQuery.data?.error_logs || [];
 
+    // --- Fatal error breakdown (for resource error visibility) ---
+    const breakdownQuery = useQuery({
+        queryKey: [
+            'workflow_details',
+            'fatal_breakdown',
+            workflowId,
+            taskTemplateVersionId,
+        ],
+        queryFn: getFatalErrorBreakdownFn,
+        enabled: !!taskTemplateVersionId && !!workflowId,
+        staleTime: 120000,
+    });
+
     // --- Usage filters ---
     const {
         selectedResourceClusters,
@@ -123,6 +139,17 @@ export default function TaskTemplateDetails() {
     const [showResourceZones, setShowResourceZones] = useState(false);
     const [tableFilteredInstanceIds, setTableFilteredInstanceIds] =
         useState<Set<number> | null>(null);
+
+    // --- Resource section collapse (persisted to localStorage) ---
+    const [resourceSectionExpanded, setResourceSectionExpanded] = useState(
+        () => localStorage.getItem('jobmon_resourceSectionExpanded') === 'true'
+    );
+    useEffect(() => {
+        localStorage.setItem(
+            'jobmon_resourceSectionExpanded',
+            String(resourceSectionExpanded)
+        );
+    }, [resourceSectionExpanded]);
 
     // --- Helper: resource cluster filter predicate ---
     const passesResourceClusterFilter = useCallback(
@@ -561,120 +588,40 @@ export default function TaskTemplateDetails() {
                 </Box>
             </Box>
 
-            {/* --- SECTION A: Analytics (sidebar + main) --- */}
+            {/* --- SECTION A: Errors (full width, prominent) --- */}
+            <Box sx={{ px: 1, mt: 1 }}>
+                <ErrorClustersCard
+                    layout="fullwidth"
+                    errorLogs={errorLogsForCard}
+                    isLoading={clusteredErrorsQuery.isLoading}
+                    workflowId={workflowId}
+                    taskTemplateId={
+                        TaskTemplateDetailsData.data.task_template_id
+                    }
+                    selectedInstanceIds={selectedInstanceIds}
+                    scatterInstanceIds={scatterInstanceIds}
+                    onFilterByInstanceIds={handleErrorFilterByInstanceIds}
+                    resourceErrorBreakdown={breakdownQuery.data}
+                />
+            </Box>
 
-            {usageIsLoading ? (
-                <Box
-                    sx={{
-                        display: 'flex',
-                        flexDirection: { xs: 'column', md: 'row' },
-                        px: 1,
-                        gap: 1,
-                    }}
-                >
-                    <Box
-                        sx={{
-                            flex: {
-                                xs: '1 1 auto',
-                                md: '0 0 280px',
-                            },
-                            maxWidth: { md: 280 },
-                            minWidth: 0,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 1,
-                        }}
-                    >
-                        <Skeleton variant="rectangular" height={150} />
-                        <Skeleton variant="rectangular" height={150} />
-                        <Skeleton variant="rectangular" height={200} />
-                    </Box>
-                    <Box sx={{ flex: '1 1 0', minWidth: 0 }}>
-                        <Skeleton variant="rectangular" height={500} />
-                    </Box>
-                </Box>
-            ) : (
-                <Box
-                    sx={{
-                        display: 'flex',
-                        flexDirection: {
-                            xs: 'column',
-                            md: 'row',
-                        },
-                        px: 1,
-                        gap: 1,
-                    }}
-                >
-                    {/* Sidebar */}
-                    <Box
-                        sx={{
-                            flex: {
-                                xs: '1 1 auto',
-                                md: '0 0 280px',
-                            },
-                            maxWidth: { md: 280 },
-                            minWidth: 0,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 1,
-                        }}
-                    >
-                        <UsageKPICards
-                            layout={isMdUp ? 'vertical' : 'horizontal'}
-                            kpiStats={kpiStats}
+            {/* --- SECTION B: Resource Profiling (summary bar + collapsible detail) --- */}
+            <Box sx={{ px: 1, mt: 1 }}>
+                {usageIsLoading ? (
+                    <Skeleton
+                        variant="rectangular"
+                        height={48}
+                        sx={{ borderRadius: 2 }}
+                    />
+                ) : (
+                    <>
+                        <ResourceSummaryBar
                             resourceEfficiency={resourceEfficiency}
-                            selectedDataCount={
-                                selectedData.length > 0
-                                    ? selectedData.length
-                                    : undefined
+                            expanded={resourceSectionExpanded}
+                            onToggleExpanded={() =>
+                                setResourceSectionExpanded(prev => !prev)
                             }
-                            totalDataCount={effectiveScatterData.length}
-                        />
-                        <ErrorClustersCard
-                            errorLogs={errorLogsForCard}
-                            isLoading={clusteredErrorsQuery.isLoading}
-                            workflowId={workflowId}
-                            taskTemplateId={
-                                TaskTemplateDetailsData.data.task_template_id
-                            }
-                            selectedInstanceIds={selectedInstanceIds}
-                            scatterInstanceIds={scatterInstanceIds}
-                            onFilterByInstanceIds={
-                                handleErrorFilterByInstanceIds
-                            }
-                            maxListHeight={isMdUp ? 400 : 180}
-                        />
-                    </Box>
-
-                    {/* Main content */}
-                    <Box
-                        sx={{
-                            flex: '1 1 0',
-                            minWidth: 0,
-                            display: 'flex',
-                            flexDirection: 'column',
-                        }}
-                    >
-                        <UsagePlotSection
-                            isLoading={usageInfo.isLoading}
-                            filteredScatterData={effectiveScatterData}
-                            taskTemplateName={taskTemplateName || ''}
-                            medianRequestedRuntime={
-                                medianRequestedRuntimeForKPI
-                            }
-                            medianRequestedMemoryGiB={
-                                medianRequestedMemoryGiBForKPI
-                            }
-                            showResourceZones={showResourceZones}
-                            selectedInstanceIds={selectedInstanceIds}
-                            onTaskClick={handleScatterTaskClick}
-                            onSelected={handleDataSelection}
-                            onShowResourceZonesChange={setShowResourceZones}
-                            onDownloadCSV={downloadCSV}
-                            hasData={
-                                rawTaskNodesFromApi &&
-                                rawTaskNodesFromApi.length > 0
-                            }
+                            selectedDataCount={selectedData.length}
                             availableResourceClusters={
                                 availableResourceClusters
                             }
@@ -685,12 +632,92 @@ export default function TaskTemplateDetails() {
                             onResetFilters={resetFilters}
                             hasActiveSelection={selectedData.length > 0}
                             onClearSelection={handleClearSelection}
+                            hasData={
+                                rawTaskNodesFromApi != null &&
+                                rawTaskNodesFromApi.length > 0
+                            }
                         />
-                    </Box>
-                </Box>
-            )}
+                        <Collapse in={resourceSectionExpanded}>
+                            <Box
+                                sx={{
+                                    display: 'flex',
+                                    flexDirection: {
+                                        xs: 'column',
+                                        md: 'row',
+                                    },
+                                    gap: 1,
+                                    mt: 1,
+                                }}
+                            >
+                                <Box
+                                    sx={{
+                                        flex: {
+                                            xs: '1 1 auto',
+                                            md: '0 0 320px',
+                                        },
+                                        maxWidth: { md: 320 },
+                                        minWidth: 0,
+                                    }}
+                                >
+                                    <UsageKPICards
+                                        layout={
+                                            isMdUp ? 'vertical' : 'horizontal'
+                                        }
+                                        kpiStats={kpiStats}
+                                        resourceEfficiency={resourceEfficiency}
+                                        selectedDataCount={
+                                            selectedData.length > 0
+                                                ? selectedData.length
+                                                : undefined
+                                        }
+                                        totalDataCount={
+                                            effectiveScatterData.length
+                                        }
+                                    />
+                                </Box>
+                                <Box
+                                    sx={{
+                                        flex: '1 1 0',
+                                        minWidth: 0,
+                                    }}
+                                >
+                                    <UsagePlotSection
+                                        isLoading={usageInfo.isLoading}
+                                        filteredScatterData={
+                                            effectiveScatterData
+                                        }
+                                        taskTemplateName={
+                                            taskTemplateName || ''
+                                        }
+                                        medianRequestedRuntime={
+                                            medianRequestedRuntimeForKPI
+                                        }
+                                        medianRequestedMemoryGiB={
+                                            medianRequestedMemoryGiBForKPI
+                                        }
+                                        showResourceZones={showResourceZones}
+                                        selectedInstanceIds={
+                                            selectedInstanceIds
+                                        }
+                                        onTaskClick={handleScatterTaskClick}
+                                        onSelected={handleDataSelection}
+                                        onShowResourceZonesChange={
+                                            setShowResourceZones
+                                        }
+                                        onDownloadCSV={downloadCSV}
+                                        hasData={
+                                            rawTaskNodesFromApi != null &&
+                                            rawTaskNodesFromApi.length > 0
+                                        }
+                                    />
+                                </Box>
+                            </Box>
+                        </Collapse>
+                    </>
+                )}
+            </Box>
 
-            {/* Task Table (full width, below both columns) */}
+            {/* --- SECTION C: Task Table (full width) --- */}
             <Box sx={{ mt: 1 }}>
                 <TaskTable
                     data={tableData}

--- a/jobmon_gui/src/screens/WorkflowDetails.tsx
+++ b/jobmon_gui/src/screens/WorkflowDetails.tsx
@@ -32,7 +32,6 @@ import { getWorkflowTTStatusQueryFn } from '@jobmon_gui/queries/GetWorkflowTTSta
 import { getWorkflowDetailsQueryFn } from '@jobmon_gui/queries/GetWorkflowDetails.ts';
 import { getWorkflowUsageQueryFn } from '@jobmon_gui/queries/GetWorkflowUsage.ts';
 import { getClusteredErrorsFn } from '@jobmon_gui/queries/GetClusteredErrors.ts';
-import { getWorkflowHasResourceErrorsFn } from '@jobmon_gui/queries/GetWorkflowHasResourceErrors.ts';
 import {
     AppBreadcrumbs,
     BreadcrumbItem,
@@ -123,17 +122,13 @@ function WorkflowDetails() {
         refetchOnMount: true,
     });
 
+    const latestWfrId = wfDetails.data?.wfr_id ?? null;
+
     const wfTTStatus = useQuery({
-        queryKey: ['workflow_details', 'tt_status', workflowId],
+        queryKey: ['workflow_details', 'tt_status', workflowId, latestWfrId],
         queryFn: getWorkflowTTStatusQueryFn,
         refetchOnMount: true,
         refetchOnWindowFocus: true,
-    });
-
-    const hasResourceErrorsQuery = useQuery({
-        queryKey: ['workflow_details', 'has_resource_errors', workflowId],
-        queryFn: getWorkflowHasResourceErrorsFn,
-        staleTime: 120000,
     });
 
     const ttStatusByName = useMemo(() => {
@@ -260,6 +255,7 @@ function WorkflowDetails() {
             onBack={handleTemplateBack}
             onNavigate={() => resetStoresAndNavigate(selectedTemplateData.id)}
             disabled={disabled}
+            workflowRunId={latestWfrId}
         />
     ) : leftPanelView === 'manage' ? (
         <WorkflowManagePanel
@@ -270,12 +266,8 @@ function WorkflowDetails() {
         />
     ) : (
         <TemplateListPanel
-            workflowId={workflowId!}
             ttData={wfTTStatus.data}
             hoveredTemplateName={hoveredTemplateName}
-            hasResourceErrors={
-                hasResourceErrorsQuery.data?.has_resource_errors ?? false
-            }
             onTemplateSelect={handleTemplateSelect}
             onTemplateHover={setHoveredTemplateName}
             onPrefetch={prefetchTemplateData}

--- a/jobmon_gui/src/stores/TaskTable.ts
+++ b/jobmon_gui/src/stores/TaskTable.ts
@@ -162,10 +162,16 @@ export const useTaskTableStore = create<TaskTableStore>()(
         }),
         {
             name: 'TaskTable',
+            version: 1,
             storage: taskTableStorage,
+            migrate: (persisted: unknown) => {
+                const state = persisted as Record<string, unknown>;
+                delete state.filters;
+                // zustand merges this partial with store defaults
+                return state as Partial<TaskTableStore>;
+            },
             partialize: state => ({
                 maxRows: state.maxRows,
-                filters: state.filters,
                 sorting: state.sorting,
                 columnOrder: state.columnOrder,
                 pagination: state.pagination,

--- a/jobmon_gui/src/types/TaskInstance.ts
+++ b/jobmon_gui/src/types/TaskInstance.ts
@@ -16,6 +16,7 @@ export type TaskInstance = {
     ti_queue_name: string | null;
     ti_cpu: string | null;
     ti_io: string | null;
+    ti_workflow_run_id: number | null;
 };
 
 export type TypeInstanceResponse = {

--- a/jobmon_gui/src/types/TaskTable.ts
+++ b/jobmon_gui/src/types/TaskTable.ts
@@ -12,6 +12,7 @@ export type TaskInstanceRow = {
     task_status_date: dayjs.Dayjs;
     runtime_seconds: number | null;
     memory_gib: number | null;
+    workflow_run_id: number | null;
 };
 
 export type TaskTableProps = {
@@ -20,4 +21,9 @@ export type TaskTableProps = {
     workflowId: number | string;
     taskTemplateName: string;
     onFilteredInstanceIdsChange?: (ids: Set<number> | null) => void;
+    showLatestOnly: boolean;
+    onShowLatestOnlyChange: (value: boolean) => void;
+    selectedWorkflowRunId: number | null;
+    availableWorkflowRunIds: number[];
+    onSelectedWorkflowRunIdChange: (id: number | null) => void;
 };

--- a/jobmon_gui/src/types/TaskTemplateStatus.ts
+++ b/jobmon_gui/src/types/TaskTemplateStatus.ts
@@ -12,6 +12,7 @@ export type TTStatus = {
     num_attempts_min: number;
     task_template_version_id: number;
     tasks: number;
+    resource_error_count: number;
 };
 
 export type TTStatusResponse = Record<number | string, TTStatus>;

--- a/jobmon_gui/src/types/WorkflowDetails.ts
+++ b/jobmon_gui/src/types/WorkflowDetails.ts
@@ -9,5 +9,6 @@ export type WorkflowDetails = {
     wfr_jobmon_version: string;
     wfr_heartbeat_date: string;
     wfr_user: string;
+    wfr_id: number;
 };
 export type WorkflowDetailsResponse = WorkflowDetails[];

--- a/jobmon_gui/src/types/apiSchema.ts
+++ b/jobmon_gui/src/types/apiSchema.ts
@@ -1240,6 +1240,10 @@ export interface paths {
         /**
          * Task Template Dag
          * @description Compute the shape of a Workflow's DAG by TaskTemplate.
+         *
+         *     Templates whose nodes span multiple pipeline stages are split into
+         *     numbered phases so the resulting graph stays acyclic and faithfully
+         *     represents the execution order.
          */
         get: operations['task_template_dag_api_v3_workflow__workflow_id__task_template_dag_get'];
         put?: never;
@@ -1928,6 +1932,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    '/api/v3/workflow_has_resource_errors/{workflow_id}': {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Workflow Has Resource Errors
+         * @description Check if any task instances in this workflow have resource errors.
+         */
+        get: operations['get_workflow_has_resource_errors_api_v3_workflow_has_resource_errors__workflow_id__get'];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    '/api/v3/fatal_error_breakdown/{workflow_id}/{tt_version_id}': {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Fatal Error Breakdown
+         * @description Classify fatal errors for one template by type.
+         */
+        get: operations['get_fatal_error_breakdown_api_v3_fatal_error_breakdown__workflow_id___tt_version_id__get'];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     '/api/v3/tt_error_log_viz/{wf_id}/{tt_id}/{ti_id}': {
         parameters: {
             query?: never;
@@ -2289,6 +2333,42 @@ export interface components {
             };
         };
         /**
+         * FatalErrorBreakdownResponse
+         * @description Breakdown of fatal errors by type for a single template.
+         */
+        FatalErrorBreakdownResponse: {
+            /**
+             * Resource
+             * @default 0
+             */
+            resource: number;
+            /**
+             * App
+             * @default 0
+             */
+            app: number;
+            /**
+             * Infra
+             * @default 0
+             */
+            infra: number;
+            /**
+             * Resource Error Total
+             * @default 0
+             */
+            resource_error_total: number;
+            /**
+             * Resource Error Retried
+             * @default 0
+             */
+            resource_error_retried: number;
+            /**
+             * Resource Error Ti Ids
+             * @default []
+             */
+            resource_error_ti_ids: number[];
+        };
+        /**
          * FormattedStats
          * @description Formatted statistics for legacy client compatibility.
          */
@@ -2442,6 +2522,8 @@ export interface components {
             ti_cpu: string | null;
             /** Ti Io */
             ti_io: string | null;
+            /** Ti Workflow Run Id */
+            ti_workflow_run_id?: number | null;
         };
         /**
          * TaskInstanceDetailsResponse
@@ -2491,6 +2573,8 @@ export interface components {
             task_num_attempts?: number | null;
             /** Task Max Attempts */
             task_max_attempts?: number | null;
+            /** Workflow Run Id */
+            workflow_run_id?: number | null;
         };
         /**
          * TaskStatusAuditRecord
@@ -2672,6 +2756,10 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
+            /** Input */
+            input?: unknown;
+            /** Context */
+            ctx?: Record<string, never>;
         };
         /**
          * WorkflowDetailsItem
@@ -2698,6 +2786,8 @@ export interface components {
             wfr_heartbeat_date: string | null;
             /** Wfr User */
             wfr_user: string;
+            /** Wfr Id */
+            wfr_id?: number | null;
         };
         /**
          * WorkflowOverviewItem
@@ -2753,6 +2843,14 @@ export interface components {
         WorkflowOverviewResponse: {
             /** Workflows */
             workflows: components['schemas']['WorkflowOverviewItem'][];
+        };
+        /**
+         * WorkflowResourceErrorCheckResponse
+         * @description Response for checking if a workflow has any resource errors.
+         */
+        WorkflowResourceErrorCheckResponse: {
+            /** Has Resource Errors */
+            has_resource_errors: boolean;
         };
         /**
          * WorkflowRunForResetResponse
@@ -5340,7 +5438,9 @@ export interface operations {
     };
     get_workflow_tt_status_viz_api_v3_workflow_tt_status_viz__workflow_id__get: {
         parameters: {
-            query?: never;
+            query?: {
+                workflow_run_id?: number | null;
+            };
             header?: never;
             path: {
                 workflow_id: number;
@@ -5369,6 +5469,71 @@ export interface operations {
             };
         };
     };
+    get_workflow_has_resource_errors_api_v3_workflow_has_resource_errors__workflow_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['WorkflowResourceErrorCheckResponse'];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['HTTPValidationError'];
+                };
+            };
+        };
+    };
+    get_fatal_error_breakdown_api_v3_fatal_error_breakdown__workflow_id___tt_version_id__get: {
+        parameters: {
+            query?: {
+                workflow_run_id?: number | null;
+            };
+            header?: never;
+            path: {
+                workflow_id: number;
+                tt_version_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['FatalErrorBreakdownResponse'];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['HTTPValidationError'];
+                };
+            };
+        };
+    };
     get_tt_error_log_viz_api_v3_tt_error_log_viz__wf_id___tt_id___ti_id__get: {
         parameters: {
             query?: {
@@ -5376,6 +5541,7 @@ export interface operations {
                 page_size?: number;
                 just_recent_errors?: string;
                 cluster_errors?: string;
+                workflow_run_id?: number | null;
             };
             header?: never;
             path: {
@@ -5415,6 +5581,7 @@ export interface operations {
                 page_size?: number;
                 just_recent_errors?: string;
                 cluster_errors?: string;
+                workflow_run_id?: number | null;
             };
             header?: never;
             path: {

--- a/jobmon_server/src/jobmon/server/web/repositories/task_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_repository.py
@@ -680,6 +680,7 @@ class TaskRepository:
                 Queue.name,
                 TaskInstance.cpu,
                 TaskInstance.io,
+                TaskInstance.workflow_run_id,
             )
             .outerjoin_from(
                 TaskInstance,
@@ -725,6 +726,7 @@ class TaskRepository:
                 ti_queue_name=row[14],
                 ti_cpu=row[15],
                 ti_io=row[16],
+                ti_workflow_run_id=row[17],
             )
             for row in rows
         ]

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -94,6 +94,7 @@ class TaskTemplateRepository:
                 task_command=row_data.get("task_command"),
                 task_num_attempts=row_data.get("task_num_attempts"),
                 task_max_attempts=row_data.get("task_max_attempts"),
+                workflow_run_id=row_data.get("workflow_run_id"),
             )
         except Exception as e:
             logger.error(
@@ -151,8 +152,8 @@ class TaskTemplateRepository:
                     # Requested resources and attempt number
                     TaskResources.requested_resources.label("requested_resources_col"),
                     attempt_number_col,
-                    # TaskInstance.id (not used but kept for consistency)
                     TaskInstance.id.label("task_instance_id_col"),
+                    TaskInstance.workflow_run_id.label("workflow_run_id_col"),
                 )
                 .select_from(TaskTemplateVersion)
                 .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
@@ -182,6 +183,7 @@ class TaskTemplateRepository:
                     "task_num_attempts": row[8],  # task_num_attempts_col
                     "task_max_attempts": row[9],  # task_max_attempts_col
                     "task_instance_id": row[12],  # task_instance_id_col
+                    "workflow_run_id": row[13],  # workflow_run_id_col
                 }
                 item = self._convert_to_task_resource_detail_item(row_data)
                 if item:
@@ -223,6 +225,7 @@ class TaskTemplateRepository:
                 Task.num_attempts.label("task_num_attempts"),
                 Task.max_attempts.label("task_max_attempts"),
                 TaskInstance.id.label("task_instance_id"),
+                TaskInstance.workflow_run_id,
             )
             .select_from(TaskTemplateVersion)
             .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
@@ -265,6 +268,7 @@ class TaskTemplateRepository:
             base_query.c.task_num_attempts,
             base_query.c.task_max_attempts,
             base_query.c.task_instance_id,
+            base_query.c.workflow_run_id,
         ).select_from(base_query)
 
         for subquery in node_arg_subqueries:
@@ -290,6 +294,7 @@ class TaskTemplateRepository:
                 "task_num_attempts": row[10],  # task_num_attempts
                 "task_max_attempts": row[11],  # task_max_attempts
                 "task_instance_id": row[12],  # task_instance_id
+                "workflow_run_id": row[13],  # workflow_run_id
             }
             item = self._convert_to_task_resource_detail_item(row_data)
             if item:
@@ -718,7 +723,10 @@ class TaskTemplateRepository:
         return MostPopularQueueResponse(queue_info=queue_info)
 
     def get_workflow_tt_status_viz(
-        self, workflow_id: int, dialect: str = "sqlite"
+        self,
+        workflow_id: int,
+        dialect: str = "sqlite",
+        workflow_run_id: Optional[int] = None,
     ) -> Dict[int, WorkflowTaskTemplateStatusItem]:
         """Get the status of workflow task templates for GUI visualization.
 
@@ -765,14 +773,30 @@ class TaskTemplateRepository:
             )
         )
 
-        # Single optimized query with SQL aggregation instead of two separate queries
+        # Pre-aggregated resource error counts per task (avoids
+        # correlated subquery that fires per-row at scale)
+        re_filters = [
+            TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
+        ]
+        if workflow_run_id is not None:
+            re_filters.append(TaskInstance.workflow_run_id == workflow_run_id)
+        resource_error_agg = (
+            select(
+                TaskInstance.task_id,
+                func.count(TaskInstance.id).label("re_count"),
+            )
+            .where(*re_filters)
+            .group_by(TaskInstance.task_id)
+            .subquery()
+        )
+
+        # Single optimized query with SQL aggregation
         optimized_sql = (
             select(
                 TaskTemplate.id.label("task_template_id"),
                 TaskTemplate.name.label("task_template_name"),
                 TaskTemplateVersion.id.label("task_template_version_id"),
                 sub_query.c.max_concurrently_running,
-                # SQL aggregation instead of Python loops - much faster
                 func.count(Task.id).label("total_tasks"),
                 func.sum(case((Task.status == "G", 1), else_=0)).label("pending_count"),
                 func.sum(
@@ -789,12 +813,15 @@ class TaskTemplateRepository:
                 func.sum(case((Task.status == "R", 1), else_=0)).label("running_count"),
                 func.sum(case((Task.status == "D", 1), else_=0)).label("done_count"),
                 func.sum(case((Task.status == "F", 1), else_=0)).label("fatal_count"),
-                # Attempt statistics in same query - no second database round-trip
+                func.coalesce(func.sum(resource_error_agg.c.re_count), 0).label(
+                    "resource_error_count"
+                ),
                 func.min(Task.num_attempts).label("min_attempts"),
                 func.max(Task.num_attempts).label("max_attempts"),
                 func.avg(Task.num_attempts).label("avg_attempts"),
             )
             .select_from(join_table)
+            .outerjoin(resource_error_agg, resource_error_agg.c.task_id == Task.id)
             .where(Task.workflow_id == workflow_id)
             .group_by(
                 TaskTemplate.id,
@@ -845,6 +872,7 @@ class TaskTemplateRepository:
                     else None
                 ),
                 task_template_version_id=row.task_template_version_id,
+                resource_error_count=row.resource_error_count,
             )
 
         return result_dict
@@ -853,6 +881,7 @@ class TaskTemplateRepository:
         self,
         workflow_id: int,
         task_template_version_id: int,
+        workflow_run_id: Optional[int] = None,
     ) -> FatalErrorBreakdownResponse:
         """Classify fatal tasks for one template by last TI status.
 
@@ -897,30 +926,27 @@ class TaskTemplateRepository:
             else:
                 infra += row.cnt
 
+        z_filters = [
+            Task.workflow_id == workflow_id,
+            Node.task_template_version_id == task_template_version_id,
+            TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
+        ]
+        if workflow_run_id is not None:
+            z_filters.append(TaskInstance.workflow_run_id == workflow_run_id)
+
         z_count_sql = (
             select(func.count(TaskInstance.id))
             .join(Task, TaskInstance.task_id == Task.id)
             .join(Node, Task.node_id == Node.id)
-            .where(
-                Task.workflow_id == workflow_id,
-                Node.task_template_version_id == task_template_version_id,
-                TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
-            )
+            .where(*z_filters)
         )
         resource_error_total = self.session.execute(z_count_sql).scalar() or 0
 
-        # Count tasks that had a resource error TI but recovered
-        # (task is not in ERROR_FATAL state).
         retried_sql = (
             select(func.count(func.distinct(Task.id)))
             .join(TaskInstance, TaskInstance.task_id == Task.id)
             .join(Node, Task.node_id == Node.id)
-            .where(
-                Task.workflow_id == workflow_id,
-                Node.task_template_version_id == task_template_version_id,
-                TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
-                Task.status != TaskStatus.ERROR_FATAL,
-            )
+            .where(*z_filters, Task.status != TaskStatus.ERROR_FATAL)
         )
         resource_error_retried = self.session.execute(retried_sql).scalar() or 0
 
@@ -930,11 +956,7 @@ class TaskTemplateRepository:
                 select(TaskInstance.id)
                 .join(Task, TaskInstance.task_id == Task.id)
                 .join(Node, Task.node_id == Node.id)
-                .where(
-                    Task.workflow_id == workflow_id,
-                    Node.task_template_version_id == task_template_version_id,
-                    TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
-                )
+                .where(*z_filters)
                 .order_by(TaskInstance.id.desc())
                 .limit(20)
             )
@@ -960,6 +982,7 @@ class TaskTemplateRepository:
         page_size: int = 10,
         recent_errors_only: bool = False,
         cluster_errors: bool = False,
+        workflow_run_id: Optional[int] = None,
     ) -> ErrorLogResponse:
         """Get error logs for a task template ID for GUI visualization.
 
@@ -1086,13 +1109,14 @@ class TaskTemplateRepository:
                 page_size=page_size,
             )
 
-        # recent_error_only case, we should know the wfr id
-        if recent_errors_only:
-            workflow_run_id = self.session.execute(
-                select(func.max(WorkflowRun.id)).where(
-                    WorkflowRun.workflow_id == workflow_id
-                )
-            ).scalar_one()
+        # Scope to a specific workflow run (explicit or latest)
+        if recent_errors_only or workflow_run_id is not None:
+            if workflow_run_id is None:
+                workflow_run_id = self.session.execute(
+                    select(func.max(WorkflowRun.id)).where(
+                        WorkflowRun.workflow_id == workflow_id
+                    )
+                ).scalar_one()
 
             if workflow_run_id is None:
                 return ErrorLogResponse(
@@ -1175,6 +1199,17 @@ class TaskTemplateRepository:
                 Original count query: 3 min 13.148 sec;
                 New combined query: 0.021 sec
             """
+            wfr_filters = [
+                TaskInstance.workflow_run_id == workflow_run_id,
+                Node.task_template_version_id == ttv_id,
+            ]
+            # recent_errors_only: diagnostic view — show all errors
+            # from the run regardless of current task status.
+            # Explicit workflow_run_id (from workflow details page):
+            # only show errors for tasks still in fatal state,
+            # since resolved errors are noise in the current-state view.
+            if not recent_errors_only:
+                wfr_filters.append(Task.status == TaskStatus.ERROR_FATAL)
             query = (
                 select(
                     func.max(TaskInstanceErrorLog.id).label("ttel_id"),
@@ -1187,10 +1222,7 @@ class TaskTemplateRepository:
                 )
                 .join_from(TaskInstance, Task, TaskInstance.task_id == Task.id)
                 .join_from(Task, Node, Task.node_id == Node.id)
-                .where(
-                    TaskInstance.workflow_run_id == workflow_run_id,
-                    Node.task_template_version_id == ttv_id,
-                )
+                .where(*wfr_filters)
                 .group_by(Task.id)
                 .order_by("ttel_id")
             )

--- a/jobmon_server/src/jobmon/server/web/repositories/workflow_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/workflow_repository.py
@@ -697,7 +697,7 @@ class WorkflowRepository:
         """Fetch name, args, dates, tool for a Workflow provided WF ID."""
         latest_workflow_run_subquery = (
             self.session.query(
-                WorkflowRun.workflow_id, func.max(WorkflowRun.heartbeat_date)
+                WorkflowRun.workflow_id, func.max(WorkflowRun.id).label("max_wfr_id")
             )
             .group_by(WorkflowRun.workflow_id)
             .subquery()
@@ -715,14 +715,19 @@ class WorkflowRepository:
                 WorkflowRun.jobmon_version,
                 WorkflowRun.heartbeat_date,
                 WorkflowRun.user,
+                WorkflowRun.id.label("wfr_id"),
             )
             .select_from(Workflow)
             .join(ToolVersion, Workflow.tool_version_id == ToolVersion.id)
             .join(Tool, ToolVersion.tool_id == Tool.id)
             .join(WorkflowStatus, WorkflowStatus.id == Workflow.status)
-            .join(WorkflowRun, WorkflowRun.workflow_id == Workflow.id)
             .join(
                 latest_workflow_run_subquery,
+                latest_workflow_run_subquery.c.workflow_id == Workflow.id,
+            )
+            .join(
+                WorkflowRun,
+                WorkflowRun.id == latest_workflow_run_subquery.c.max_wfr_id,
             )
             .where(
                 Workflow.id == workflow_id,
@@ -741,6 +746,7 @@ class WorkflowRepository:
             "wfr_jobmon_version",
             "wfr_heartbeat_date",
             "wfr_user",
+            "wfr_id",
         )
 
         result = [dict(zip(column_names, row)) for row in rows]

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
@@ -5,14 +5,16 @@ from typing import Any, Optional
 
 import structlog
 from fastapi import Depends, HTTPException, Query
-from sqlalchemy import exists, select
+from sqlalchemy import and_, exists, select
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
 
 from jobmon.server.web.db import get_db, get_dialect
+from jobmon.server.web.models.node import Node
 from jobmon.server.web.models.task import Task
 from jobmon.server.web.models.task_instance import TaskInstance
 from jobmon.server.web.models.task_instance_status import TaskInstanceStatus
+from jobmon.server.web.models.task_template_version import TaskTemplateVersion
 from jobmon.server.web.repositories.task_template_repository import (
     TaskTemplateRepository,
 )
@@ -136,7 +138,7 @@ async def get_task_template_resource_usage(
 
         # Prepare viz data if requested
         viz_data = None
-        if request_data.viz and task_details:
+        if request_data.viz:
             viz_data = []
             for detail_item in task_details:
                 viz_data.append(
@@ -154,6 +156,55 @@ async def get_task_template_resource_usage(
                         task_command=detail_item.task_command,
                         task_num_attempts=detail_item.task_num_attempts,
                         task_max_attempts=detail_item.task_max_attempts,
+                    )
+                )
+
+            # Include tasks without qualifying instances
+            # (Registered, Queued, Running — not yet terminal).
+            # Uses a subquery anti-join instead of literal NOT IN
+            # to avoid SQLite's 999-parameter limit.
+            instance_subq = select(TaskInstance.task_id).where(
+                TaskInstance.task_id == Task.id,
+                TaskInstance.status.in_(
+                    [
+                        TaskInstanceStatus.DONE,
+                        TaskInstanceStatus.RESOURCE_ERROR,
+                        TaskInstanceStatus.NO_HEARTBEAT,
+                        TaskInstanceStatus.UNKNOWN_ERROR,
+                        TaskInstanceStatus.ERROR_FATAL,
+                        TaskInstanceStatus.ERROR,
+                    ]
+                ),
+            )
+            task_filters = [
+                TaskTemplateVersion.id == request_data.task_template_version_id,
+                Node.task_template_version_id == TaskTemplateVersion.id,
+                Task.node_id == Node.id,
+                ~exists(instance_subq),
+            ]
+            if request_data.workflows:
+                task_filters.append(Task.workflow_id.in_(request_data.workflows))
+            remaining_tasks_query = select(
+                Task.id,
+                Task.name,
+                Task.status,
+                Task.command,
+                Task.num_attempts,
+                Task.max_attempts,
+                Task.status_date,
+                Node.id.label("node_id"),
+            ).where(and_(*task_filters))
+            for row in db.execute(remaining_tasks_query).all():
+                viz_data.append(
+                    TaskResourceVizItem(
+                        node_id=row[7],
+                        task_id=row[0],
+                        task_name=row[1],
+                        status=row[2],
+                        task_command=row[3],
+                        task_num_attempts=row[4],
+                        task_max_attempts=row[5],
+                        task_status_date=row[6],
                     )
                 )
 

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
@@ -156,6 +156,7 @@ async def get_task_template_resource_usage(
                         task_command=detail_item.task_command,
                         task_num_attempts=detail_item.task_num_attempts,
                         task_max_attempts=detail_item.task_max_attempts,
+                        workflow_run_id=detail_item.workflow_run_id,
                     )
                 )
 
@@ -235,13 +236,16 @@ async def get_task_template_resource_usage(
 @api_v3_router.get("/workflow_tt_status_viz/{workflow_id}")
 def get_workflow_tt_status_viz(
     workflow_id: int,
+    workflow_run_id: Optional[int] = None,
     db: Session = Depends(get_db),
     dialect: str = Depends(get_dialect),
 ) -> Any:
     """Get the status of the workflows for GUI."""
     tt_repo = TaskTemplateRepository(db)
     result_dict = tt_repo.get_workflow_tt_status_viz(
-        workflow_id=workflow_id, dialect=dialect
+        workflow_id=workflow_id,
+        dialect=dialect,
+        workflow_run_id=workflow_run_id,
     )
 
     # Convert Pydantic models back to serializable dict format for JSONResponse
@@ -280,6 +284,7 @@ def get_workflow_has_resource_errors(
 def get_fatal_error_breakdown(
     workflow_id: int,
     tt_version_id: int,
+    workflow_run_id: Optional[int] = None,
     db: Session = Depends(get_db),
 ) -> FatalErrorBreakdownResponse:
     """Classify fatal errors for one template by type."""
@@ -287,6 +292,7 @@ def get_fatal_error_breakdown(
     return tt_repo.get_fatal_error_breakdown_for_tt(
         workflow_id=workflow_id,
         task_template_version_id=tt_version_id,
+        workflow_run_id=workflow_run_id,
     )
 
 
@@ -300,6 +306,7 @@ def get_tt_error_log_viz(
     page_size: int = 10,
     just_recent_errors: str = "false",
     cluster_errors: str = "false",
+    workflow_run_id: Optional[int] = None,
     db: Session = Depends(get_db),
 ) -> Any:
     """Get the error logs for a task template id for GUI."""
@@ -318,6 +325,7 @@ def get_tt_error_log_viz(
         page_size=page_size,
         recent_errors_only=recent_errors,
         cluster_errors=output_clustered_errors,
+        workflow_run_id=workflow_run_id,
     )
 
     return result

--- a/jobmon_server/src/jobmon/server/web/schemas/task.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task.py
@@ -114,6 +114,7 @@ class TaskInstanceDetailItem(BaseModel):
     ti_queue_name: Optional[str]
     ti_cpu: Optional[str]
     ti_io: Optional[str]
+    ti_workflow_run_id: Optional[int] = None
 
 
 class TaskInstanceDetailsResponse(BaseModel):

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -34,6 +34,7 @@ class TaskResourceDetailItem(BaseModel):
     task_command: Optional[str] = None
     task_num_attempts: Optional[int] = None
     task_max_attempts: Optional[int] = None
+    workflow_run_id: Optional[int] = None
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -51,6 +52,7 @@ class TaskResourceVizItem(BaseModel):
     task_command: Optional[str] = None
     task_num_attempts: Optional[int] = None
     task_max_attempts: Optional[int] = None
+    workflow_run_id: Optional[int] = None
 
 
 class FormattedStats(BaseModel):
@@ -175,6 +177,7 @@ class WorkflowTaskTemplateStatusItem(BaseModel):
     num_attempts_max: Optional[float]
     num_attempts_avg: Optional[float]
     task_template_version_id: int
+    resource_error_count: int = 0
 
 
 class FatalErrorBreakdownResponse(BaseModel):

--- a/jobmon_server/src/jobmon/server/web/schemas/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/workflow.py
@@ -125,6 +125,7 @@ class WorkflowDetailsItem(BaseModel):
     wfr_jobmon_version: Optional[str]
     wfr_heartbeat_date: Optional[str]
     wfr_user: str
+    wfr_id: Optional[int] = None
 
 
 class WorkflowDetailsResponse(BaseModel):


### PR DESCRIPTION
## Summary

- **Task template details**: "Latest attempt only" toggle and workflow run dropdown filter, both propagating to scatter plot, task table, error clusters, and KPIs
- **Workflow details**: Errors and resource error counts scoped to latest workflow run; resource error chips on all template rows; unified template list with "Needs Attention" / "Other Templates" split
- **Task details**: Auto-expand failed attempts, workflow run ID in metadata, inline resource utilization bars
- **Backend**: `workflow_run_id` added to usage viz items, `resource_error_count` on per-template status (pre-aggregated subquery), optional `workflow_run_id` param on 3 endpoints, fixed latest WFR detection (`max(id)` vs `max(heartbeat_date)`)

## Test plan

- [ ] Verify "Latest attempt only" toggle shows one row per task, errors for succeeded tasks hidden
- [ ] Verify workflow run dropdown filters all components consistently
- [ ] Verify workflow details page shows no resource error chips for templates with only resolved errors
- [ ] Verify clicking a template with resource errors shows ErrorClustersCard in detail panel
- [ ] Verify task details page auto-expands latest failed attempt (not old failures for succeeded tasks)
- [ ] Verify tasks without instances (Registered/Queued) appear in task table
- [ ] Run `uv run pytest -n 10` — 927 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new filtering controls and changes when error/breakdown queries run (now gated by `workflowRunId` and resource-error counts), which could hide data or change displayed results if wiring is incorrect. Mostly front-end rendering/UX refactors with limited data-handling risk.
> 
> **Overview**
> Improves task and template detail UX by **adding workflow-run scoping and new filtering controls**, including a `Latest attempt only` toggle and a workflow run selector in the task table toolbar, plus status sorting that prioritizes error states.
> 
> Enhances task details by auto-expanding the latest failed attempt when the task is currently in an error status, adding workflow run ID to attempt metadata, and replacing the per-attempt resource comparison component with inline `LinearProgress` utilization bars (reusing exported `getBarColor`).
> 
> Refactors usage/error UI by introducing `ResourceSummaryBar`, centralizing `getEfficiencyStatus` in `usageCalculations`, updating KPI cards to use the shared status mapping, and extending `ErrorClustersCard` to support a `fullwidth` layout and show per-cluster resource-error counts via a chip. Simplifies `ResourceCard` to only show runtime/memory summary cards and moves resource-error presentation into the template error area.
> 
> Updates workflow template detail fetching to include `workflowRunId` in query keys and to enable clustered error and fatal breakdown queries when either fatal errors or resource-error counts exist (and a workflow run is selected).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3501dff99e256d014a763fed7d2b8fed35d6bf42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->