### PR TITLE
Fix resource_error_count query timeout on production MySQL

### DIFF
--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -773,10 +773,11 @@ class TaskTemplateRepository:
             )
         )
 
-        # Pre-aggregated resource error counts per task (avoids
-        # correlated subquery that fires per-row at scale)
+        # Pre-aggregated resource error counts, scoped to this
+        # workflow's tasks to avoid scanning the full TI table.
         re_filters = [
             TaskInstance.status == TaskInstanceStatus.RESOURCE_ERROR,
+            Task.workflow_id == workflow_id,
         ]
         if workflow_run_id is not None:
             re_filters.append(TaskInstance.workflow_run_id == workflow_run_id)
@@ -785,6 +786,7 @@ class TaskTemplateRepository:
                 TaskInstance.task_id,
                 func.count(TaskInstance.id).label("re_count"),
             )
+            .join(Task, TaskInstance.task_id == Task.id)
             .where(*re_filters)
             .group_by(TaskInstance.task_id)
             .subquery()


### PR DESCRIPTION
## Summary

- The pre-aggregated subquery for `resource_error_count` was scanning the entire `task_instance` table globally before joining, causing MySQL `Server has gone away` timeouts on production
- Fix: scope the subquery to the workflow's tasks by joining through `Task` and filtering by `workflow_id`

## Test plan

- [ ] Verify `/workflow_tt_status_viz/{workflow_id}` returns within timeout on production
- [ ] Verify `resource_error_count` values are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk query optimization that only changes how `resource_error_count` is aggregated; main risk is unintended count differences if the new join/filter interacts with edge cases like missing tasks or run scoping.
> 
> **Overview**
> Fixes a production MySQL timeout in `get_workflow_tt_status_viz` by **scoping the `resource_error_count` aggregation subquery to the current workflow**.
> 
> The resource-error pre-aggregation now joins `task_instance` through `task` and filters by `workflow_id` (and optionally `workflow_run_id`), avoiding a full-table scan of `task_instance` before the main query join.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fbb2a2a35c0618aa31f9720b4fdc77a8ebb4326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->