### PR TITLE
Fix reaper status_date, TTV race condition, and add orchestrator diagnostics

### DIFF
--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -404,6 +404,16 @@ class WorkflowRunOrchestrator:
                 # No observable work still queued, but tasks remain outstanding
                 # Force an immediate full sync before deciding to exit
                 if not self._state.all_tasks_final():
+                    logger.warning(
+                        "Main loop exiting with non-final tasks — "
+                        "forcing full sync before exit",
+                        status=self._state.status,
+                        total_tasks=len(self._state.tasks),
+                        done=self._state.get_done_count(),
+                        failed=self._state.get_failed_count(),
+                        active=self._state.get_active_task_count(),
+                        ready_to_run=self._state.get_ready_to_run_count(),
+                    )
                     await self._do_sync(full_sync=True)
                     time_since_last_full_sync = 0.0
 
@@ -702,6 +712,16 @@ class WorkflowRunOrchestrator:
                 f"Workflow run exited with server-set status: {self._state.status}"
             )
         else:
+            logger.error(
+                "Workflow run finalizing as ERROR — main loop exited "
+                "with incomplete tasks",
+                status=self._state.status,
+                total_tasks=total_tasks,
+                done=done_count,
+                failed=failed_count,
+                active=self._state.get_active_task_count(),
+                ready_to_run=self._state.get_ready_to_run_count(),
+            )
             await self._update_status(WorkflowRunStatus.ERROR)
 
         # Build task-level results

--- a/jobmon_client/src/jobmon/client/swarm/run.py
+++ b/jobmon_client/src/jobmon/client/swarm/run.py
@@ -440,7 +440,11 @@ async def _run_orchestrator(
                 raise
 
             # For fail-fast and other RuntimeErrors, construct result from state
-            logger.warning(f"Workflow run RuntimeError: {e}")
+            logger.exception(
+                "Workflow run RuntimeError — constructing result from state",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             return _build_result_from_state(state, start_time)
 
         except (DistributorNotAlive, DistributorInterruptedError, WorkflowTestError):
@@ -452,7 +456,11 @@ async def _run_orchestrator(
 
         except Exception as e:
             # On other errors, construct result from state
-            logger.warning(f"Workflow run error: {e}")
+            logger.exception(
+                "Workflow run error — constructing result from state",
+                error=str(e),
+                error_type=type(e).__name__,
+            )
             return _build_result_from_state(state, start_time)
 
     finally:

--- a/jobmon_server/src/jobmon/server/web/models/task_template_version.py
+++ b/jobmon_server/src/jobmon/server/web/models/task_template_version.py
@@ -42,7 +42,7 @@ class TaskTemplateVersion(Base):
             task_args=args_by_type["task_args"],
             op_args=args_by_type["op_args"],
             id_name_map=id_name_map,
-            task_template_id=self.task_template.id,
+            task_template_id=int(self.task_template_id),
         )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/jobmon_server/src/jobmon/server/web/routes/v3/reaper/reaper.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/reaper/reaper.py
@@ -5,7 +5,7 @@ from typing import Any, Union
 
 import structlog
 from fastapi import Depends, Query, Request
-from sqlalchemy import case, func, insert, select, text, update
+from sqlalchemy import case, func, insert, select, update
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
 
@@ -305,16 +305,16 @@ def reap_workflow_run(workflow_run_id: int, db: Session = Depends(get_db)) -> An
             logger.debug(f"Unable to reap workflow_run {wfr_id}: {e}")
 
     # update status
-    query1 = f"""UPDATE workflow_run
-                SET status="{target_wfr_status}"
-                WHERE id={wfr_id}
-            """
-    db.execute(text(query1))
-    query2 = f"""UPDATE workflow
-                    SET status="{target_wf_status}"
-                    WHERE id={wf_id}
-            """
-    db.execute(text(query2))
+    db.execute(
+        update(WorkflowRun)
+        .where(WorkflowRun.id == wfr_id)
+        .values(status=target_wfr_status, status_date=func.now())
+    )
+    db.execute(
+        update(Workflow)
+        .where(Workflow.id == wf_id)
+        .values(status=target_wf_status, status_date=func.now())
+    )
     db.commit()
     resp = JSONResponse(
         content={"status": target_wfr_status}, status_code=StatusCodes.OK


### PR DESCRIPTION
## Summary

Fixes discovered during the SCICOMP-1540 (FHS distributor startup failures) investigation:

- **Reaper status_date bug**: The reaper transitioned workflow runs to Error using raw SQL that updated `status` but not `status_date`, making reaped runs appear to fail in seconds. Converted to SQLAlchemy `update()` expressions that set both fields. This was causing the "errored within 30 seconds" appearance reported in the ticket.

- **TaskTemplateVersion AttributeError**: `to_wire_as_client_task_template_version()` accessed `self.task_template.id` via the ORM relationship, which is `None` after an IntegrityError rollback during concurrent TTV creation. Changed to `self.task_template_id` (FK column). This was causing HTTP 500s on the `/add_version` endpoint during concurrent workflow submissions.

- **Swallowed exception logging**: `_run_orchestrator` caught non-timeout RuntimeErrors and generic Exceptions with `logger.warning` (no traceback), making orchestrator failures invisible. Changed to `logger.exception` with full traceback and exception type.

- **Orchestrator premature exit diagnostics**: Added logging when the main loop exits with non-final tasks and when `_finalize()` sets ERROR, including full state breakdown (total, done, failed, active, ready_to_run). Investigation found 40 confirmed instances of the orchestrator self-terminating while tasks were still pending, but couldn't diagnose further without this logging.

## Test plan
- [ ] Verify reaper correctly updates `status_date` on workflow_run and workflow tables
- [ ] Verify TTV creation race condition returns the existing TTV instead of 500
- [ ] Verify swallowed exceptions now appear in structured logs with traceback
- [ ] Verify orchestrator state is logged when exiting with incomplete tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow run termination/reaping and serialization paths; while changes are small, they affect how runs are marked terminal and could impact monitoring/cleanup if incorrect.
> 
> **Overview**
> Fixes several failure/diagnostic gaps across client and server.
> 
> On the **server**, the reaper now updates `workflow_run`/`workflow` using SQLAlchemy `update()` and sets `status_date` alongside `status` (instead of raw SQL that only updated `status`), and `TaskTemplateVersion.to_wire_as_client_task_template_version()` now uses the FK column `task_template_id` rather than the ORM relationship to avoid post-rollback `AttributeError`s.
> 
> On the **client**, orchestrator/run error handling and premature-exit scenarios now emit richer structured logs (including traceback via `logger.exception` and state breakdown when exiting with non-final tasks / finalizing as `ERROR`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b66e68ce4f0d42813f1fa8a77c2b9c7223631759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->