### PR TITLE
Log report_by heartbeat receipt at INFO level

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
@@ -152,7 +152,7 @@ async def log_ti_report_by(
     set_jobmon_context(task_instance_id=task_instance_id)
     data = cast(Dict, await request.json())
 
-    logger.debug(
+    logger.info(
         "Server received heartbeat",
         distributor_id=data.get("distributor_id"),
     )
@@ -199,7 +199,7 @@ async def log_ti_report_by(
                         f"Unable to transition to running from {task_instance.status}"
                     )
 
-            logger.debug("Heartbeat processed successfully")
+            logger.info("Heartbeat processed successfully")
 
             resp = JSONResponse(
                 content={"status": task_instance.status}, status_code=StatusCodes.OK


### PR DESCRIPTION
## Summary
- Promotes `log_report_by` endpoint entry and success logs from DEBUG to INFO
- Enables diagnosing whether worker heartbeats reach the server during triage investigations

## Context
While investigating TI 349708596 (triaged to UNKNOWN_ERROR while the worker was alive), we couldn't determine whether `log_report_by` requests reached the server — both worker and server sides logged at DEBUG, which doesn't appear in ES. This 2-line change closes that observability gap.

## Test plan
- [ ] Full pytest suite passes
- [ ] After deploy, verify `"Server received heartbeat"` appears in ES for active TIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk observability-only change: increases log verbosity for worker heartbeat receipt/success in `log_report_by`, with no functional or data-handling behavior changes.
> 
> **Overview**
> Promotes `POST /task_instance/{task_instance_id}/log_report_by` (heartbeat) entry and success logs from `DEBUG` to `INFO`, making heartbeat arrival/processing visible in standard server logs for triage investigations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914c2428024e7f213b92d154402d120416a2cac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->