### PR TITLE
Fix distributor crashing on transient failures

### DIFF
--- a/jobmon_core/src/jobmon/distributor/distributor_service.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_service.py
@@ -170,7 +170,19 @@ class DistributorService:
                     status = todo.pop(0)
 
                     # refresh internal state from db
-                    self.refresh_status_from_db(status)
+                    try:
+                        self.refresh_status_from_db(status)
+                    except DistributorInterruptedError:
+                        raise
+                    except Exception as e:
+                        logger.warning(
+                            "Status refresh failed, will retry next cycle",
+                            status=status,
+                            error=str(e),
+                        )
+                        done.append(status)
+                        time_till_next_heartbeat -= time.time() - start_time
+                        continue
 
                     # how long the heartbeat took
                     refresh_time = time.time()
@@ -205,13 +217,18 @@ class DistributorService:
                 if time_till_next_heartbeat > 0:
                     time.sleep(time_till_next_heartbeat)
 
-                self.log_task_instance_report_by_date()
+                try:
+                    self.log_task_instance_report_by_date()
+                except DistributorInterruptedError:
+                    raise
+                except Exception as e:
+                    logger.warning(
+                        "Heartbeat logging failed, will retry next cycle",
+                        error=str(e),
+                    )
 
         except DistributorInterruptedError as e:
             logger.info(f"Distributor interrupted: {e}")
-        except Exception as e:
-            logger.exception("Distributor error", error=str(e))
-            raise
         finally:
             logger.info("Distributor stopping")
             # stop distributor
@@ -587,9 +604,17 @@ class DistributorService:
         task_instances_launched = self._task_instance_status_map[
             TaskInstanceStatus.LAUNCHED
         ]
-        submitted_or_running = self.cluster_interface.get_submitted_or_running(
-            [x.distributor_id for x in task_instances_launched]
-        )
+        try:
+            submitted_or_running = self.cluster_interface.get_submitted_or_running(
+                [x.distributor_id for x in task_instances_launched]
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to query submitted/running jobs, skipping heartbeat",
+                error=str(e),
+            )
+            self._last_heartbeat_time = time.time()
+            return
 
         task_instance_ids_to_heartbeat: List[int] = []
         for task_instance_launched in task_instances_launched:
@@ -623,7 +648,14 @@ class DistributorService:
                 asyncio.create_task(self._log_heartbeat_by_batch(session, batch))
                 for batch in task_instance_batches
             ]
-            await asyncio.gather(*heartbeat_tasks)
+            results = await asyncio.gather(*heartbeat_tasks, return_exceptions=True)
+            for i, result in enumerate(results):
+                if isinstance(result, Exception):
+                    logger.warning(
+                        "Heartbeat batch failed",
+                        batch_index=i,
+                        error=str(result),
+                    )
 
     async def _log_heartbeat_by_batch(
         self, session: aiohttp.ClientSession, task_instance_ids_to_heartbeat: List[int]

--- a/jobmon_core/src/jobmon/distributor/distributor_service.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_service.py
@@ -652,6 +652,8 @@ class DistributorService:
             ]
             results = await asyncio.gather(*heartbeat_tasks, return_exceptions=True)
             for i, result in enumerate(results):
+                if isinstance(result, DistributorInterruptedError):
+                    raise result
                 if isinstance(result, Exception):
                     logger.warning(
                         "Heartbeat batch failed",

--- a/jobmon_core/src/jobmon/distributor/distributor_service.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_service.py
@@ -608,6 +608,8 @@ class DistributorService:
             submitted_or_running = self.cluster_interface.get_submitted_or_running(
                 [x.distributor_id for x in task_instances_launched]
             )
+        except DistributorInterruptedError:
+            raise
         except Exception as e:
             logger.warning(
                 "Failed to query submitted/running jobs, skipping heartbeat",


### PR DESCRIPTION
## Summary
- The distributor's main loop crashed on any transient failure (HTTP timeouts, `squeue` errors) because exceptions propagated to the top-level handler which re-raised them — killing the process and orphaning all in-flight tasks
- 57 distributor deaths traced to `asyncio.TimeoutError` during heartbeats, 3 from `squeue` `CalledProcessError`, all recoverable
- Three targeted fixes: wrap non-critical operations (`refresh_status_from_db`, `log_task_instance_report_by_date`, `get_submitted_or_running`) in try/except that log warnings and retry next cycle; add `return_exceptions=True` to `asyncio.gather()` so one batch failure doesn't cancel all heartbeats

## Changes
- `distributor_service.py`: Wrap `refresh_status_from_db()` in try/except with `continue` to skip to next status on failure
- `distributor_service.py`: Wrap `log_task_instance_report_by_date()` call in try/except in main loop
- `distributor_service.py`: Wrap `get_submitted_or_running()` (squeue) call in try/except with early return
- `distributor_service.py`: Add `return_exceptions=True` to `asyncio.gather()` in `_log_heartbeats()`, log individual batch failures
- All handlers re-raise `DistributorInterruptedError` so signal-based shutdown still works

## Test plan
- [x] All 927 tests pass (including 45 distributor-specific tests)
- [x] `DistributorInterruptedError` is always re-raised (graceful shutdown preserved)
- [x] Transient exceptions are logged at WARNING level for observability

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling in the distributor main loop and heartbeat pipeline to swallow/log transient exceptions instead of aborting the process; risk is moderate because it can mask persistent failures and alter heartbeat timing/behavior.
> 
> **Overview**
> Prevents the distributor process from crashing on transient errors by **catching and downgrading failures to warnings** in the main loop.
> 
> `refresh_status_from_db()` and `log_task_instance_report_by_date()` are now wrapped so unexpected exceptions are logged and retried on the next cycle (while `DistributorInterruptedError` still aborts for graceful shutdown). Heartbeat submission is made more resilient by using `asyncio.gather(..., return_exceptions=True)` and logging per-batch failures so one failing batch doesn’t cancel the rest, and `get_submitted_or_running()` query failures now skip the heartbeat for that cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11310a0e29e412369e5cc095dc737d8e306b046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->