### PR TITLE
Fix OTLP logs silently dropped when host reconfigures structlog

### DIFF
--- a/jobmon_core/src/jobmon/core/config/structlog_config.py
+++ b/jobmon_core/src/jobmon/core/config/structlog_config.py
@@ -731,7 +731,13 @@ def prepend_jobmon_processors_to_existing_config() -> None:
     if wrapper_class is not None:
         new_config["wrapper_class"] = wrapper_class
 
-    structlog.configure(**new_config)
+    # Set reentrancy flag so the reconfigure hook (if installed) does not
+    # call us again when we call structlog.configure below.
+    _reinjecting.active = True
+    try:
+        structlog.configure(**new_config)
+    finally:
+        _reinjecting.active = False
 
 
 def is_structlog_configured() -> bool:

--- a/jobmon_core/src/jobmon/core/config/structlog_config.py
+++ b/jobmon_core/src/jobmon/core/config/structlog_config.py
@@ -414,9 +414,23 @@ def _install_structlog_reconfigure_hook() -> None:
                     _reinjecting.active = False
 
         _hooked_configure.__jobmon_hooked__ = True  # type: ignore[attr-defined]
+        _hooked_configure.__wrapped__ = _orig_configure  # type: ignore[attr-defined]
         _structlog.configure = _hooked_configure  # type: ignore[assignment]
 
         _structlog_hook_installed = True
+
+
+def _reset_structlog_reconfigure_hook() -> None:
+    """Remove the structlog.configure hook. For testing only."""
+    global _structlog_hook_installed
+    import structlog as _structlog
+
+    with _structlog_hook_lock:
+        current = _structlog.configure
+        if getattr(current, "__jobmon_hooked__", False):
+            # The hooked function closes over _orig_configure
+            _structlog.configure = current.__wrapped__  # type: ignore[attr-defined]
+        _structlog_hook_installed = False
 
 
 def enable_structlog_otlp_capture() -> None:

--- a/jobmon_core/src/jobmon/core/config/structlog_config.py
+++ b/jobmon_core/src/jobmon/core/config/structlog_config.py
@@ -402,8 +402,8 @@ def _install_structlog_reconfigure_hook() -> None:
 
         _orig_configure = _structlog.configure
 
-        def _hooked_configure(**kwargs: Any) -> None:
-            _orig_configure(**kwargs)
+        def _hooked_configure(*args: Any, **kwargs: Any) -> None:
+            _orig_configure(*args, **kwargs)
             if not getattr(_reinjecting, "active", False):
                 _reinjecting.active = True
                 try:

--- a/jobmon_core/src/jobmon/core/config/structlog_config.py
+++ b/jobmon_core/src/jobmon/core/config/structlog_config.py
@@ -408,11 +408,13 @@ def _install_structlog_reconfigure_hook() -> None:
                 _reinjecting.active = True
                 try:
                     prepend_jobmon_processors_to_existing_config()
+                except Exception:
+                    pass
                 finally:
                     _reinjecting.active = False
 
         _hooked_configure.__jobmon_hooked__ = True  # type: ignore[attr-defined]
-        _structlog.configure = _hooked_configure  # type: ignore[attr-defined]
+        _structlog.configure = _hooked_configure  # type: ignore[assignment]
 
         _structlog_hook_installed = True
 

--- a/jobmon_core/src/jobmon/core/config/structlog_config.py
+++ b/jobmon_core/src/jobmon/core/config/structlog_config.py
@@ -68,6 +68,12 @@ _thread_local = threading.local()
 # Reference count so multiple OTLP handlers can co-exist safely.
 _otlp_handler_count = 0
 _otlp_capture_lock = threading.Lock()
+# Guards against installing the structlog reconfigure hook more than once.
+_structlog_hook_installed = False
+_structlog_hook_lock = threading.Lock()
+# Per-thread reentrancy guard: prevents infinite recursion when our hook calls
+# prepend_jobmon_processors_to_existing_config(), which calls structlog.configure().
+_reinjecting = threading.local()
 
 
 def _store_event_dict_for_otlp(
@@ -369,11 +375,55 @@ def _extract_exc_info(event_dict: Dict[str, Any]) -> Optional[Any]:
     return None
 
 
+def _install_structlog_reconfigure_hook() -> None:
+    """Wrap structlog.configure so jobmon processors survive host reconfiguration.
+
+    Host applications (e.g. FHS) call ``structlog.reset_defaults()`` followed by
+    ``structlog.configure(...)`` during their own logging setup, silently wiping
+    jobmon's ``_forward_event_to_logging_handlers`` processor.  This hook re-prepends
+    jobmon's processors after every ``structlog.configure`` call so the stdlib →
+    OTLP bridge remains intact regardless of when the host configures structlog.
+
+    Installed at most once per process (guarded by ``_structlog_hook_lock``).
+    A per-thread reentrancy flag prevents infinite recursion because
+    ``prepend_jobmon_processors_to_existing_config`` itself calls
+    ``structlog.configure``.
+    """
+    global _structlog_hook_installed
+
+    if _structlog_hook_installed:
+        return
+
+    with _structlog_hook_lock:
+        if _structlog_hook_installed:
+            return
+
+        import structlog as _structlog
+
+        _orig_configure = _structlog.configure
+
+        def _hooked_configure(**kwargs: Any) -> None:
+            _orig_configure(**kwargs)
+            if not getattr(_reinjecting, "active", False):
+                _reinjecting.active = True
+                try:
+                    prepend_jobmon_processors_to_existing_config()
+                finally:
+                    _reinjecting.active = False
+
+        _hooked_configure.__jobmon_hooked__ = True  # type: ignore[attr-defined]
+        _structlog.configure = _hooked_configure  # type: ignore[attr-defined]
+
+        _structlog_hook_installed = True
+
+
 def enable_structlog_otlp_capture() -> None:
     """Enable thread-local capture for OTLP handlers."""
     global _otlp_handler_count
     with _otlp_capture_lock:
         _otlp_handler_count += 1
+        if _otlp_handler_count == 1:
+            _install_structlog_reconfigure_hook()
 
 
 def disable_structlog_otlp_capture() -> None:

--- a/jobmon_core/src/jobmon/core/otlp/manager.py
+++ b/jobmon_core/src/jobmon/core/otlp/manager.py
@@ -170,6 +170,7 @@ class JobmonOTLPManager:
                     from jobmon.core.config.structlog_config import (
                         _install_structlog_reconfigure_hook,
                     )
+
                     _install_structlog_reconfigure_hook()
                 except Exception:
                     pass

--- a/jobmon_core/src/jobmon/core/otlp/manager.py
+++ b/jobmon_core/src/jobmon/core/otlp/manager.py
@@ -160,6 +160,20 @@ class JobmonOTLPManager:
                 # Set the global tracer provider
                 trace.set_tracer_provider(self.tracer_provider)
 
+                # Install structlog reconfigure hook so jobmon's bridge processors
+                # survive any future host calls to structlog.configure() or
+                # structlog.reset_defaults() (e.g. FHS tiny_structured_logger).
+                # Must be installed here — before any host logging setup runs —
+                # rather than in enable_structlog_otlp_capture() which fires too
+                # late (after the host has already reconfigured structlog).
+                try:
+                    from jobmon.core.config.structlog_config import (
+                        _install_structlog_reconfigure_hook,
+                    )
+                    _install_structlog_reconfigure_hook()
+                except Exception:
+                    pass
+
                 self._initialized = True
 
             except Exception:

--- a/tests/unit/logging/test_client_logging.py
+++ b/tests/unit/logging/test_client_logging.py
@@ -504,6 +504,7 @@ def test_print_logger_factory_adds_logger_name(client_env):
 
 
 def test_direct_rendering_console_output_is_message_only(client_env):
+    core_structlog_config._reset_structlog_reconfigure_hook()
     structlog.reset_defaults()
     jobmon_client_logging._structlog_configured_by_jobmon = False
 

--- a/tests/unit/logging/test_structlog_context.py
+++ b/tests/unit/logging/test_structlog_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import structlog
 
 from jobmon.core.config.structlog_config import (
+    _reset_structlog_reconfigure_hook,
     _store_event_dict_for_otlp,
     create_telemetry_isolation_processor,
 )
@@ -18,6 +19,7 @@ from jobmon.core.logging.context import (
 
 
 def setup_function() -> None:
+    _reset_structlog_reconfigure_hook()
     structlog.reset_defaults()
     structlog.contextvars.clear_contextvars()
     clear_jobmon_context()
@@ -297,3 +299,70 @@ def test_lazy_configuration_allows_host_to_configure_first():
         logger.info("Test message")
     output = captured.getvalue()
     assert "[FHS_LAZY]" in output
+
+
+def test_reconfigure_hook_reinjects_processors_after_host_configure():
+    """The hook should re-prepend jobmon processors when the host reconfigures."""
+    from jobmon.core.config.structlog_config import (
+        _install_structlog_reconfigure_hook,
+        _store_event_dict_for_otlp,
+    )
+
+    # Install the hook (simulates OTLP manager startup)
+    _install_structlog_reconfigure_hook()
+
+    # Simulate host app reconfiguring structlog, wiping all processors
+    def host_renderer(logger, method_name, event_dict):
+        return event_dict
+
+    structlog.configure(
+        processors=[host_renderer],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+    )
+
+    processors = structlog.get_config().get("processors", [])
+
+    # Hook should have re-injected jobmon processors
+    assert len(processors) > 1, "Hook did not re-inject processors"
+
+    # Host renderer should still be present (at the end)
+    assert host_renderer in processors
+
+    # Jobmon's OTLP capture should be present
+    assert _store_event_dict_for_otlp in processors
+
+    # Isolation processor should be present
+    isolation = [p for p in processors if hasattr(p, "__jobmon_telemetry_isolation__")]
+    assert len(isolation) == 1
+    assert isolation[0].__jobmon_telemetry_isolation__ == ("jobmon.",)
+
+
+def test_reconfigure_hook_exception_does_not_break_host():
+    """If re-injection fails, host's structlog.configure should still work."""
+    from unittest.mock import patch
+
+    from jobmon.core.config.structlog_config import (
+        _install_structlog_reconfigure_hook,
+    )
+
+    _install_structlog_reconfigure_hook()
+
+    def host_renderer(logger, method_name, event_dict):
+        return event_dict
+
+    # Make re-injection blow up
+    with patch(
+        "jobmon.core.config.structlog_config"
+        ".prepend_jobmon_processors_to_existing_config",
+        side_effect=RuntimeError("boom"),
+    ):
+        # Host's configure should NOT raise
+        structlog.configure(
+            processors=[host_renderer],
+            logger_factory=structlog.stdlib.LoggerFactory(),
+        )
+
+    processors = structlog.get_config().get("processors", [])
+    # Host renderer should still be there — exception was swallowed
+    assert host_renderer in processors


### PR DESCRIPTION
## Summary

- Host applications (e.g. FHS pipelines using `tiny_structured_logger`) call `structlog.reset_defaults()` + `structlog.configure()` during their own logging setup, silently wiping jobmon's `_forward_event_to_logging_handlers` processor — the bridge that routes structlog events into stdlib logging where `JobmonOTLPLoggingHandler` lives
- This caused **100% of OTLP log records to be silently dropped** in FHS environments
- Fix installs a hook on `structlog.configure` inside `JobmonOTLPManager.initialize()` that re-prepends jobmon's processors after every host reconfiguration
- A per-thread reentrancy guard prevents infinite recursion (`prepend_jobmon_processors_to_existing_config` calls `structlog.configure` itself)
- Hook is installed in `initialize()` rather than `enable_structlog_otlp_capture()` because `initialize()` provably runs before the host's logging setup

## Test plan

- [ ] Unit tests pass: `nox -s tests -- tests/unit/logging/test_structlog_context.py tests/unit/logging/test_structlog_detection.py tests/unit/logging/test_otlp.py`
- [ ] Live integration verified: ran FHS `fhs_pipeline_hale parallelize` (workflow_run_id=382200) against `fhs_env_4.18.8` with local `jobmon_core` via `PYTHONPATH` override — all jobmon log records reached OTLP collector with `LogRecordExportResult.SUCCESS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wraps `structlog.configure` at runtime and swallows hook exceptions, which is global behavior that could have subtle interactions with host logging setups despite being guarded and re-entrant safe.
> 
> **Overview**
> Prevents OTLP log forwarding from being silently disabled when host applications call `structlog.reset_defaults()`/`structlog.configure()` by installing a one-time hook that re-prepends Jobmon’s processors after every `structlog.configure`.
> 
> The hook is installed early in `JobmonOTLPManager.initialize()` (and guarded against recursion via a thread-local flag), adds a test-only reset helper, and extends unit tests to validate processor reinjection and that host `structlog.configure` continues to work even if reinjection fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 782a8be91b88f5449d1d345d9ab902293b86df2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->