### PR TITLE
Increase lock retry backoff and add jitter

### DIFF
--- a/jobmon_server/src/jobmon/server/web/services/transition_service.py
+++ b/jobmon_server/src/jobmon/server/web/services/transition_service.py
@@ -1,5 +1,6 @@
 """Unified transition service with TI-centric architecture and audit logging."""
 
+import random
 from time import sleep
 from typing import Any, Dict, List, Optional, Set, Tuple, Type
 
@@ -39,7 +40,7 @@ class TransitionService:
     """
 
     DEFAULT_MAX_RETRIES = 5
-    DEFAULT_BASE_DELAY_MS = 2  # Exponential backoff: 2ms, 4ms, 8ms, 16ms, 32ms
+    DEFAULT_BASE_DELAY_MS = 50  # Exponential backoff: 100ms, 200ms, 400ms, 800ms, 1.6s
 
     # TaskInstance valid transitions (mirrors TaskInstance.valid_transitions)
     TI_VALID_TRANSITIONS: Set[Tuple[str, str]] = {
@@ -115,8 +116,9 @@ class TransitionService:
 
     @classmethod
     def _calculate_backoff_delay(cls: Type["TransitionService"], attempt: int) -> float:
-        """Calculate exponential backoff delay in seconds."""
-        return cls.DEFAULT_BASE_DELAY_MS * (2 ** (attempt + 1)) / 1000
+        """Calculate exponential backoff delay in seconds with ±50% jitter."""
+        base = cls.DEFAULT_BASE_DELAY_MS * (2 ** (attempt + 1)) / 1000
+        return base * random.uniform(0.5, 1.5)
 
     @classmethod
     def _is_error_retry_transition(


### PR DESCRIPTION
## Summary
- Raises `TransitionService.DEFAULT_BASE_DELAY_MS` from 2ms to 50ms, changing the backoff sequence from 4/8/16/32/64ms (~124ms total) to 100/200/400/800/1600ms (~3.1s total)
- Adds ±50% random jitter to each retry delay to prevent thundering herd across pods

## Context
Production (80+ server pods) is hitting MySQL `FOR UPDATE NOWAIT` lock failures on `task_instance` rows. The 2ms base delay exhausts all 5 retries before lock holders can finish, causing cascading errors and reaper timeouts.

## Test plan
- [ ] Full pytest suite passes
- [ ] Monitor prod lock contention errors after deploy — expect significant reduction in `OperationalError 3572` log volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry timing for DB row-lock contention in task/task-instance transitions, which can affect throughput and perceived latency under load. Logic is small and localized but impacts a core transition path.
> 
> **Overview**
> **Lock contention retries are slowed and de-synchronized.** `TransitionService` now uses a larger exponential backoff base (50ms instead of 2ms) and adds ±50% random jitter in `_calculate_backoff_delay()`.
> 
> This increases total wait time across the existing retry loop, aiming to reduce thundering-herd behavior when many pods hit `NOWAIT`/lock failures at once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff38f5d807f00046068ad131870e15470fe5ade7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->