### PR TITLE
Fix task FSM blocking error recovery from INSTANTIATING and LAUNCHED

### DIFF
--- a/jobmon_server/src/jobmon/server/web/services/task_fsm.py
+++ b/jobmon_server/src/jobmon/server/web/services/task_fsm.py
@@ -22,11 +22,18 @@ class TaskFSM:
             TaskStatus.LAUNCHED,
             TaskStatus.RUNNING,  # Race condition: worker reports before distributor
             TaskStatus.ERROR_RECOVERABLE,
+            # Direct transitions (skip ERROR_RECOVERABLE):
+            TaskStatus.REGISTERING,  # Retry (e.g. NO_DISTRIBUTOR_ID)
+            TaskStatus.ADJUSTING_RESOURCES,  # Resource error retry
+            TaskStatus.ERROR_FATAL,  # Max attempts exceeded
         },
         TaskStatus.LAUNCHED: {
             TaskStatus.RUNNING,
             TaskStatus.ERROR_RECOVERABLE,
-            TaskStatus.ERROR_FATAL,  # Kill operation
+            TaskStatus.ERROR_FATAL,  # Kill operation or max attempts
+            # Direct transitions (skip ERROR_RECOVERABLE):
+            TaskStatus.REGISTERING,  # Retry (e.g. NO_HEARTBEAT)
+            TaskStatus.ADJUSTING_RESOURCES,  # Resource error retry
         },
         TaskStatus.RUNNING: {
             TaskStatus.DONE,


### PR DESCRIPTION
## Summary

Add missing direct transitions from INSTANTIATING and LAUNCHED states to REGISTERING, ADJUSTING_RESOURCES, and ERROR_FATAL in the centralized Task FSM.

## Problem

When `get_task_status_for_ti` computes the final task status for error recovery (skipping the ERROR_RECOVERABLE intermediate state), the FSM gate in `TransitionService` rejected the transition as invalid because the target states weren't in the valid transitions set. This caused tasks to get **permanently stuck** in INSTANTIATING or LAUNCHED when errors occurred (e.g., NO_DISTRIBUTOR_ID, NO_HEARTBEAT, RESOURCE_ERROR).

## Fix

Add the same direct transitions that RUNNING already has:

| From | New valid targets | Trigger |
|------|------------------|---------|
| INSTANTIATING | REGISTERING | Retry (e.g. NO_DISTRIBUTOR_ID) |
| INSTANTIATING | ADJUSTING_RESOURCES | Resource error retry |
| INSTANTIATING | ERROR_FATAL | Max attempts exceeded |
| LAUNCHED | REGISTERING | Retry (e.g. NO_HEARTBEAT) |
| LAUNCHED | ADJUSTING_RESOURCES | Resource error retry |

## Test plan

- [x] Backend passes format, lint, typecheck
- [ ] Verify stuck tasks in INSTANTIATING/LAUNCHED states recover after deploy
- [ ] Monitor task status audit trail for new transition patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands allowed Task status transitions in the centralized FSM; incorrect mappings could permit unintended state changes or alter recovery behavior for in-flight tasks.
> 
> **Overview**
> Fixes Task error-recovery getting blocked in `INSTANTIATING` and `LAUNCHED` by expanding `TaskFSM.VALID_TRANSITIONS` to allow direct transitions to `REGISTERING`, `ADJUSTING_RESOURCES`, and (for `INSTANTIATING`) `ERROR_FATAL` when retry logic skips the `ERROR_RECOVERABLE` intermediate state.
> 
> Also updates the `LAUNCHED -> ERROR_FATAL` transition comment to reflect that it can occur via max-attempts exhaustion as well as kill operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fb21b9dea4e698d98809621a52cfc3d7cbd7208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->