### PR TITLE
Use aiofiles for non-blocking subprocess log writes

### DIFF
--- a/jobmon_core/pyproject.toml
+++ b/jobmon_core/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    'aiofiles',
     'aiohttp',
     'pyyaml',
     'psutil',

--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -5,8 +5,9 @@ import os
 import signal
 import socket
 from time import time
-from typing import Dict, Optional, TextIO
+from typing import Dict, Optional
 
+import aiofiles
 import structlog
 
 from jobmon.core.cluster_protocol import ClusterWorkerNode
@@ -367,7 +368,7 @@ class WorkerNodeTaskInstance:
     @bind_method_context(task_instance_id="_task_instance_id")
     def log_report_by(self) -> None:
         """Log the heartbeat to show that the task instance is still alive."""
-        logger.debug("Worker node logging heartbeat")
+        logger.info("Worker node sending heartbeat")
         message: Dict = {
             "next_report_increment": (
                 self._task_instance_heartbeat_interval
@@ -462,34 +463,30 @@ class WorkerNodeTaskInstance:
 
     @staticmethod
     async def _communicate(
-        async_stream: asyncio.StreamReader, output_stream: TextIO, chunk_size: int = 64
+        async_stream: asyncio.StreamReader,
+        output_path: str,
+        chunk_size: int = 64,
     ) -> str:
         mem_buffer = ""
         try:
-            while True:
-                # Read a chunk of data. If no data is returned, we've reached EOF.
-                data_chunk = await async_stream.read(chunk_size)
-                if not data_chunk:
-                    break  # EOF reached
+            async with aiofiles.open(output_path, "w") as output_stream:
+                while True:
+                    data_chunk = await async_stream.read(chunk_size)
+                    if not data_chunk:
+                        break  # EOF reached
 
-                # Attempt to decode and write the data chunk.
-                try:
-                    data_chunk_str = data_chunk.decode()
-                    output_stream.write(data_chunk_str)
-                    output_stream.flush()
-                    mem_buffer += data_chunk_str
-                    # Keep only the last 10k characters in memory.
-                    mem_buffer = mem_buffer[-10000:]
-                except UnicodeDecodeError:
-                    pass  # Ignore decoding errors and continue reading the stream.
+                    try:
+                        data_chunk_str = data_chunk.decode()
+                        await output_stream.write(data_chunk_str)
+                        await output_stream.flush()
+                        mem_buffer += data_chunk_str
+                        mem_buffer = mem_buffer[-10000:]
+                    except UnicodeDecodeError:
+                        pass
         except Exception as e:
-            # Log unexpected errors. This could be any exception raised by
-            # the reading or writing operations. Consider appending an error message
-            # to `mem_buffer` to indicate that an error occurred.
             logger.exception("Stream reading error", error=str(e))
             mem_buffer += "\n[Error reading stream: {}]".format(e)
         finally:
-            # Ensure that the method always returns the buffer, even if an error occurred.
             return mem_buffer
 
     async def _process_poller(self, process: asyncio.subprocess.Process) -> int:
@@ -535,24 +532,21 @@ class WorkerNodeTaskInstance:
         stdout_task = stderr_task = heartbeat_task = None
 
         try:
-            # Context manager to ensure file streams are properly closed after writing.
-            with open(self.stdout, "w") as stdout_stream, open(
-                self.stderr, "w"
-            ) as stderr_stream:
-                # Create asyncio tasks for reading subprocess stdout and stderr.
-                stdout_task = asyncio.create_task(
-                    self._communicate(process.stdout, stdout_stream)
-                )
-                stderr_task = asyncio.create_task(
-                    self._communicate(process.stderr, stderr_stream)
-                )
-                # Task for monitoring the subprocess (e.g., for timeouts or heartbeats).
-                heartbeat_task = asyncio.create_task(self._process_poller(process))
+            # Create asyncio tasks for reading subprocess stdout and stderr.
+            # File I/O is handled via aiofiles inside _communicate so that
+            # slow NFS writes cannot block the event loop or delay heartbeats.
+            stdout_task = asyncio.create_task(
+                self._communicate(process.stdout, self.stdout)
+            )
+            stderr_task = asyncio.create_task(
+                self._communicate(process.stderr, self.stderr)
+            )
+            # Task for monitoring the subprocess (e.g., for timeouts or heartbeats).
+            heartbeat_task = asyncio.create_task(self._process_poller(process))
 
-                # Await the completion of communication and monitoring tasks.
-                # We gather all tasks together, ensuring they are completed before proceeding.
-                valid_tasks = [stdout_task, stderr_task, heartbeat_task]
-                await asyncio.gather(*valid_tasks)
+            # Await the completion of communication and monitoring tasks.
+            valid_tasks = [stdout_task, stderr_task, heartbeat_task]
+            await asyncio.gather(*valid_tasks)
 
         except Exception as e:
             # If an exception occurs, cancel all ongoing tasks to prevent dangling operations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "isort",
     "autoflake",
     "mypy",
+    "types-aiofiles",
     "types-Flask",
     "types-requests",
     "types-PyMySQL",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -15,6 +15,15 @@ members = [
     "jobmon-core",
     "jobmon-server",
     "jobmon-workspace",
+]
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
 ]
 
 [[package]]
@@ -1487,6 +1496,7 @@ provides-extras = ["server"]
 name = "jobmon-core"
 source = { editable = "jobmon_core" }
 dependencies = [
+    { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "docstring-parser" },
     { name = "docutils" },
@@ -1511,6 +1521,7 @@ otlp = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "docstring-parser" },
     { name = "docutils" },
@@ -1623,6 +1634,8 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
+    { name = "types-aiofiles", version = "25.1.0.20251011", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "types-aiofiles", version = "25.1.0.20260408", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "types-flask" },
     { name = "types-flask-cors" },
     { name = "types-mysqlclient" },
@@ -1671,6 +1684,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
+    { name = "types-aiofiles" },
     { name = "types-flask" },
     { name = "types-flask-cors" },
     { name = "types-mysqlclient" },
@@ -3637,6 +3651,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/1a/5f36851f439884bcfe8539f6a20ff7516e7b60f319bbaf69a90dc35cc2eb/typer-0.15.3.tar.gz", hash = "sha256:818873625d0569653438316567861899f7e9972f2e6e0c16dab608345ced713c", size = 101641, upload-time = "2025-04-28T21:40:59.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/20/9d953de6f4367163d23ec823200eb3ecb0050a2609691e512c8b95827a9b/typer-0.15.3-py3-none-any.whl", hash = "sha256:c86a65ad77ca531f03de08d1b9cb67cd09ad02ddddf4b34745b5008f43b239bd", size = 45253, upload-time = "2025-04-28T21:40:56.269Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "25.1.0.20251011"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/6c/6d23908a8217e36704aa9c79d99a620f2fdd388b66a4b7f72fbc6b6ff6c6/types_aiofiles-25.1.0.20251011.tar.gz", hash = "sha256:1c2b8ab260cb3cd40c15f9d10efdc05a6e1e6b02899304d80dfa0410e028d3ff", size = 14535, upload-time = "2025-10-11T02:44:51.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/0f/76917bab27e270bb6c32addd5968d69e558e5b6f7fb4ac4cbfa282996a96/types_aiofiles-25.1.0.20251011-py3-none-any.whl", hash = "sha256:8ff8de7f9d42739d8f0dadcceeb781ce27cd8d8c4152d4a7c52f6b20edb8149c", size = 14338, upload-time = "2025-10-11T02:44:50.054Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "25.1.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/74/0760ad0b138edba9ba77b968c44d66ab834b7fc5a1d06ec447701851e321/types_aiofiles-25.1.0.20260408.tar.gz", hash = "sha256:7023ff9fac150f7d69c34436daa1e42c8358b5742dc69471053b533894b7d328", size = 14764, upload-time = "2026-04-08T04:33:11.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/8e/fd2a1385795005cae5037f679c42d673cdb08faea527e36b52003efd059b/types_aiofiles-25.1.0.20260408-py3-none-any.whl", hash = "sha256:45e4c39f49f515c6e147e94c9cba52eeca0b5bf30dd0f0439378d95a5c724292", size = 14339, upload-time = "2026-04-08T04:33:10.077Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Worker node's `_communicate` method was doing synchronous `write()`/`flush()` on NFS-backed log paths inside the asyncio event loop. When NFS is slow, these block the main thread, preventing heartbeat poller timeouts from firing (causes U-status race condition) and SIGTERM delivery (causes Slurm node drains via "Kill task failed").
- Switch to `aiofiles` so file I/O is offloaded to a thread pool. The event loop stays responsive for heartbeats and signal handling regardless of NFS performance.
- Elevate `log_report_by` from DEBUG to INFO so worker heartbeat attempts are visible in Elasticsearch for diagnosing future issues.

## Context

Investigated TaskInstance 350046932 which failed with a U-status TransitionError. ES/APM traces confirmed the worker started running but sent zero heartbeats for 5+ minutes — the poller's `asyncio.wait_for` timeout never fired because the event loop was blocked by synchronous NFS writes in `_communicate`.

This same root cause explains HELP-75495 (Slurm nodes drained due to "Kill task failed"): when the nanny process is blocked on NFS I/O, it cannot handle SIGTERM within Slurm's KillWait timeout, causing the controller to drain the node.

## Test plan

- [x] `test_unicode` (exercises `_communicate` directly) — passed
- [x] `test_output_capture` (3 tests, full worker lifecycle) — passed
- [x] Full test suite (`uv run pytest -n 10`) — 934 passed, 6 skipped
- [x] Pre-commit hooks (format, lint, typecheck) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how worker nodes stream subprocess stdout/stderr to disk and adjusts heartbeat logging, which can affect runtime behavior and observability under load (especially on NFS-backed log paths). Dependency updates (`aiofiles`) also change the runtime environment for `jobmon_core`.
> 
> **Overview**
> Updates worker-node subprocess output capture to write `stdout`/`stderr` via `aiofiles` inside `_communicate`, avoiding synchronous file I/O in the asyncio event loop (and reducing the chance of heartbeats being delayed by slow filesystem writes).
> 
> Adds `aiofiles` (and `types-aiofiles` for dev/typechecking) to project dependencies/lockfile, and bumps the heartbeat log message in `log_report_by` from DEBUG to INFO for better visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd04563201dbb4d23dc9e9dc21d37aec70f561c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->