### PR TITLE
Scope increase_resources subquery to workflow

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/workflow.py
@@ -720,11 +720,14 @@ async def increase_resources_for_resource_error_tasks(
     logger.info("Increase resources for tasks with RESOURCE_ERROR latest TI")
 
     # Subquery to get latest TaskInstance per task by most recent status_date
+    # Scoped to this workflow's tasks to avoid full table scan
     latest_ti_subq = (
         select(
             TaskInstance.task_id,
             func.max(TaskInstance.status_date).label("max_status_date"),
         )
+        .join(Task, TaskInstance.task_id == Task.id)
+        .where(Task.workflow_id == workflow_id)
         .group_by(TaskInstance.task_id)
         .subquery()
     )


### PR DESCRIPTION
## Summary
- Adds `Task.workflow_id` filter to the latest-TI-per-task subquery in `increase_resources_for_resource_error_tasks`
- Previously the subquery did `GROUP BY task_instance.task_id` across the entire `task_instance` table (hundreds of millions of rows), causing MySQL TLS timeout ("Server has gone away")

## Context
Workflow 562601 resume triggered `POST /workflow/562601/increase_resources` which timed out at 20s due to the unscoped full table scan. The fix joins through `task` and filters by `workflow_id` so the scan is limited to just the workflow's tasks.

## Test plan
- [ ] Full pytest suite passes
- [ ] Verify the generated SQL includes the workflow_id filter in the subquery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized query change that only narrows the subquery to tasks in the given workflow; main concern is any unintended exclusion if the join/filter is incorrect.
> 
> **Overview**
> Fixes a performance issue in `POST /workflow/{workflow_id}/increase_resources` by scoping the “latest TaskInstance per task” subquery to the current workflow via a join to `Task` and a `Task.workflow_id` filter.
> 
> This prevents full-table scans over `task_instance` when computing latest instances, reducing timeouts while keeping the outer query’s workflow filtering intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3d8647ed8fd954ba4207784b965fb773f5ad07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->