### PR TITLE
Fix resource usage query excluding running/registered instances

### DIFF
--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -108,23 +108,24 @@ class TaskTemplateRepository:
         workflows: Optional[List[int]],
         node_args: Optional[Dict[str, List[Any]]],
     ) -> List[TaskResourceDetailItem]:
-        """Fetch and filter task resource details with optimized single-query approach."""
+        """Fetch and filter task resource details with optimized single-query approach.
+
+        Uses LEFT JOINs on TaskInstance and TaskResources so that every
+        task appears in the result set regardless of instance state:
+        - Tasks with terminal instances → full resource data
+        - Tasks with running/launched instances → instance row, null resources
+        - Tasks with no instances yet (registered) → single row, null instance fields
+        Status falls back to Task.status when no instance exists.
+        """
         base_filters = [
             TaskTemplateVersion.id == task_template_version_id,
-            TaskInstance.status.in_(
-                [
-                    TaskInstanceStatus.DONE,
-                    TaskInstanceStatus.RESOURCE_ERROR,
-                    TaskInstanceStatus.NO_HEARTBEAT,
-                    TaskInstanceStatus.UNKNOWN_ERROR,
-                    TaskInstanceStatus.ERROR_FATAL,
-                    TaskInstanceStatus.ERROR,
-                ]
-            ),
         ]
 
         if workflows:
             base_filters.append(Task.workflow_id.in_(workflows))
+
+        # COALESCE gives instance status when present, task status otherwise
+        status_col = func.coalesce(TaskInstance.status, Task.status).label("status_col")
 
         attempt_number_col = (
             func.row_number()
@@ -139,7 +140,7 @@ class TaskTemplateRepository:
                     # TaskInstance resource usage fields
                     TaskInstance.wallclock,
                     TaskInstance.maxrss,
-                    TaskInstance.status.label("status_col"),
+                    status_col,
                     # Node and Task identifiers
                     Node.id.label("node_id_col"),
                     Task.id.label("task_id_col"),
@@ -156,10 +157,16 @@ class TaskTemplateRepository:
                     TaskInstance.workflow_run_id.label("workflow_run_id_col"),
                 )
                 .select_from(TaskTemplateVersion)
-                .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+                .join(
+                    Node,
+                    TaskTemplateVersion.id == Node.task_template_version_id,
+                )
                 .join(Task, Node.id == Task.node_id)
-                .join(TaskInstance, Task.id == TaskInstance.task_id)
-                .join(TaskResources, TaskInstance.task_resources_id == TaskResources.id)
+                .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
+                .outerjoin(
+                    TaskResources,
+                    TaskInstance.task_resources_id == TaskResources.id,
+                )
                 .where(and_(*base_filters))
             )
 
@@ -177,7 +184,7 @@ class TaskTemplateRepository:
                     "task_name": row[5],  # task_name_col
                     "requested_resources": row[10],  # requested_resources_col
                     "attempt_number_of_instance": row[11],  # attempt_number_col
-                    "status_orig": row[2],  # status_col (from TaskInstance)
+                    "status_orig": row[2],  # status_col (coalesced)
                     "task_status_date": row[6],  # task_status_date_col
                     "task_command": row[7],  # task_command_col
                     "task_num_attempts": row[8],  # task_num_attempts_col
@@ -198,6 +205,7 @@ class TaskTemplateRepository:
                 workflows,
                 node_args,
                 base_filters,
+                status_col,
                 attempt_number_col,
             )
 
@@ -207,6 +215,7 @@ class TaskTemplateRepository:
         workflows: Optional[List[int]],
         node_args: Dict[str, List[Any]],
         base_filters: List[ColumnElement],
+        status_col: Label,
         attempt_number_col: Label,
     ) -> List[TaskResourceDetailItem]:
         """Optimized node_args filtering using database-level joins and filtering."""
@@ -219,7 +228,7 @@ class TaskTemplateRepository:
                 Task.name.label("task_name"),
                 TaskResources.requested_resources,
                 attempt_number_col,
-                TaskInstance.status,
+                status_col,
                 Task.status_date.label("task_status_date"),
                 Task.command.label("task_command"),
                 Task.num_attempts.label("task_num_attempts"),
@@ -228,10 +237,16 @@ class TaskTemplateRepository:
                 TaskInstance.workflow_run_id,
             )
             .select_from(TaskTemplateVersion)
-            .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+            .join(
+                Node,
+                TaskTemplateVersion.id == Node.task_template_version_id,
+            )
             .join(Task, Node.id == Task.node_id)
-            .join(TaskInstance, Task.id == TaskInstance.task_id)
-            .join(TaskResources, TaskInstance.task_resources_id == TaskResources.id)
+            .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
+            .outerjoin(
+                TaskResources,
+                TaskInstance.task_resources_id == TaskResources.id,
+            )
             .where(and_(*base_filters))
         ).cte("base_tasks")
 
@@ -262,7 +277,7 @@ class TaskTemplateRepository:
             base_query.c.task_name,
             base_query.c.requested_resources,
             base_query.c.attempt_number_of_instance,
-            base_query.c.status,
+            base_query.c.status_col,
             base_query.c.task_status_date,
             base_query.c.task_command,
             base_query.c.task_num_attempts,

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
@@ -5,16 +5,14 @@ from typing import Any, Optional
 
 import structlog
 from fastapi import Depends, HTTPException, Query
-from sqlalchemy import and_, exists, select
+from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
 
 from jobmon.server.web.db import get_db, get_dialect
-from jobmon.server.web.models.node import Node
 from jobmon.server.web.models.task import Task
 from jobmon.server.web.models.task_instance import TaskInstance
 from jobmon.server.web.models.task_instance_status import TaskInstanceStatus
-from jobmon.server.web.models.task_template_version import TaskTemplateVersion
 from jobmon.server.web.repositories.task_template_repository import (
     TaskTemplateRepository,
 )
@@ -160,44 +158,6 @@ async def get_task_template_resource_usage(
                         task_num_attempts=detail_item.task_num_attempts,
                         task_max_attempts=detail_item.task_max_attempts,
                         workflow_run_id=detail_item.workflow_run_id,
-                    )
-                )
-
-            # Include tasks without qualifying instances
-            # (Registered, Queued, Running — not yet terminal).
-            # Uses Python-side exclusion to avoid expensive NOT EXISTS
-            # subquery against task_instance.
-            task_ids_with_instances = {d.task_id for d in task_details}
-            task_filters = [
-                TaskTemplateVersion.id == request_data.task_template_version_id,
-                Node.task_template_version_id == TaskTemplateVersion.id,
-                Task.node_id == Node.id,
-            ]
-            if request_data.workflows:
-                task_filters.append(Task.workflow_id.in_(request_data.workflows))
-            all_tasks_query = select(
-                Task.id,
-                Task.name,
-                Task.status,
-                Task.command,
-                Task.num_attempts,
-                Task.max_attempts,
-                Task.status_date,
-                Node.id.label("node_id"),
-            ).where(and_(*task_filters))
-            for row in db.execute(all_tasks_query).all():
-                if row[0] in task_ids_with_instances:
-                    continue
-                viz_data.append(
-                    TaskResourceVizItem(
-                        node_id=row[7],
-                        task_id=row[0],
-                        task_name=row[1],
-                        status=row[2],
-                        task_command=row[3],
-                        task_num_attempts=row[4],
-                        task_max_attempts=row[5],
-                        task_status_date=row[6],
                     )
                 )
 


### PR DESCRIPTION
## Summary
- The `task_template_resource_usage` endpoint had a terminal-only status filter (`IN ('D','Z','X','U','F','E')`) and INNER JOINs on `TaskInstance`/`TaskResources`, which excluded running, launched, and registered instances from the task table on the template details page
- This caused "latest attempt only" to show stale error statuses instead of the current running attempt, and hid the workflow run dropdown when a resume created a second workflow run
- Replaced INNER JOINs with LEFT JOINs, removed the status filter, added `COALESCE(TaskInstance.status, Task.status)` for instance-less tasks, and removed the now-redundant fallback query

## Performance (profiled against prod DB)

| Workflow | Old (2 queries) | New (1 query) | Delta |
|---|---|---|---|
| 330 tasks | 616ms | 519ms | -16% |
| 2735 tasks | 2560ms | 1151ms | -55% |

## Test plan
- [x] All 927 tests pass (including e2e)
- [x] Verified task 329640314 now returns all 3 instances with correct statuses
- [x] Workflow run dropdown appears when multiple runs exist
- [x] Profiled query performance against prod data — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SQL join and status-selection logic for the `task_template_resource_usage` endpoint, which can alter returned rows/statuses across task states and may surface null resource fields that downstream consumers must handle.
> 
> **Overview**
> Fixes `task_template_resource_usage` to **stop excluding non-terminal tasks** by removing the terminal-only `TaskInstance.status` filter and switching `TaskInstance`/`TaskResources` joins to `LEFT OUTER JOIN`s.
> 
> Adds `COALESCE(TaskInstance.status, Task.status)` so tasks without instances still return a status, threads this through the node-arg filtered CTE path, and removes the now-redundant route-level fallback query that separately fetched tasks without qualifying instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb27244a897dadad827d9cb41c15403c5768d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->