### PR TITLE
Fix /task_resources deserialization to handle JSON booleans

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_resources.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_resources.py
@@ -1,6 +1,7 @@
 """Routes for Task Resources."""
 
 import ast
+import json
 from http import HTTPStatus as StatusCodes
 from typing import Any
 
@@ -19,6 +20,20 @@ from jobmon.server.web.routes.v3.fsm import fsm_router as api_v3_router
 logger = structlog.get_logger(__name__)
 
 
+def _deserialize_requested_resources(raw: str) -> Any:
+    """Deserialize a requested_resources column value.
+
+    New rows are written via ``json.dumps`` by ``/task/bind_resources``, which
+    emits JSON (lowercase ``true``/``false``/``null``). Older rows may be
+    Python ``repr``-style (``True``/``False``/``None``) from pre-FastAPI
+    versions. Try JSON first, fall back to ``ast.literal_eval``.
+    """
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return ast.literal_eval(raw)
+
+
 @api_v3_router.post("/task_resources/{task_resources_id}")
 def get_task_resources(task_resources_id: int, db: Session = Depends(get_db)) -> Any:
     """Return an task_resources."""
@@ -32,7 +47,9 @@ def get_task_resources(task_resources_id: int, db: Session = Depends(get_db)) ->
     row = db.execute(select_stmt).fetchone()
     requested_resources_raw, queue_name = row if row else (None, None)
     requested_resources = (
-        ast.literal_eval(requested_resources_raw) if requested_resources_raw else None
+        _deserialize_requested_resources(requested_resources_raw)
+        if requested_resources_raw
+        else None
     )
 
     resp = JSONResponse(

--- a/tests/unit/server/test_task_resources_routes.py
+++ b/tests/unit/server/test_task_resources_routes.py
@@ -1,0 +1,56 @@
+"""Unit tests for the task_resources route helpers."""
+
+import pytest
+
+from jobmon.server.web.routes.v3.fsm.task_resources import (
+    _deserialize_requested_resources,
+)
+
+
+class TestDeserializeRequestedResources:
+    """Test the deserialize helper used by /task_resources/{id}.
+
+    Requested resources are written via ``json.dumps`` by
+    ``/task/bind_resources`` (which emits lowercase JSON literals) but older
+    rows may use Python ``repr``-style literals. The helper must handle both.
+    """
+
+    def test_json_dict_with_json_booleans(self) -> None:
+        """Rows written by json.dumps contain lowercase true/false/null.
+
+        Regression test: previously the route called ast.literal_eval which
+        raised ValueError on JSON booleans, producing 500s that crashed the
+        distributor and stuck tasks in INSTANTIATED indefinitely.
+        """
+        raw = (
+            '{"project": "proj_dismod_at", "memory": 2, "runtime": 1024, '
+            '"cores": 3, "absolute_buffer_applied": true, '
+            '"absolute_buffer_min": 5, "runtime_before_buffer_sec": 723.23}'
+        )
+        result = _deserialize_requested_resources(raw)
+        assert result["absolute_buffer_applied"] is True
+        assert result["memory"] == 2
+        assert result["runtime_before_buffer_sec"] == pytest.approx(723.23)
+
+    def test_json_with_null(self) -> None:
+        raw = '{"project": "proj_test", "stderr": null}'
+        result = _deserialize_requested_resources(raw)
+        assert result["stderr"] is None
+
+    def test_python_repr_style_dict_fallback(self) -> None:
+        """Legacy rows may use Python repr with True/False/None."""
+        raw = (
+            "{'project': 'proj_test', 'absolute_buffer_applied': True, 'stderr': None}"
+        )
+        result = _deserialize_requested_resources(raw)
+        assert result["absolute_buffer_applied"] is True
+        assert result["stderr"] is None
+
+    def test_plain_json_dict(self) -> None:
+        raw = '{"memory": 10, "cores": 1}'
+        result = _deserialize_requested_resources(raw)
+        assert result == {"memory": 10, "cores": 1}
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises((ValueError, SyntaxError)):
+            _deserialize_requested_resources("not a dict at all {{{")


### PR DESCRIPTION
## Summary

- `/task/bind_resources` writes `requested_resources` via `json.dumps` (lowercase `true`/`false`/`null`), but `/task_resources/{id}` read via `ast.literal_eval`, which only accepts Python literals. Any row containing a JSON boolean — e.g. user-added metadata like `absolute_buffer_applied: true` — returned HTTP 500 from the read endpoint.
- Replace the bare `ast.literal_eval` call with a helper that tries `json.loads` first (for rows written by the current `bind_resources` code) and falls back to `ast.literal_eval` for legacy Python-repr rows from pre-FastAPI versions.

## Why this matters

In the distributor the 500 surfaces as a `TypeError` in `task_instance_batch.load_requested_resources`, which is swallowed by `DistributorCommand` **after** the batch has already been popped from `_task_instance_batches`. The TI is never transitioned out of `INSTANTIATED` locally, so `_check_instantiated_for_work` re-yields the stale batch every cycle, hitting "Batch already removed from tracking" forever and **gridlocking the entire DAG on a single stuck task**.

Observed in prod:
- Workflow `562561` / WFR `382695` stuck for 9+ hours with **687 G-status tasks** blocked behind a single `INSTANTIATED` TI (task `331588680`, `fit_4875.male__43906_43942`)
- **73 instances** of this `TypeError` across 20+ workflow runs since 2026-03-23, spiking after dismod_at started stashing booleans in `requested_resources` at scale on 2026-04-07
- **136 of 139** task_resources rows for WFR 382695 contain JSON-style booleans — every single row is unparseable by the current server code

## Test plan

- [x] `uv run pytest tests/unit/server/test_task_resources_routes.py -v` — 5/5 pass
- [x] `uv run nox -s format`
- [x] `uv run nox -s lint`
- [x] `uv run nox -s typecheck`
- [ ] Full suite `uv run pytest -n 10`
- [ ] Manual verification against prod-stuck row: `POST /api/v3/task_resources/50174922` returns 200 after deploy
- [ ] Monitor ES `error-default` index for the TypeError signature post-deploy

## Follow-ups (not in this PR)

1. **Distributor state recovery**: `launch_task_instance_batch` pops the batch before `prepare_task_instance_batch_for_launch` runs, so any failure there leaves TIs permanently in `INSTANTIATED` with no recovery path. The fix commit `1c2f2b25` added an early-return for the re-yield case but doesn't recover the stuck TIs. Needs a separate fix to transition them to `NO_DISTRIBUTOR_ID` on `prepare_` failure.
2. **Unstick workflow 562561 now**: manually mark TI `350369842` as Error so the swarm retries the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: confines changes to parsing of the `requested_resources` payload for a single endpoint, adding JSON support while preserving legacy `repr` parsing; main risk is unexpected behavior if stored strings are neither valid JSON nor Python literals.
> 
> **Overview**
> Fixes `POST /api/v3/task_resources/{id}` to correctly parse `requested_resources` values stored as JSON (including `true`/`false`/`null`) by trying `json.loads` first and falling back to `ast.literal_eval` for legacy rows.
> 
> Adds unit tests covering JSON booleans/null, legacy Python-literal rows, and invalid input to prevent regressions that previously caused 500s when encountering JSON-style booleans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c62ad2f3f40cd249280f5b372013fcc4ca6460f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->