### PR TITLE
Batch resume-state with SKIP LOCKED for large workflows

### DIFF
--- a/jobmon_server/src/jobmon/server/web/migrations/versions/2025_04_01_1400-b2c3d4e5f6a7_add_audit_exited_index.py
+++ b/jobmon_server/src/jobmon/server/web/migrations/versions/2025_04_01_1400-b2c3d4e5f6a7_add_audit_exited_index.py
@@ -1,0 +1,41 @@
+"""Add (task_id, exited_at) index to task_status_audit.
+
+Speeds up the bulk audit close query in create_audit_records_bulk:
+  UPDATE task_status_audit SET exited_at = NOW()
+  WHERE task_id IN (...) AND exited_at IS NULL
+
+Safe to run on a live database — MySQL 8.0 builds secondary indexes
+online (ALGORITHM=INPLACE, LOCK=NONE) without blocking reads or writes.
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2025-04-01
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add composite index for bulk audit close queries."""
+    op.create_index(
+        "ix_task_status_audit_task_exited",
+        "task_status_audit",
+        ["task_id", "exited_at"],
+        mysql_algorithm="INPLACE",
+        mysql_lock="NONE",
+    )
+
+
+def downgrade() -> None:
+    """Remove the (task_id, exited_at) index."""
+    op.drop_index(
+        "ix_task_status_audit_task_exited",
+        table_name="task_status_audit",
+    )

--- a/jobmon_server/src/jobmon/server/web/migrations/versions/2025_04_01_1400-b2c3d4e5f6a7_add_audit_exited_index.py
+++ b/jobmon_server/src/jobmon/server/web/migrations/versions/2025_04_01_1400-b2c3d4e5f6a7_add_audit_exited_index.py
@@ -14,6 +14,7 @@ Create Date: 2025-04-01
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "b2c3d4e5f6a7"
@@ -24,13 +25,23 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Add composite index for bulk audit close queries."""
-    op.create_index(
-        "ix_task_status_audit_task_exited",
-        "task_status_audit",
-        ["task_id", "exited_at"],
-        mysql_algorithm="INPLACE",
-        mysql_lock="NONE",
-    )
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        # Online DDL: no table lock, no write blocking
+        op.execute(
+            sa.text(
+                "ALTER TABLE task_status_audit "
+                "ADD INDEX ix_task_status_audit_task_exited "
+                "(task_id, exited_at), "
+                "ALGORITHM=INPLACE, LOCK=NONE"
+            )
+        )
+    else:
+        op.create_index(
+            "ix_task_status_audit_task_exited",
+            "task_status_audit",
+            ["task_id", "exited_at"],
+        )
 
 
 def downgrade() -> None:

--- a/jobmon_server/src/jobmon/server/web/models/task_status_audit.py
+++ b/jobmon_server/src/jobmon/server/web/models/task_status_audit.py
@@ -33,4 +33,5 @@ class TaskStatusAudit(Base):
     __table_args__ = (
         Index("ix_task_status_audit_workflow_time", "workflow_id", "entered_at"),
         Index("ix_task_status_audit_task_time", "task_id", "entered_at"),
+        Index("ix_task_status_audit_task_exited", "task_id", "exited_at"),
     )

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
@@ -1,6 +1,7 @@
 """Routes for Tasks."""
 
 import json
+import time
 from http import HTTPStatus as StatusCodes
 from typing import Any, Dict, List, Set, Union, cast
 
@@ -428,8 +429,8 @@ async def set_task_resume_state(
     if not reset_if_running:
         excluded_states.append(TaskStatus.RUNNING)
 
-    # Get task IDs and their current statuses in one query (indexed on workflow_id,
-    # no IN clause needed). This avoids a second round-trip with a giant IN list.
+    # Snapshot which tasks need resetting and their current statuses
+    # (for audit records). Uses workflow_id index, no IN clause.
     tasks_to_reset = db.execute(
         select(Task.id, Task.status).where(
             Task.status.not_in(excluded_states),
@@ -438,18 +439,38 @@ async def set_task_resume_state(
     ).all()
 
     if tasks_to_reset:
-        # Reset is not a normal FSM transition — REGISTERING doesn't have valid
-        # source statuses for all states (e.g. QUEUED, LAUNCHED, ERROR_FATAL).
-        # Use direct update with audit records, batched to avoid MySQL timeouts
-        # on large workflows (10k+ tasks generate enormous IN clauses).
-        batch_size = 1000
-        for i in range(0, len(tasks_to_reset), batch_size):
-            batch = tasks_to_reset[i : i + batch_size]
-            batch_ids = [row.id for row in batch]
+        status_map = {row.id: row.status for row in tasks_to_reset}
+        pending_ids = set(status_map.keys())
+
+        # Use SKIP LOCKED to avoid blocking on rows the distributor
+        # holds mid-transition. Most rows are uncontested; the few
+        # that are locked get retried on subsequent passes.
+        batch_size = 2000
+        max_passes = 5
+        for pass_num in range(max_passes):
+            if not pending_ids:
+                break
+
+            batch_ids = list(pending_ids)[:batch_size]
+
+            # Lock available rows, skip any held by the distributor
+            locked_rows = db.execute(
+                select(Task.id)
+                .where(Task.id.in_(batch_ids))
+                .with_for_update(skip_locked=True)
+            ).all()
+            locked_ids = [r.id for r in locked_rows]
+
+            if not locked_ids:
+                # All remaining rows are locked — brief pause
+                # then retry on next pass
+                db.flush()
+                time.sleep(0.2)
+                continue
 
             db.execute(
                 update(Task)
-                .where(Task.id.in_(batch_ids))
+                .where(Task.id.in_(locked_ids))
                 .values(
                     status=TaskStatus.REGISTERING,
                     num_attempts=0,
@@ -459,15 +480,25 @@ async def set_task_resume_state(
 
             audit_records = [
                 {
-                    "task_id": row.id,
+                    "task_id": tid,
                     "workflow_id": workflow_id,
-                    "previous_status": row.status,
+                    "previous_status": status_map[tid],
                     "new_status": TaskStatus.REGISTERING,
                 }
-                for row in batch
+                for tid in locked_ids
             ]
             TransitionService.create_audit_records_bulk(
                 session=db, records=audit_records
+            )
+
+            db.flush()
+            pending_ids -= set(locked_ids)
+
+        if pending_ids:
+            logger.warning(
+                f"Resume: {len(pending_ids)} tasks still locked "
+                f"after {max_passes} passes for workflow "
+                f"{workflow_id}",
             )
 
     resp = JSONResponse(content={}, status_code=StatusCodes.OK)

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
@@ -1,7 +1,6 @@
 """Routes for Tasks."""
 
 import json
-import time
 from http import HTTPStatus as StatusCodes
 from typing import Any, Dict, List, Set, Union, cast
 
@@ -429,86 +428,66 @@ async def set_task_resume_state(
     if not reset_if_running:
         excluded_states.append(TaskStatus.RUNNING)
 
-    # Count tasks needing reset (read-only snapshot).
-    total = (
-        db.execute(
-            select(func.count(Task.id)).where(
+    # Batched commits: lock a batch → update → audit → commit.
+    # Each commit releases row locks so we never hold more than
+    # RESET_BATCH_SIZE locks at once. SKIP LOCKED avoids blocking
+    # on rows the distributor holds mid-transition. REGISTERING
+    # is in excluded_states, so already-reset tasks are skipped
+    # on re-entry (idempotent for client retries).
+    RESET_BATCH_SIZE = 5000
+    MAX_EMPTY_PASSES = 10
+    reset_count = 0
+    empty_passes = 0
+
+    while True:
+        locked_rows = db.execute(
+            select(Task.id, Task.status)
+            .where(
                 Task.workflow_id == workflow_id,
                 Task.status.not_in(excluded_states),
             )
-        ).scalar()
-        or 0
-    )
+            .with_for_update(skip_locked=True)
+            .limit(RESET_BATCH_SIZE)
+        ).all()
 
-    if total:
-        # Process in batched commits: each iteration locks a batch
-        # of tasks, updates them, writes audit records, and commits.
-        # Commit releases all row locks so we never hold more than
-        # batch_size locks at once — no timeout or distributor
-        # contention on large workflows.
-        reset_count = 0
-        batch_size = 5000
-        empty_passes = 0
-        max_empty_passes = 10
-
-        while reset_count < total:
-            # Lock a batch, skipping rows the distributor holds.
-            locked_rows = db.execute(
-                select(Task.id, Task.status)
-                .where(
-                    Task.workflow_id == workflow_id,
-                    Task.status.not_in(excluded_states),
-                )
-                .with_for_update(skip_locked=True)
-                .limit(batch_size)
-            ).all()
-
-            if not locked_rows:
-                empty_passes += 1
-                if empty_passes >= max_empty_passes:
-                    break
-                db.commit()
-                time.sleep(0.2)
-                continue
-
-            empty_passes = 0
-            locked_ids = [row.id for row in locked_rows]
-
-            db.execute(
-                update(Task)
-                .where(Task.id.in_(locked_ids))
-                .values(
-                    status=TaskStatus.REGISTERING,
-                    num_attempts=0,
-                    status_date=func.now(),
-                )
-            )
-
-            TransitionService.create_audit_records_bulk(
-                session=db,
-                records=[
-                    {
-                        "task_id": row.id,
-                        "workflow_id": workflow_id,
-                        "previous_status": row.status,
-                        "new_status": TaskStatus.REGISTERING,
-                    }
-                    for row in locked_rows
-                ],
-            )
-
-            # Commit releases locks and saves progress.
-            # If we crash here, committed batches are safe
-            # and the client retries for the remainder.
+        if not locked_rows:
+            empty_passes += 1
+            if empty_passes >= MAX_EMPTY_PASSES:
+                break
             db.commit()
-            reset_count += len(locked_ids)
+            continue
 
-        if reset_count < total:
-            logger.warning(
-                f"Resume: reset {reset_count}/{total} tasks "
-                f"for workflow {workflow_id}, "
-                f"{total - reset_count} still locked"
+        empty_passes = 0
+        locked_ids = [row.id for row in locked_rows]
+
+        db.execute(
+            update(Task)
+            .where(Task.id.in_(locked_ids))
+            .values(
+                status=TaskStatus.REGISTERING,
+                num_attempts=0,
+                status_date=func.now(),
             )
+        )
+
+        TransitionService.create_audit_records_bulk(
+            session=db,
+            records=[
+                {
+                    "task_id": row.id,
+                    "workflow_id": workflow_id,
+                    "previous_status": row.status,
+                    "new_status": TaskStatus.REGISTERING,
+                }
+                for row in locked_rows
+            ],
+        )
+
+        db.commit()
+        reset_count += len(locked_ids)
+
+    if reset_count > 0:
+        logger.info(f"Resume: reset {reset_count} tasks for " f"workflow {workflow_id}")
 
     resp = JSONResponse(content={}, status_code=StatusCodes.OK)
     return resp

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
@@ -6,7 +6,7 @@ from http import HTTPStatus as StatusCodes
 from typing import Any, Dict, List, Set, Union, cast
 
 import structlog
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, Request
 from sqlalchemy import desc, insert, select, tuple_, update
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.mysql.dml import Insert as MySQLInsert
@@ -429,100 +429,85 @@ async def set_task_resume_state(
     if not reset_if_running:
         excluded_states.append(TaskStatus.RUNNING)
 
-    # Snapshot task statuses for audit records (read-only, no lock).
-    tasks_to_reset = db.execute(
-        select(Task.id, Task.status).where(
-            Task.workflow_id == workflow_id,
-            Task.status.not_in(excluded_states),
-        )
-    ).all()
+    # Count tasks needing reset (read-only snapshot).
+    total = (
+        db.execute(
+            select(func.count(Task.id)).where(
+                Task.workflow_id == workflow_id,
+                Task.status.not_in(excluded_states),
+            )
+        ).scalar()
+        or 0
+    )
 
-    if tasks_to_reset:
-        expected_count = len(tasks_to_reset)
-        status_map = {row.id: row.status for row in tasks_to_reset}
+    if total:
+        # Process in batched commits: each iteration locks a batch
+        # of tasks, updates them, writes audit records, and commits.
+        # Commit releases all row locks so we never hold more than
+        # batch_size locks at once — no timeout or distributor
+        # contention on large workflows.
         reset_count = 0
+        batch_size = 5000
+        empty_passes = 0
+        max_empty_passes = 10
 
-        # Subquery UPDATE with SKIP LOCKED: locks and updates in one
-        # server-side statement, no 100K-ID round-trip through Python.
-        # Retries with backoff pick up rows the distributor held.
-        max_passes = 5
-        for attempt in range(max_passes):
-            locked_subq = (
-                select(Task.id)
+        while reset_count < total:
+            # Lock a batch, skipping rows the distributor holds.
+            locked_rows = db.execute(
+                select(Task.id, Task.status)
                 .where(
                     Task.workflow_id == workflow_id,
                     Task.status.not_in(excluded_states),
                 )
                 .with_for_update(skip_locked=True)
-            ).subquery()
+                .limit(batch_size)
+            ).all()
 
-            result = db.execute(
+            if not locked_rows:
+                empty_passes += 1
+                if empty_passes >= max_empty_passes:
+                    break
+                db.commit()
+                time.sleep(0.2)
+                continue
+
+            empty_passes = 0
+            locked_ids = [row.id for row in locked_rows]
+
+            db.execute(
                 update(Task)
-                .where(Task.id.in_(select(locked_subq.c.id)))
+                .where(Task.id.in_(locked_ids))
                 .values(
                     status=TaskStatus.REGISTERING,
                     num_attempts=0,
                     status_date=func.now(),
                 )
             )
-            reset_count += result.rowcount
 
-            if reset_count >= expected_count:
-                break
-
-            db.flush()
-            time.sleep(0.2 * (attempt + 1))
-
-        # Find which tasks were actually reset so we only audit those.
-        actually_reset = (
-            db.execute(
-                select(Task.id).where(
-                    Task.workflow_id == workflow_id,
-                    Task.status == TaskStatus.REGISTERING,
-                    Task.id.in_(list(status_map.keys())),
-                )
-            )
-            .scalars()
-            .all()
-        )
-        reset_ids = set(actually_reset)
-
-        # Batch audit records with flush() to keep the
-        # task_status_audit lock footprint manageable.
-        batch_size = 2000
-        audit_records = [
-            {
-                "task_id": tid,
-                "workflow_id": workflow_id,
-                "previous_status": status_map[tid],
-                "new_status": TaskStatus.REGISTERING,
-            }
-            for tid in reset_ids
-        ]
-        for i in range(0, len(audit_records), batch_size):
             TransitionService.create_audit_records_bulk(
                 session=db,
-                records=audit_records[i : i + batch_size],
+                records=[
+                    {
+                        "task_id": row.id,
+                        "workflow_id": workflow_id,
+                        "previous_status": row.status,
+                        "new_status": TaskStatus.REGISTERING,
+                    }
+                    for row in locked_rows
+                ],
             )
-            db.flush()
 
-        # If some tasks couldn't be reset, commit the progress
-        # and raise so the client retries for the remainder.
-        remaining = expected_count - len(reset_ids)
-        if remaining > 0:
+            # Commit releases locks and saves progress.
+            # If we crash here, committed batches are safe
+            # and the client retries for the remainder.
             db.commit()
+            reset_count += len(locked_ids)
+
+        if reset_count < total:
             logger.warning(
-                f"Resume: {remaining} of {expected_count} tasks "
-                f"still locked after {max_passes} passes for "
-                f"workflow {workflow_id}, committed partial reset",
-            )
-            raise HTTPException(
-                status_code=StatusCodes.SERVICE_UNAVAILABLE,
-                detail=(
-                    f"Reset {len(reset_ids)}/{expected_count} "
-                    f"tasks. {remaining} locked by active "
-                    f"transitions — retry to complete."
-                ),
+                f"Resume: reset {reset_count}/{total} tasks "
+                f"for workflow {workflow_id}, "
+                f"{total - reset_count} still locked"
             )
 
     resp = JSONResponse(content={}, status_code=StatusCodes.OK)

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
@@ -428,45 +428,47 @@ async def set_task_resume_state(
     if not reset_if_running:
         excluded_states.append(TaskStatus.RUNNING)
 
-    # Get task IDs that need to be reset
-    task_ids_query = select(Task.id).where(
-        Task.status.not_in(excluded_states), Task.workflow_id == workflow_id
-    )
-    task_ids = [row[0] for row in db.execute(task_ids_query).all()]
-
-    if task_ids:
-        # Use TransitionService for audit logging
-        # Note: REGISTERING doesn't have valid source statuses in FSM for all states,
-        # so we need to do a direct update with audit records
-        # This is a reset operation, not a normal FSM transition
-
-        # Get current statuses for audit records
-        current_statuses = db.execute(
-            select(Task.id, Task.status, Task.workflow_id).where(Task.id.in_(task_ids))
-        ).all()
-
-        # Bulk update
-        db.execute(
-            update(Task)
-            .where(Task.id.in_(task_ids))
-            .values(
-                status=TaskStatus.REGISTERING,
-                num_attempts=0,
-                status_date=func.now(),
-            )
+    # Get task IDs and their current statuses in one query (indexed on workflow_id,
+    # no IN clause needed). This avoids a second round-trip with a giant IN list.
+    tasks_to_reset = db.execute(
+        select(Task.id, Task.status).where(
+            Task.status.not_in(excluded_states),
+            Task.workflow_id == workflow_id,
         )
+    ).all()
 
-        # Create audit records for the reset (properly closes previous records)
-        audit_records = [
-            {
-                "task_id": task_id,
-                "workflow_id": wf_id,
-                "previous_status": prev_status,
-                "new_status": TaskStatus.REGISTERING,
-            }
-            for task_id, prev_status, wf_id in current_statuses
-        ]
-        TransitionService.create_audit_records_bulk(session=db, records=audit_records)
+    if tasks_to_reset:
+        # Reset is not a normal FSM transition — REGISTERING doesn't have valid
+        # source statuses for all states (e.g. QUEUED, LAUNCHED, ERROR_FATAL).
+        # Use direct update with audit records, batched to avoid MySQL timeouts
+        # on large workflows (10k+ tasks generate enormous IN clauses).
+        batch_size = 1000
+        for i in range(0, len(tasks_to_reset), batch_size):
+            batch = tasks_to_reset[i : i + batch_size]
+            batch_ids = [row.id for row in batch]
+
+            db.execute(
+                update(Task)
+                .where(Task.id.in_(batch_ids))
+                .values(
+                    status=TaskStatus.REGISTERING,
+                    num_attempts=0,
+                    status_date=func.now(),
+                )
+            )
+
+            audit_records = [
+                {
+                    "task_id": row.id,
+                    "workflow_id": workflow_id,
+                    "previous_status": row.status,
+                    "new_status": TaskStatus.REGISTERING,
+                }
+                for row in batch
+            ]
+            TransitionService.create_audit_records_bulk(
+                session=db, records=audit_records
+            )
 
     resp = JSONResponse(content={}, status_code=StatusCodes.OK)
     return resp

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
@@ -429,77 +429,76 @@ async def set_task_resume_state(
     if not reset_if_running:
         excluded_states.append(TaskStatus.RUNNING)
 
-    # Snapshot which tasks need resetting and their current statuses
-    # (for audit records). Uses workflow_id index, no IN clause.
+    # Snapshot task statuses for audit records (read-only, no lock).
     tasks_to_reset = db.execute(
         select(Task.id, Task.status).where(
-            Task.status.not_in(excluded_states),
             Task.workflow_id == workflow_id,
+            Task.status.not_in(excluded_states),
         )
     ).all()
 
     if tasks_to_reset:
+        expected_count = len(tasks_to_reset)
         status_map = {row.id: row.status for row in tasks_to_reset}
-        pending_ids = set(status_map.keys())
+        reset_count = 0
 
-        # Use SKIP LOCKED to avoid blocking on rows the distributor
-        # holds mid-transition. Most rows are uncontested; the few
-        # that are locked get retried on subsequent passes.
-        batch_size = 2000
+        # Subquery UPDATE with SKIP LOCKED: locks and updates in one
+        # server-side statement, no 100K-ID round-trip through Python.
+        # Retries with backoff pick up rows the distributor held.
         max_passes = 5
-        for pass_num in range(max_passes):
-            if not pending_ids:
-                break
-
-            batch_ids = list(pending_ids)[:batch_size]
-
-            # Lock available rows, skip any held by the distributor
-            locked_rows = db.execute(
+        for attempt in range(max_passes):
+            locked_subq = (
                 select(Task.id)
-                .where(Task.id.in_(batch_ids))
+                .where(
+                    Task.workflow_id == workflow_id,
+                    Task.status.not_in(excluded_states),
+                )
                 .with_for_update(skip_locked=True)
-            ).all()
-            locked_ids = [r.id for r in locked_rows]
+            ).subquery()
 
-            if not locked_ids:
-                # All remaining rows are locked — brief pause
-                # then retry on next pass
-                db.flush()
-                time.sleep(0.2)
-                continue
-
-            db.execute(
+            result = db.execute(
                 update(Task)
-                .where(Task.id.in_(locked_ids))
+                .where(Task.id.in_(select(locked_subq.c.id)))
                 .values(
                     status=TaskStatus.REGISTERING,
                     num_attempts=0,
                     status_date=func.now(),
                 )
             )
+            reset_count += result.rowcount
 
-            audit_records = [
-                {
-                    "task_id": tid,
-                    "workflow_id": workflow_id,
-                    "previous_status": status_map[tid],
-                    "new_status": TaskStatus.REGISTERING,
-                }
-                for tid in locked_ids
-            ]
-            TransitionService.create_audit_records_bulk(
-                session=db, records=audit_records
-            )
+            if reset_count >= expected_count:
+                break
 
             db.flush()
-            pending_ids -= set(locked_ids)
+            time.sleep(0.2 * (attempt + 1))
 
-        if pending_ids:
+        if reset_count < expected_count:
             logger.warning(
-                f"Resume: {len(pending_ids)} tasks still locked "
-                f"after {max_passes} passes for workflow "
+                f"Resume: {expected_count - reset_count} of "
+                f"{expected_count} tasks still locked after "
+                f"{max_passes} passes for workflow "
                 f"{workflow_id}",
             )
+
+        # Batch audit records with flush() to keep the
+        # task_status_audit lock footprint manageable.
+        batch_size = 2000
+        all_records = [
+            {
+                "task_id": tid,
+                "workflow_id": workflow_id,
+                "previous_status": prev_status,
+                "new_status": TaskStatus.REGISTERING,
+            }
+            for tid, prev_status in status_map.items()
+        ]
+        for i in range(0, len(all_records), batch_size):
+            TransitionService.create_audit_records_bulk(
+                session=db,
+                records=all_records[i : i + batch_size],
+            )
+            db.flush()
 
     resp = JSONResponse(content={}, status_code=StatusCodes.OK)
     return resp

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
@@ -1,6 +1,7 @@
 """Routes for Tasks."""
 
 import json
+import time
 from http import HTTPStatus as StatusCodes
 from typing import Any, Dict, List, Set, Union, cast
 
@@ -455,6 +456,7 @@ async def set_task_resume_state(
             if empty_passes >= MAX_EMPTY_PASSES:
                 break
             db.commit()
+            time.sleep(0.1 * empty_passes)
             continue
 
         empty_passes = 0

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task.py
@@ -6,7 +6,7 @@ from http import HTTPStatus as StatusCodes
 from typing import Any, Dict, List, Set, Union, cast
 
 import structlog
-from fastapi import Depends, Request
+from fastapi import Depends, HTTPException, Request
 from sqlalchemy import desc, insert, select, tuple_, update
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.mysql.dml import Insert as MySQLInsert
@@ -473,32 +473,57 @@ async def set_task_resume_state(
             db.flush()
             time.sleep(0.2 * (attempt + 1))
 
-        if reset_count < expected_count:
-            logger.warning(
-                f"Resume: {expected_count - reset_count} of "
-                f"{expected_count} tasks still locked after "
-                f"{max_passes} passes for workflow "
-                f"{workflow_id}",
+        # Find which tasks were actually reset so we only audit those.
+        actually_reset = (
+            db.execute(
+                select(Task.id).where(
+                    Task.workflow_id == workflow_id,
+                    Task.status == TaskStatus.REGISTERING,
+                    Task.id.in_(list(status_map.keys())),
+                )
             )
+            .scalars()
+            .all()
+        )
+        reset_ids = set(actually_reset)
 
         # Batch audit records with flush() to keep the
         # task_status_audit lock footprint manageable.
         batch_size = 2000
-        all_records = [
+        audit_records = [
             {
                 "task_id": tid,
                 "workflow_id": workflow_id,
-                "previous_status": prev_status,
+                "previous_status": status_map[tid],
                 "new_status": TaskStatus.REGISTERING,
             }
-            for tid, prev_status in status_map.items()
+            for tid in reset_ids
         ]
-        for i in range(0, len(all_records), batch_size):
+        for i in range(0, len(audit_records), batch_size):
             TransitionService.create_audit_records_bulk(
                 session=db,
-                records=all_records[i : i + batch_size],
+                records=audit_records[i : i + batch_size],
             )
             db.flush()
+
+        # If some tasks couldn't be reset, commit the progress
+        # and raise so the client retries for the remainder.
+        remaining = expected_count - len(reset_ids)
+        if remaining > 0:
+            db.commit()
+            logger.warning(
+                f"Resume: {remaining} of {expected_count} tasks "
+                f"still locked after {max_passes} passes for "
+                f"workflow {workflow_id}, committed partial reset",
+            )
+            raise HTTPException(
+                status_code=StatusCodes.SERVICE_UNAVAILABLE,
+                detail=(
+                    f"Reset {len(reset_ids)}/{expected_count} "
+                    f"tasks. {remaining} locked by active "
+                    f"transitions — retry to complete."
+                ),
+            )
 
     resp = JSONResponse(content={}, status_code=StatusCodes.OK)
     return resp


### PR DESCRIPTION
## Summary

- **Batched commits**: Replace single-transaction bulk task reset with a commit-per-batch loop. Each iteration locks ~5000 tasks (`SELECT FOR UPDATE SKIP LOCKED`), updates them, writes audit records, and commits — releasing all row locks before the next batch. Bounds lock hold time to ~1-2s regardless of workflow size.
- **SKIP LOCKED**: Avoids blocking on rows the distributor holds mid-transition. Skipped rows are picked up on subsequent passes.
- **Audit index**: Add `(task_id, exited_at)` index to `task_status_audit` to speed up the bulk audit close query (`UPDATE ... WHERE task_id IN (...) AND exited_at IS NULL`). Migration uses `ALGORITHM=INPLACE, LOCK=NONE` — safe to run on a live database.

### Why this approach

The root issue: resetting 100K+ tasks with consistent audit records in a single transaction exceeds the 20-second request timeout and blocks the distributor. `get_db` commits once at request end, so all row locks accumulate until then.

The fix: `db.commit()` inside the loop releases locks between batches. Each batch is a complete, consistent transaction (task updates + audit records). If the request crashes or times out, committed batches are safe. The endpoint is idempotent — REGISTERING is in `excluded_states`, so already-reset tasks are skipped on re-entry. The client's existing retry logic (10 attempts, 300s budget) handles incomplete resets.

### Production data

- Largest workflow: 179K tasks
- `task_status_audit`: 8.4M rows, ~1.1 GB
- Index build estimate: 30-90 seconds (online DDL, no locks)

## Test plan

- [x] Backend passes format, lint, typecheck (`nox -s format lint typecheck`)
- [ ] Docker e2e: resume a completed workflow (all DONE → nothing to reset → fast return)
- [ ] Docker e2e: resume a failed workflow with tasks to reset
- [ ] Run migration on staging, verify index build completes without blocking
- [ ] Monitor production after deploy: check for lock-wait timeouts in slow query log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task resume/reset behavior to use batched `SELECT ... FOR UPDATE SKIP LOCKED` with per-batch commits, which affects concurrency and lock/transaction semantics under load. Adds a new composite index via migration (online DDL for MySQL) that should be safe but impacts a large audit table during build.
> 
> **Overview**
> Speeds up and de-risks large workflow resume resets by replacing the single bulk update with a loop that locks tasks in batches (`FOR UPDATE SKIP LOCKED`), resets them to `REGISTERING`, writes audit records, and commits each batch to release row locks promptly.
> 
> Adds a `(task_id, exited_at)` composite index on `task_status_audit` (model + Alembic migration, using MySQL online DDL) to accelerate the bulk audit “close open record” update used by `TransitionService.create_audit_records_bulk`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77828f386efbff30d2082de19b8fb7e1be2364e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->