### PR TITLE
Fix UnboundLocalError in log_unknown_error causing heartbeat cascade failure

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
@@ -817,6 +817,17 @@ async def log_unknown_error(
                     nodename,
                     request,
                 )
+            return resp
+
+        # Task instance heartbeat recovered since triage began — skip
+        logger.info(
+            f"Task instance {task_instance_id} heartbeat recovered "
+            "during triage, skipping error transition"
+        )
+        resp = JSONResponse(
+            content={"status": "skipped"},
+            status_code=StatusCodes.OK,
+        )
         return resp
     except Exception as e:
         raise e


### PR DESCRIPTION
## Summary

Fixes a critical server-side bug causing cascading false triage of thousands of task instances.

When a task instance's heartbeat recovers between triage detection and the `log_unknown_error` call, the endpoint returns HTTP 500 (`UnboundLocalError: cannot access local variable 'resp'`). This blocks the distributor in a retry loop (~9 minutes of exponential backoff), starving heartbeats for all other LAUNCHED task instances. Their heartbeats expire, the server triages them as dead, and workers that start running find their TI already in Error status.

## Impact

In the last 24 hours: 5,008 TransitionErrors, 300 ProcessLookupErrors, 102 UnboundLocalErrors. Primarily affecting `svc_dismod_at` (93%) with hundreds of falsely triaged task instances per cascade event.

## Root Cause

`log_unknown_error` endpoint (`task_instance.py:820`): when `task_instance is None` (heartbeat recovered), the `if` block is skipped but `return resp` executes with `resp` never assigned.

## Fix

Return HTTP 200 with `{"status": "skipped"}` when the heartbeat has recovered, allowing the distributor to proceed immediately instead of retrying for 9 minutes.

## Test plan
- [ ] Verify endpoint returns 200 when task_instance heartbeat has recovered
- [ ] Verify existing triage flow still works for genuinely dead task instances
- [ ] Monitor TransitionError rate after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task-instance triage/error logging behavior; while the change is small, it affects a high-traffic state transition endpoint and could impact how distributors proceed on borderline heartbeat races.
> 
> **Overview**
> Prevents `log_unknown_error` from raising an `UnboundLocalError` when the task instance no longer qualifies for triage (heartbeat recovered). The endpoint now explicitly logs the recovery and returns HTTP 200 with `{ "status": "skipped" }` instead of failing, avoiding distributor retry loops and cascading false error transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16b9db18d3ce2d367cacb2a969a9d808e5960298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->