### PR TITLE
Unify all NOWAIT retry backoff through TransitionService

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/array.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/array.py
@@ -218,7 +218,7 @@ async def record_array_batch_num(
                         f"{attempt + 1}/{max_retries}"
                     )
                     db.rollback()
-                    sleep(0.001 * (2 ** (attempt + 1)))  # Exponential backoff
+                    sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 # All retries failed
                 logger.error(
@@ -354,7 +354,7 @@ async def transition_array_to_launched(
                     f"retrying attempt {attempt + 1}/{max_retries}. {e}"
                 )
                 db.rollback()  # Clear the corrupted session state
-                sleep(0.001 * (2 ** (attempt + 1)))  # Exponential backoff: 2ms, 4ms...
+                sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 logger.error(f"Unexpected database error in atomic launch update: {e}")
                 db.rollback()
@@ -493,7 +493,7 @@ async def transition_to_killed(
                     f"retrying attempt {attempt + 1}/{max_retries}. {e}"
                 )
                 db.rollback()  # Clear the corrupted session state
-                sleep(0.001 * (2 ** (attempt + 1)))  # Exponential backoff: 2ms, 4ms...
+                sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 logger.error(f"Unexpected database error in atomic update: {e}")
                 db.rollback()

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/array.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/array.py
@@ -218,7 +218,8 @@ async def record_array_batch_num(
                         f"{attempt + 1}/{max_retries}"
                     )
                     db.rollback()
-                    sleep(TransitionService._calculate_backoff_delay(attempt))
+                    if attempt < max_retries - 1:
+                        sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 # All retries failed
                 logger.error(
@@ -354,7 +355,8 @@ async def transition_array_to_launched(
                     f"retrying attempt {attempt + 1}/{max_retries}. {e}"
                 )
                 db.rollback()  # Clear the corrupted session state
-                sleep(TransitionService._calculate_backoff_delay(attempt))
+                if attempt < max_retries - 1:
+                    sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 logger.error(f"Unexpected database error in atomic launch update: {e}")
                 db.rollback()
@@ -493,7 +495,8 @@ async def transition_to_killed(
                     f"retrying attempt {attempt + 1}/{max_retries}. {e}"
                 )
                 db.rollback()  # Clear the corrupted session state
-                sleep(TransitionService._calculate_backoff_delay(attempt))
+                if attempt < max_retries - 1:
+                    sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 logger.error(f"Unexpected database error in atomic update: {e}")
                 db.rollback()

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
@@ -212,7 +212,7 @@ async def log_ti_report_by(
                 f"retrying attempt {attempt + 1}/{max_retries}. {e}"
             )
             db.rollback()
-            sleep(0.001 * (2 ** (attempt + 1)))  # 2ms, 4ms, 8ms delays
+            sleep(TransitionService._calculate_backoff_delay(attempt))
             continue
         except Exception as e:
             logger.error(
@@ -285,7 +285,7 @@ async def log_ti_report_by_batch(
                     f"retrying attempt {attempt + 1}/{max_retries}"
                 )
                 db.rollback()
-                sleep(0.001 * (2 ** (attempt + 1)))  # 2ms, 4ms, 8ms delays
+                sleep(TransitionService._calculate_backoff_delay(attempt))
                 continue
             except Exception as e:
                 # The bulk update may fail if any row is locked by another transaction.
@@ -571,7 +571,7 @@ async def log_no_distributor_id(
                 f"retrying attempt {attempt + 1}/{max_retries}. {e}"
             )
             db.rollback()
-            sleep(0.001 * (2 ** (attempt + 1)))  # 2ms, 4ms, 8ms delays
+            sleep(TransitionService._calculate_backoff_delay(attempt))
             continue
         except Exception as e:
             logger.error(
@@ -623,7 +623,7 @@ async def log_distributor_id(
                 f"retrying attempt {attempt + 1}/{max_retries}. {e}"
             )
             db.rollback()
-            sleep(0.001 * (2 ** (attempt + 1)))  # 2ms, 4ms, 8ms delays
+            sleep(TransitionService._calculate_backoff_delay(attempt))
             continue
         except Exception as e:
             logger.error(
@@ -987,7 +987,7 @@ async def instantiate_task_instances(
                     f"retrying attempt {attempt + 1}/{max_retries}. {e}"
                 )
                 db.rollback()  # Clear the corrupted session state
-                sleep(0.001 * (2 ** (attempt + 1)))  # Exponential backoff: 2ms, 4ms...
+                sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 logger.error(f"Unexpected database error in atomic instantiation: {e}")
                 db.rollback()

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
@@ -212,7 +212,8 @@ async def log_ti_report_by(
                 f"retrying attempt {attempt + 1}/{max_retries}. {e}"
             )
             db.rollback()
-            sleep(TransitionService._calculate_backoff_delay(attempt))
+            if attempt < max_retries - 1:
+                sleep(TransitionService._calculate_backoff_delay(attempt))
             continue
         except Exception as e:
             logger.error(
@@ -285,7 +286,8 @@ async def log_ti_report_by_batch(
                     f"retrying attempt {attempt + 1}/{max_retries}"
                 )
                 db.rollback()
-                sleep(TransitionService._calculate_backoff_delay(attempt))
+                if attempt < max_retries - 1:
+                    sleep(TransitionService._calculate_backoff_delay(attempt))
                 continue
             except Exception as e:
                 # The bulk update may fail if any row is locked by another transaction.
@@ -571,7 +573,8 @@ async def log_no_distributor_id(
                 f"retrying attempt {attempt + 1}/{max_retries}. {e}"
             )
             db.rollback()
-            sleep(TransitionService._calculate_backoff_delay(attempt))
+            if attempt < max_retries - 1:
+                sleep(TransitionService._calculate_backoff_delay(attempt))
             continue
         except Exception as e:
             logger.error(
@@ -623,7 +626,8 @@ async def log_distributor_id(
                 f"retrying attempt {attempt + 1}/{max_retries}. {e}"
             )
             db.rollback()
-            sleep(TransitionService._calculate_backoff_delay(attempt))
+            if attempt < max_retries - 1:
+                sleep(TransitionService._calculate_backoff_delay(attempt))
             continue
         except Exception as e:
             logger.error(
@@ -987,7 +991,8 @@ async def instantiate_task_instances(
                     f"retrying attempt {attempt + 1}/{max_retries}. {e}"
                 )
                 db.rollback()  # Clear the corrupted session state
-                sleep(TransitionService._calculate_backoff_delay(attempt))
+                if attempt < max_retries - 1:
+                    sleep(TransitionService._calculate_backoff_delay(attempt))
             else:
                 logger.error(f"Unexpected database error in atomic instantiation: {e}")
                 db.rollback()


### PR DESCRIPTION
## Summary
- Replaces 8 hardcoded 2ms-base backoff sleeps in `array.py` and `task_instance.py` with `TransitionService._calculate_backoff_delay()`
- All lock retry paths now share the same 50ms base delay with ±50% jitter from #375

## Context
Follow-up to #375. The backoff fix only covered `TransitionService` internally, but 8 other NOWAIT retry sites in the array and task_instance routes still used the old `sleep(0.001 * (2 ** (attempt + 1)))` pattern (2ms base). These are high-contention batch paths that see the same lock pressure.

## Test plan
- [ ] Full pytest suite passes
- [ ] Monitor prod lock contention after deploy — array/TI instantiation and launch routes should show fewer retry exhaustions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry/backoff behavior on several high-contention NOWAIT/lock error paths, which can affect latency and throughput under database contention. Logic is straightforward but touches core state-transition endpoints for arrays and task instances.
> 
> **Overview**
> Standardizes database lock retry behavior in v3 FSM routes by replacing multiple hardcoded exponential sleeps with `TransitionService._calculate_backoff_delay()` (includes the shared base delay and jitter).
> 
> Also avoids sleeping after the final retry attempt in these endpoints, keeping failure handling the same while reducing unnecessary delay before returning `503`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd6478d971f33821b04f25abe4b9c7bb18ce1d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->