### PR TITLE
Defer triage when cluster accounting is unfinalized

### DIFF
--- a/jobmon_core/src/jobmon/core/cluster_protocol.py
+++ b/jobmon_core/src/jobmon/core/cluster_protocol.py
@@ -12,6 +12,7 @@ except ImportError:
 
 from jobmon.core import __version__
 from jobmon.core.exceptions import RemoteExitInfoNotAvailable
+from jobmon.core.exit_info import RemoteExitInfo
 
 
 class ClusterQueue(Protocol):
@@ -114,8 +115,16 @@ class ClusterDistributor(Protocol):
         raise NotImplementedError
 
     @abstractmethod
-    def get_remote_exit_info(self, distributor_id: str) -> Tuple[str, str]:
-        """Get the exit info about the task instance once it is done running."""
+    def get_remote_exit_info(
+        self, distributor_id: str
+    ) -> Union[RemoteExitInfo, Tuple[str, str]]:
+        """Get the exit info about the task instance once it is done running.
+
+        Returns:
+            RemoteExitInfo with error_state, error_message, and finalized flag.
+            Legacy plugins may return a (error_state, error_message) tuple,
+            which is treated as finalized=True.
+        """
         raise RemoteExitInfoNotAvailable
 
     @abstractmethod

--- a/jobmon_core/src/jobmon/core/exit_info.py
+++ b/jobmon_core/src/jobmon/core/exit_info.py
@@ -1,0 +1,25 @@
+"""Remote exit info from cluster plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RemoteExitInfo:
+    """Exit information returned by cluster plugins during triage.
+
+    Attributes:
+        error_state: The TaskInstanceStatus error code to transition to
+            (e.g., UNKNOWN_ERROR, RESOURCE_ERROR, ERROR_FATAL).
+        error_message: Human-readable error description for the error log.
+        finalized: Whether the cluster's accounting system has finalized
+            this job's metadata. If False, the distributor will defer
+            the triage transition and retry on the next cycle, giving
+            the accounting system time to produce accurate exit info
+            (needed for correct resource scaling on OOM, etc.).
+    """
+
+    error_state: str
+    error_message: str
+    finalized: bool = True

--- a/jobmon_core/src/jobmon/distributor/distributor_service.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_service.py
@@ -484,27 +484,77 @@ class DistributorService:
                 distributor_id, self._next_report_increment
             )
 
+    # Maximum wall-clock time to wait for cluster accounting to
+    # finalize before proceeding with potentially inaccurate metadata.
+    MAX_TRIAGE_DURATION: float = 300.0  # 5 minutes
+
     @bind_context(task_instance_id="task_instance.task_instance_id")
     def triage_error(self, task_instance: DistributorTaskInstance) -> None:
         """Triage a running task instance that has missed a heartbeat.
 
+        Queries the cluster for exit info. If accounting has not
+        finalized yet (plugin returns finalized=False), defers the
+        transition and retries on the next distributor cycle, up to
+        MAX_TRIAGE_DURATION wall-clock seconds.
+
         Allowed transitions are (R, U, Z, F)
         """
+        now = time.time()
+        if task_instance.first_triage_time is None:
+            task_instance.first_triage_time = now
+        task_instance.triage_attempts += 1
+
         logger.info(
             "Distributor triaging task instance error",
             distributor_id=task_instance.distributor_id,
+            triage_attempt=task_instance.triage_attempts,
         )
 
-        r_value, r_msg = self.cluster_interface.get_remote_exit_info(
+        result = self.cluster_interface.get_remote_exit_info(
             task_instance.distributor_id
         )
+
+        # Support legacy plugins returning (error_state, error_message)
+        if isinstance(result, tuple):
+            r_value, r_msg = result
+            finalized = True
+        else:
+            r_value = result.error_state
+            r_msg = result.error_message
+            finalized = result.finalized
+
         logger.info(
             "Retrieved exit info from cluster",
             return_code=r_value,
             error_message=(
                 r_msg[:100] if r_msg else None
             ),  # Truncate for log readability
+            finalized=finalized,
         )
+
+        # Defer if accounting hasn't finalized and we're within the
+        # retry window. Accurate exit info is needed for resource
+        # scaling (e.g., OOM → bumped memory on retry).
+        if not finalized:
+            elapsed = now - task_instance.first_triage_time
+            if elapsed < self.MAX_TRIAGE_DURATION:
+                logger.info(
+                    "Cluster accounting not finalized, "
+                    "deferring triage to next cycle",
+                    distributor_id=task_instance.distributor_id,
+                    triage_attempts=task_instance.triage_attempts,
+                    elapsed_seconds=round(elapsed, 1),
+                    max_duration=self.MAX_TRIAGE_DURATION,
+                )
+                return  # Stay in TRIAGING — next cycle retries
+
+            logger.warning(
+                "Cluster accounting still unfinalized after timeout, "
+                "proceeding with available metadata",
+                distributor_id=task_instance.distributor_id,
+                triage_attempts=task_instance.triage_attempts,
+                elapsed_seconds=round(elapsed, 1),
+            )
 
         task_instance.transition_to_error(r_msg, r_value)
 

--- a/jobmon_core/src/jobmon/distributor/distributor_task_instance.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_task_instance.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Set, Tuple
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple
 
 import structlog
 
@@ -43,6 +43,11 @@ class DistributorTaskInstance:
         self.error_msg = ""
 
         self.requester = requester
+
+        # Triage retry tracking — used when cluster accounting
+        # is not yet finalized after a worker death
+        self.first_triage_time: Optional[float] = None
+        self.triage_attempts: int = 0
 
     @property
     def submission_name(self) -> str:

--- a/jobmon_core/src/jobmon/plugins/dummy/dummy_distributor.py
+++ b/jobmon_core/src/jobmon/plugins/dummy/dummy_distributor.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from jobmon.core.cluster_protocol import ClusterDistributor, ClusterWorkerNode
 from jobmon.core.constants import TaskInstanceStatus
+from jobmon.core.exit_info import RemoteExitInfo
 from jobmon.worker_node.cli import WorkerNodeCLI
 from jobmon.worker_node.worker_node_factory import WorkerNodeFactory
 
@@ -87,9 +88,12 @@ class DummyDistributor(ClusterDistributor):
         """
         return {}
 
-    def get_remote_exit_info(self, distributor_id: str) -> Tuple[str, str]:
+    def get_remote_exit_info(self, distributor_id: str) -> RemoteExitInfo:
         """Get exit info from task instances that have run."""
-        return TaskInstanceStatus.UNKNOWN_ERROR, "Whatever"
+        return RemoteExitInfo(
+            error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+            error_message="Whatever",
+        )
 
     def get_submitted_or_running(
         self, distributor_ids: Optional[List[str]] = None

--- a/jobmon_core/src/jobmon/plugins/multiprocess/multiproc_distributor.py
+++ b/jobmon_core/src/jobmon/plugins/multiprocess/multiproc_distributor.py
@@ -18,6 +18,7 @@ import psutil
 from jobmon.core.cluster_protocol import ClusterDistributor, ClusterWorkerNode
 from jobmon.core.constants import TaskInstanceStatus
 from jobmon.core.exceptions import RemoteExitInfoNotAvailable
+from jobmon.core.exit_info import RemoteExitInfo
 
 logger = logging.getLogger(__name__)
 
@@ -231,18 +232,18 @@ class MultiprocessDistributor(ClusterDistributor):
                 errors[did] = self._queueing_errors.pop(did)
         return errors
 
-    def get_remote_exit_info(self, distributor_id: str) -> Tuple[str, str]:
+    def get_remote_exit_info(self, distributor_id: str) -> RemoteExitInfo:
         """Get the exit info about the task instance once done."""
         try:
             exit_code = self._exit_info[distributor_id]
             if exit_code == 199:
-                return (
-                    TaskInstanceStatus.UNKNOWN_ERROR,
-                    "job was in kill self state",
+                return RemoteExitInfo(
+                    error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+                    error_message="job was in kill self state",
                 )
-            return (
-                TaskInstanceStatus.UNKNOWN_ERROR,
-                f"Process exited with code {exit_code}",
+            return RemoteExitInfo(
+                error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+                error_message=f"Process exited with code {exit_code}",
             )
         except KeyError:
             raise RemoteExitInfoNotAvailable

--- a/jobmon_core/src/jobmon/plugins/sequential/seq_distributor.py
+++ b/jobmon_core/src/jobmon/plugins/sequential/seq_distributor.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from jobmon.core.cluster_protocol import ClusterDistributor, ClusterWorkerNode
 from jobmon.core.constants import TaskInstanceStatus
 from jobmon.core.exceptions import RemoteExitInfoNotAvailable, ReturnCodes
+from jobmon.core.exit_info import RemoteExitInfo
 from jobmon.worker_node.cli import WorkerNodeCLI
 
 logger = logging.getLogger(__name__)
@@ -99,15 +100,19 @@ class SequentialDistributor(ClusterDistributor):
         """
         return {}
 
-    def get_remote_exit_info(self, distributor_id: str) -> Tuple[str, str]:
+    def get_remote_exit_info(self, distributor_id: str) -> RemoteExitInfo:
         """Get exit info from task instances that have run."""
         try:
             exit_code = self._exit_info[distributor_id]
             if exit_code == 199:
-                msg = "job was in kill self state"
-                return TaskInstanceStatus.UNKNOWN_ERROR, msg
-            else:
-                return TaskInstanceStatus.UNKNOWN_ERROR, f"found {exit_code}"
+                return RemoteExitInfo(
+                    error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+                    error_message="job was in kill self state",
+                )
+            return RemoteExitInfo(
+                error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+                error_message=f"found {exit_code}",
+            )
         except KeyError:
             raise RemoteExitInfoNotAvailable
 

--- a/tests/integration/distributor/test_triaging.py
+++ b/tests/integration/distributor/test_triaging.py
@@ -203,10 +203,15 @@ def test_triaging_to_specific_error(
     # synchronize statuses from the db and get new work
     # distributor_service._check_for_work(TaskInstanceStatus.TRIAGING)
 
+    from jobmon.core.exit_info import RemoteExitInfo
+
     with mock.patch(
         "jobmon.plugins.multiprocess.multiproc_distributor."
         "MultiprocessDistributor.get_remote_exit_info",
-        return_value=(error_state, error_message),
+        return_value=RemoteExitInfo(
+            error_state=error_state,
+            error_message=error_message,
+        ),
     ):
         # code logic to test
         distributor_service.refresh_status_from_db(TaskInstanceStatus.TRIAGING)

--- a/tests/plugins/test_sequential_distributor.py
+++ b/tests/plugins/test_sequential_distributor.py
@@ -1,4 +1,5 @@
 from jobmon.core.constants import TaskInstanceStatus
+from jobmon.core.exit_info import RemoteExitInfo
 from jobmon.plugins.sequential.seq_distributor import (
     SequentialDistributor,
     SequentialWorkerNode,
@@ -13,9 +14,10 @@ def test_seq_kill_self_state():
     expected_words = "job was in kill self state"
     executor = SequentialDistributor("sequential")
     executor._exit_info = {1: 199}
-    r_value, r_msg = executor.get_remote_exit_info(1)
-    assert r_value == TaskInstanceStatus.UNKNOWN_ERROR
-    assert expected_words in r_msg
+    result = executor.get_remote_exit_info(1)
+    assert isinstance(result, RemoteExitInfo)
+    assert result.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+    assert expected_words in result.error_message
 
 
 def test_get_queueing_errors_returns_empty():

--- a/tests/unit/core/test_deferred_triage.py
+++ b/tests/unit/core/test_deferred_triage.py
@@ -1,0 +1,171 @@
+"""Tests for deferred triage when cluster accounting is not finalized."""
+
+import time
+from unittest import mock
+
+import pytest
+
+from jobmon.core.constants import TaskInstanceStatus
+from jobmon.core.exit_info import RemoteExitInfo
+from jobmon.core.requester import Requester
+from jobmon.distributor.distributor_service import DistributorService
+from jobmon.distributor.distributor_task_instance import DistributorTaskInstance
+from jobmon.plugins.dummy.dummy_distributor import DummyDistributor
+
+
+@pytest.fixture
+def distributor_service():
+    cluster_interface = DummyDistributor("dummy")
+    requester = mock.MagicMock(spec=Requester)
+    ds = DistributorService(cluster_interface, requester=requester)
+    return ds
+
+
+@pytest.fixture
+def task_instance():
+    requester = mock.MagicMock(spec=Requester)
+    ti = DistributorTaskInstance(
+        task_instance_id=1,
+        workflow_run_id=1,
+        status=TaskInstanceStatus.TRIAGING,
+        requester=requester,
+    )
+    ti._distributor_id = "12345_1"
+    return ti
+
+
+def test_finalized_exit_info_transitions_immediately(
+    distributor_service, task_instance
+):
+    """Finalized exit info should transition the TI on the first attempt."""
+    finalized_result = RemoteExitInfo(
+        error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+        error_message="OOM killed with exit code 71",
+        finalized=True,
+    )
+
+    with mock.patch.object(
+        distributor_service.cluster_interface,
+        "get_remote_exit_info",
+        return_value=finalized_result,
+    ):
+        distributor_service.triage_error(task_instance)
+
+    assert task_instance.triage_attempts == 1
+    assert task_instance.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+
+
+def test_unfinalized_exit_info_defers_transition(distributor_service, task_instance):
+    """Unfinalized exit info should leave TI in TRIAGING (no transition)."""
+    unfinalized_result = RemoteExitInfo(
+        error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+        error_message="status=SUCCESS, state=RUNNING",
+        finalized=False,
+    )
+
+    with mock.patch.object(
+        distributor_service.cluster_interface,
+        "get_remote_exit_info",
+        return_value=unfinalized_result,
+    ):
+        distributor_service.triage_error(task_instance)
+
+    assert task_instance.triage_attempts == 1
+    assert task_instance.first_triage_time is not None
+    # No transition — error_state should still be empty
+    assert task_instance.error_state == ""
+
+
+def test_unfinalized_then_finalized_transitions_on_retry(
+    distributor_service, task_instance
+):
+    """Second attempt with finalized info should transition."""
+    unfinalized = RemoteExitInfo(
+        error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+        error_message="state=RUNNING",
+        finalized=False,
+    )
+    finalized = RemoteExitInfo(
+        error_state=TaskInstanceStatus.RESOURCE_ERROR,
+        error_message="OOM killed",
+        finalized=True,
+    )
+
+    with mock.patch.object(
+        distributor_service.cluster_interface,
+        "get_remote_exit_info",
+        return_value=unfinalized,
+    ):
+        distributor_service.triage_error(task_instance)
+
+    assert task_instance.triage_attempts == 1
+    assert task_instance.error_state == ""  # Not transitioned
+
+    with mock.patch.object(
+        distributor_service.cluster_interface,
+        "get_remote_exit_info",
+        return_value=finalized,
+    ):
+        distributor_service.triage_error(task_instance)
+
+    assert task_instance.triage_attempts == 2
+    assert task_instance.error_state == TaskInstanceStatus.RESOURCE_ERROR
+
+
+def test_unfinalized_past_timeout_transitions_anyway(
+    distributor_service, task_instance
+):
+    """After MAX_TRIAGE_DURATION, should transition even if unfinalized."""
+    unfinalized = RemoteExitInfo(
+        error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+        error_message="state=RUNNING, contradictory",
+        finalized=False,
+    )
+
+    # Set first_triage_time to well past the timeout
+    task_instance.first_triage_time = time.time() - 600  # 10 min ago
+
+    with mock.patch.object(
+        distributor_service.cluster_interface,
+        "get_remote_exit_info",
+        return_value=unfinalized,
+    ):
+        distributor_service.triage_error(task_instance)
+
+    # Should have transitioned despite being unfinalized
+    assert task_instance.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+
+
+def test_legacy_tuple_return_treated_as_finalized(distributor_service, task_instance):
+    """Legacy plugins returning (str, str) should be treated as finalized."""
+    with mock.patch.object(
+        distributor_service.cluster_interface,
+        "get_remote_exit_info",
+        return_value=(
+            TaskInstanceStatus.UNKNOWN_ERROR,
+            "legacy error message",
+        ),
+    ):
+        distributor_service.triage_error(task_instance)
+
+    assert task_instance.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+
+
+def test_triage_attempts_increment_across_deferrals(distributor_service, task_instance):
+    """Each deferral should increment triage_attempts."""
+    unfinalized = RemoteExitInfo(
+        error_state=TaskInstanceStatus.UNKNOWN_ERROR,
+        error_message="not ready",
+        finalized=False,
+    )
+
+    with mock.patch.object(
+        distributor_service.cluster_interface,
+        "get_remote_exit_info",
+        return_value=unfinalized,
+    ):
+        for i in range(5):
+            distributor_service.triage_error(task_instance)
+
+    assert task_instance.triage_attempts == 5
+    assert task_instance.error_state == ""  # Still deferred

--- a/tests/unit/core/test_multiprocess_distributor.py
+++ b/tests/unit/core/test_multiprocess_distributor.py
@@ -2,6 +2,7 @@ import pytest
 
 from jobmon.core.constants import TaskInstanceStatus
 from jobmon.core.exceptions import RemoteExitInfoNotAvailable
+from jobmon.core.exit_info import RemoteExitInfo
 from jobmon.plugins.multiprocess.multiproc_distributor import (
     MultiprocessDistributor,
     MultiprocessWorkerNode,
@@ -19,25 +20,29 @@ def distributor():
 def test_get_remote_exit_info_kill_self(distributor):
     """Exit code 199 should return UNKNOWN_ERROR with kill self message."""
     distributor._exit_info["1"] = 199
-    status, msg = distributor.get_remote_exit_info("1")
-    assert status == TaskInstanceStatus.UNKNOWN_ERROR
-    assert "kill self" in msg
+    result = distributor.get_remote_exit_info("1")
+    assert isinstance(result, RemoteExitInfo)
+    assert result.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+    assert "kill self" in result.error_message
+    assert result.finalized is True
 
 
 def test_get_remote_exit_info_nonzero(distributor):
     """Non-zero exit code should return UNKNOWN_ERROR with the code."""
     distributor._exit_info["2"] = 1
-    status, msg = distributor.get_remote_exit_info("2")
-    assert status == TaskInstanceStatus.UNKNOWN_ERROR
-    assert "1" in msg
+    result = distributor.get_remote_exit_info("2")
+    assert isinstance(result, RemoteExitInfo)
+    assert result.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+    assert "1" in result.error_message
 
 
 def test_get_remote_exit_info_zero(distributor):
     """Zero exit code should still return UNKNOWN_ERROR (triaging path)."""
     distributor._exit_info["3"] = 0
-    status, msg = distributor.get_remote_exit_info("3")
-    assert status == TaskInstanceStatus.UNKNOWN_ERROR
-    assert "0" in msg
+    result = distributor.get_remote_exit_info("3")
+    assert isinstance(result, RemoteExitInfo)
+    assert result.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+    assert "0" in result.error_message
 
 
 def test_get_remote_exit_info_missing(distributor):

--- a/tests/unit/core/test_sequential_distributor.py
+++ b/tests/unit/core/test_sequential_distributor.py
@@ -1,0 +1,17 @@
+from jobmon.core.constants import TaskInstanceStatus
+from jobmon.core.exit_info import RemoteExitInfo
+from jobmon.plugins.sequential.seq_distributor import SequentialDistributor
+
+
+def test_seq_kill_self_state():
+    """
+    mock the error status
+    """
+
+    expected_words = "job was in kill self state"
+    executor = SequentialDistributor("sequential")
+    executor._exit_info = {1: 199}
+    result = executor.get_remote_exit_info(1)
+    assert isinstance(result, RemoteExitInfo)
+    assert result.error_state == TaskInstanceStatus.UNKNOWN_ERROR
+    assert expected_words in result.error_message


### PR DESCRIPTION
## Summary

When a worker node dies (OOM, node failure), the triage flow queries the cluster plugin for
exit info to determine the correct error state and enable resource scaling (e.g., OOM → bumped
memory on retry). If the cluster's accounting system hasn't finalized yet, the metadata can be
contradictory — for example, Slurm may report `status=SUCCESS, state=RUNNING, return_code=0`
for a job that was actually OOM-killed.

This PR adds a deferral mechanism: if the plugin reports `finalized=False`, the distributor
leaves the task instance in TRIAGING and retries on the next cycle, up to 5 minutes wall clock.
This gives the accounting system time to produce accurate exit info needed for correct resource
scaling.

## Changes

- **New `RemoteExitInfo` dataclass** (`jobmon.core.exit_info`) with `error_state`,
  `error_message`, and `finalized` flag
- **Updated `ClusterDistributor` protocol** to return `RemoteExitInfo` (backward compatible —
  legacy `(str, str)` tuples are treated as `finalized=True`)
- **Deferred triage in `triage_error()`** — when `finalized=False`, tracks
  `first_triage_time` and `triage_attempts` on the `DistributorTaskInstance`, defers
  transition up to `MAX_TRIAGE_DURATION` (300s), then falls through with best available metadata
- **Updated all built-in plugins** (multiprocess, sequential, dummy) to return `RemoteExitInfo`
- **Slurm plugin** (separate repo) will need a corresponding update to set `finalized=False`
  when accounting state is non-terminal (RUNNING, PENDING)

## Background

Discovered during SCICOMP-1540 investigation. Three task instances (348350356, 348350441,
348350478) on workflow 561301 had error logs referencing contradictory Slurm metadata because
accounting hadn't finalized when the triage query ran. The triage flow is correctly
heartbeat-contingent (waits for heartbeat expiration before querying), but 60-90 seconds
isn't always enough for Slurm accounting to catch up after an OOM kill.

## Test plan

- [x] Unit tests for finalized → immediate transition
- [x] Unit tests for unfinalized → deferred (stays in TRIAGING)
- [x] Unit tests for unfinalized → retry → finalized → correct transition
- [x] Unit tests for unfinalized past timeout → transitions anyway
- [x] Unit tests for legacy tuple return → treated as finalized
- [x] Unit tests for triage_attempts tracking
- [x] Existing plugin unit tests updated for RemoteExitInfo
- [x] Integration triage test updated for RemoteExitInfo
- [ ] Slurm plugin update (separate PR in plugin repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-triage state transitions and the cluster plugin exit-info contract, which can affect retry/scaling behavior and timing under failure conditions. Backward compatibility is included, but third-party plugins may need updates to return the new structure and/or `finalized` correctly.
> 
> **Overview**
> Adds a new `RemoteExitInfo` return type (with a `finalized` flag) for cluster plugins to report exit state/message and whether accounting data is ready.
> 
> Updates `triage_error()` to **defer transitioning** task instances when exit info is unfinalized, retrying on subsequent distributor cycles for up to `MAX_TRIAGE_DURATION` (5 minutes) while tracking `first_triage_time` and `triage_attempts` on `DistributorTaskInstance`.
> 
> Migrates built-in distributors (dummy, sequential, multiprocess) and tests to return/consume `RemoteExitInfo`, while still accepting legacy `(error_state, error_message)` tuples as finalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01bc9b4a0ed6b135ecca034a1f01dd27a04029dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->