### PR TITLE
Surface fatal swarm errors to users

### DIFF
--- a/jobmon_client/src/jobmon/client/commands/workflow.py
+++ b/jobmon_client/src/jobmon/client/commands/workflow.py
@@ -9,6 +9,7 @@ Commands for querying and managing workflow state, including:
 """
 
 import getpass
+import traceback
 from io import StringIO
 from typing import Dict, List, Optional, Union
 
@@ -293,7 +294,18 @@ def resume_workflow_from_id(
     if result.final_status == WorkflowRunStatus.DONE:
         print(f"Workflow {workflow_id} has successfully resumed to completion.")
     else:
+        error_detail = f"failed with status {result.final_status}"
+        if result.error is not None:
+            tb = "".join(
+                traceback.format_exception(
+                    type(result.error),
+                    result.error,
+                    result.error.__traceback__,
+                )
+            )
+            error_detail += f"\n\nCaused by:\n{tb}"
         raise WorkflowRunStateError(
-            f"Workflow run {new_wfr.workflow_run_id}, associated with workflow {workflow_id}",
-            f"failed with status {result.final_status}",
+            f"Workflow run {new_wfr.workflow_run_id},"
+            f" associated with workflow {workflow_id}",
+            error_detail,
         )

--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -70,6 +70,8 @@ class OrchestratorResult:
     done_task_ids: frozenset[int]
     #: Immutable set of task IDs that failed fatally.
     failed_task_ids: frozenset[int]
+    #: The fatal exception that terminated the run, if any.
+    error: Optional[BaseException] = None
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/jobmon_client/src/jobmon/client/swarm/run.py
+++ b/jobmon_client/src/jobmon/client/swarm/run.py
@@ -78,7 +78,9 @@ def _is_event_loop_running() -> bool:
 
 
 def _build_result_from_state(
-    state: SwarmState, start_time: float
+    state: SwarmState,
+    start_time: float,
+    error: Optional[BaseException] = None,
 ) -> OrchestratorResult:
     """Build an OrchestratorResult from current state when orchestrator exits early.
 
@@ -88,6 +90,7 @@ def _build_result_from_state(
     Args:
         state: The current SwarmState.
         start_time: When execution started (from time.perf_counter()).
+        error: The fatal exception that caused early exit, if any.
 
     Returns:
         OrchestratorResult with current state snapshot.
@@ -112,6 +115,7 @@ def _build_result_from_state(
         task_final_statuses=task_final_statuses,
         done_task_ids=done_task_ids,
         failed_task_ids=failed_task_ids,
+        error=error,
     )
 
 
@@ -445,7 +449,7 @@ async def _run_orchestrator(
                 error=str(e),
                 error_type=type(e).__name__,
             )
-            return _build_result_from_state(state, start_time)
+            return _build_result_from_state(state, start_time, error=e)
 
         except (DistributorNotAlive, DistributorInterruptedError, WorkflowTestError):
             # Critical exceptions must propagate to callers
@@ -461,7 +465,7 @@ async def _run_orchestrator(
                 error=str(e),
                 error_type=type(e).__name__,
             )
-            return _build_result_from_state(state, start_time)
+            return _build_result_from_state(state, start_time, error=e)
 
     finally:
         # Cleanup

--- a/jobmon_client/src/jobmon/client/workflow.py
+++ b/jobmon_client/src/jobmon/client/workflow.py
@@ -9,6 +9,7 @@ import itertools
 import os
 import sys
 import time
+import traceback
 import uuid
 from subprocess import PIPE, Popen, TimeoutExpired
 from types import TracebackType
@@ -287,6 +288,7 @@ class Workflow(object):
 
         self._fail_after_n_executions = 1_000_000_000
         self.last_workflow_run_id: Optional[int] = None
+        self.error: Optional[BaseException] = None
 
     @property
     def tool(self) -> Tool:
@@ -647,8 +649,24 @@ class Workflow(object):
             for task in self.tasks.values():
                 task.final_status = result.task_final_statuses[task.task_id]
 
+            # Store error for programmatic access
+            self.error = result.error
+
             # Log completion
             if result.final_status != WorkflowRunStatus.DONE:
+                if result.error is not None:
+                    tb = "".join(
+                        traceback.format_exception(
+                            type(result.error),
+                            result.error,
+                            result.error.__traceback__,
+                        )
+                    )
+                    logger.error(
+                        "WorkflowRun failed with error",
+                        error_type=type(result.error).__name__,
+                        traceback=tb,
+                    )
                 logger.info(
                     f"WorkflowRun execution ended, num failed {result.failed_count}"
                 )


### PR DESCRIPTION
## Summary
- Fatal exceptions during orchestrator execution (e.g. `PermissionError` from Slurm resource validation) were silently swallowed and replaced with a generic `failed with status E` message
- Users had no way to diagnose root cause without Elasticsearch access
- Adds `error` field to `OrchestratorResult`, logs full traceback via structlog, includes traceback in `WorkflowRunStateError`, and exposes `workflow.error` for programmatic access

## Context
Investigated via WFR 382582 (workflow 562601): user `jchalek` ran a workflow with stderr pointed to `ferozk`'s directory. The Slurm plugin's `_validate_stdout_stderr` raised `PermissionError`, which was caught by `_run_orchestrator`'s `except Exception` and silently returned as a status-only result. The companion fix to `_validate_stdout_stderr` itself was pushed directly to `jobmon_slurm` main.

## Test plan
- [x] All 568 unit tests pass
- [x] All 17 swarm integration tests pass (3 separate runs)
- [ ] Verify error message is visible in a real failure scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core workflow execution/resume path to propagate exceptions; while behavior is mostly additive, it changes failure reporting and could affect downstream callers that assume status-only failures.
> 
> **Overview**
> **Surfaces fatal swarm/orchestrator exceptions to callers and users.** `OrchestratorResult` now carries an optional `error`, and `swarm/run.py` populates it when returning early results from fail-fast/other exceptions.
> 
> `Workflow.run()` stores the fatal exception on `workflow.error` and logs the full traceback via structlog when a run ends non-`DONE`. The `resume_workflow_from_id` command now includes the underlying exception traceback in the raised `WorkflowRunStateError`, replacing the previous generic status-only failure message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4db75f63b1c761799ce173a2d6fe53e4269194f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->