### PR TITLE
Stop orchestrator spin on sustained HTTP failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ All notable changes to Jobmon will be documented in this file.
 - Unified status colors across all views (DAG, popover, concurrency chart, summary panel) into shared constants
 
 ### Fixed
+- **Orchestrator HTTP failure cascade**: Fixed the `File descriptor N is used by transport <_SelectorSocketTransport>` runaway cascade where a single aiohttp `ClientTimeout` could leak an asyncio transport and cause the orchestrator main loop to spin at ~300 errors/sec indefinitely. Four-layer fix:
+  - `asyncio.TimeoutError` is now included in `Requester._should_retry_exception`, closing a Python 3.10 gap where it did not inherit from builtin `TimeoutError` and silently bypassed tenacity's retry/backoff
+  - `ServerGateway._request` tracks consecutive post-tenacity failures and recycles the underlying `aiohttp.ClientSession` after `SESSION_RECYCLE_THRESHOLD` (5) consecutive failures, rebuilding the `TCPConnector` to clear leaked transport state
+  - `WorkflowRunOrchestrator._main_loop` enforces a `MIN_LOOP_SLEEP` (1.0s) floor per iteration so the loop cannot spin hot when `time_till_next_sync` collapses to 0 during sustained heartbeat failure
+  - `Synchronizer.tick()` and `HeartbeatService.run_background()` now raise a new `FatalOrchestratorError` after sustained failure (3 consecutive all-failed sync ticks or 5 consecutive heartbeat failures). `WorkflowRunOrchestrator._check_heartbeat_task_healthy()` surfaces background-task failures into the main loop, and `run.py` propagates `FatalOrchestratorError` alongside `DistributorNotAlive` so users see a clean failure instead of a silent spin
+  - `Synchronizer._get_array_concurrency_limits` now raises when every per-array query fails (instead of silently returning an empty `StateUpdate`), ensuring complete array-concurrency outages are counted by the consecutive-failure guard
 - **WorkflowDAG Missing CSS**: Added `reactflow/dist/style.css` import to `WorkflowDAG.tsx`; previously relied on `TaskDAG.tsx` importing it, which broke when route-level code splitting separated them into different chunks
 - **Concurrency Input**: PUT request now fires on blur instead of every keystroke
 - **Template Detail State**: Panel resets local state (concurrency value, status message) when switching templates

--- a/jobmon_client/src/jobmon/client/swarm/gateway.py
+++ b/jobmon_client/src/jobmon/client/swarm/gateway.py
@@ -93,6 +93,13 @@ class ServerGateway:
         response = await gateway.log_heartbeat(...)
     """
 
+    #: Number of consecutive post-tenacity failures before recycling the aiohttp
+    #: session. Tenacity already handles per-request transient failures, so
+    #: reaching this count means a true sustained failure (or session-state
+    #: corruption like the asyncio selector fd leak). Recycling creates a fresh
+    #: ClientSession/TCPConnector, which clears any leaked transports.
+    SESSION_RECYCLE_THRESHOLD: int = 5
+
     def __init__(
         self,
         requester: Requester,
@@ -111,6 +118,9 @@ class ServerGateway:
         self.workflow_run_id = workflow_run_id
         self._session: Optional[aiohttp.ClientSession] = None
         self._owns_session: bool = False
+        #: Counter for consecutive failures through _request. Reset on any
+        #: successful call. Drives session recycling.
+        self._consecutive_failures: int = 0
 
     async def __aenter__(self) -> "ServerGateway":
         """Async context manager entry - creates session."""
@@ -150,6 +160,35 @@ class ServerGateway:
             self._owns_session = True
         return self._session
 
+    async def _recycle_session(self) -> None:
+        """Close the current aiohttp session so the next request gets a fresh one.
+
+        This is the recovery path for cases where the existing session's
+        underlying event-loop state has become corrupted — most notably the
+        asyncio ``_SelectorSocketTransport`` fd leak that can occur when
+        aiohttp+aiohappyeyeballs cancellation races a connect. Creating a new
+        ``ClientSession`` builds a new ``TCPConnector`` with fresh transport
+        registrations, which breaks the collision cycle.
+
+        Idempotent under concurrent callers: the first coroutine to reach here
+        transfers ownership of the old session to a local variable and nulls
+        out ``self._session``, so later callers see ``None`` and return
+        without double-closing.
+        """
+        old = self._session
+        if old is None or old.closed:
+            return
+        # Swap out the reference before awaiting close() so concurrent callers
+        # in _ensure_session will build a new session on their next attempt.
+        self._session = None
+        try:
+            await old.close()
+        except Exception as e:
+            logger.warning(
+                "Error closing aiohttp session during recycle",
+                error=str(e),
+            )
+
     async def _request(
         self,
         app_route: str,
@@ -158,6 +197,12 @@ class ServerGateway:
         tenacious: bool = True,
     ) -> tuple[int, Any]:
         """Make an async HTTP request.
+
+        Every public gateway method routes through this chokepoint. We track
+        consecutive post-tenacity failures here so that sustained HTTP pain
+        (true server outage OR session-state corruption like a leaked asyncio
+        transport) triggers a session recycle rather than an unbounded log
+        cascade from the orchestrator's main loop.
 
         Args:
             app_route: The API route to request.
@@ -169,13 +214,31 @@ class ServerGateway:
             Tuple of (status_code, response_content).
         """
         session = await self._ensure_session()
-        return await self.requester.send_request_async(
-            session=session,
-            app_route=app_route,
-            message=message,
-            request_type=request_type,
-            tenacious=tenacious,
-        )
+        try:
+            result = await self.requester.send_request_async(
+                session=session,
+                app_route=app_route,
+                message=message,
+                request_type=request_type,
+                tenacious=tenacious,
+            )
+        except Exception:
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= self.SESSION_RECYCLE_THRESHOLD:
+                logger.error(
+                    "Recycling aiohttp session after consecutive HTTP failures",
+                    consecutive_failures=self._consecutive_failures,
+                    app_route=app_route,
+                    threshold=self.SESSION_RECYCLE_THRESHOLD,
+                )
+                await self._recycle_session()
+                # Reset so the next batch of failures has to hit the threshold
+                # on the new session before we recycle again.
+                self._consecutive_failures = 0
+            raise
+        else:
+            self._consecutive_failures = 0
+            return result
 
     # ──────────────────────────────────────────────────────────────────────────
     # Heartbeat Operations

--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -479,12 +479,26 @@ class WorkflowRunOrchestrator:
         object but does not propagate to this main loop automatically. We
         poll the task state each iteration and re-raise any stored exception
         so the orchestrator can terminate the run cleanly.
+
+        Guards against a cancelled task: in current code paths the heartbeat
+        task is only cancelled in ``_teardown`` after the main loop has
+        exited, so we should never observe a cancelled task here. But
+        ``asyncio.Task.exception()`` *raises* ``CancelledError`` (a
+        ``BaseException``) rather than returning it for cancelled tasks,
+        which would bypass every ``except Exception`` handler upstream.
+        Check ``task.cancelled()`` first to make this defensive against
+        any future refactor that cancels the heartbeat mid-run.
         """
         task = self._heartbeat_task
         if task is None or not task.done():
             return
-        # Task finished. If it has an exception, propagate it. If it exited
-        # cleanly (e.g. stop_event was set), nothing to do.
+        if task.cancelled():
+            # Nothing to surface — cancellation is driven by our own
+            # teardown path, which handles propagation explicitly.
+            return
+        # Task finished without cancellation. If it stored an exception,
+        # propagate it; if it exited cleanly (stop_event was set),
+        # nothing to do.
         exc = task.exception()
         if exc is not None:
             raise exc

--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -176,6 +176,16 @@ class WorkflowRunOrchestrator:
         result = await orchestrator.run(distributor_alive_callable)
     """
 
+    #: Minimum wall-clock seconds between main-loop iterations, independent of
+    #: the heartbeat interval. This is a hard floor that prevents the main loop
+    #: from spinning at hundreds of iterations per second in pathological
+    #: scenarios — for example when heartbeats are failing and
+    #: ``time_since_last_heartbeat()`` collapses ``time_till_next_sync`` to 0.
+    #: A 1-second floor has no practical impact on healthy runs (normal sync
+    #: interval is 30s) but caps worst-case log volume by 2+ orders of
+    #: magnitude during sustained HTTP failure.
+    MIN_LOOP_SLEEP: float = 1.0
+
     def __init__(
         self,
         state: SwarmState,
@@ -352,6 +362,10 @@ class WorkflowRunOrchestrator:
             # Check constraints
             self._check_timeout(start_time)
             await self._check_distributor_alive(distributor_alive_callable)
+            # Surface background heartbeat task failures (e.g. sustained HTTP
+            # failure → FatalOrchestratorError) so the main loop terminates
+            # instead of continuing with stale state.
+            self._check_heartbeat_task_healthy()
 
             # Check if heartbeat service detected a status change
             self._sync_heartbeat_status()
@@ -384,10 +398,14 @@ class WorkflowRunOrchestrator:
             if self._state.status == WorkflowRunStatus.RUNNING:
                 await self._do_scheduling(timeout=time_till_next_sync)
 
-            # Sleep if we finished early
+            # Sleep if we finished early. Apply MIN_LOOP_SLEEP as a hard floor
+            # so the loop cannot spin hot when time_till_next_sync collapses to
+            # 0 (e.g. during sustained heartbeat failure). Defense in depth on
+            # top of the gateway's session-recycle + fatal-exit counters.
             loop_elapsed = time.perf_counter() - iteration_start
-            if loop_elapsed < time_till_next_sync:
-                await asyncio.sleep(time_till_next_sync - loop_elapsed)
+            target_sleep = max(self.MIN_LOOP_SLEEP, time_till_next_sync) - loop_elapsed
+            if target_sleep > 0:
+                await asyncio.sleep(target_sleep)
                 loop_elapsed = time.perf_counter() - iteration_start
 
             # Sync with server
@@ -451,6 +469,25 @@ class WorkflowRunOrchestrator:
             raise DistributorNotAlive(
                 "Distributor process unexpectedly stopped. Workflow will error."
             )
+
+    def _check_heartbeat_task_healthy(self) -> None:
+        """Verify the background heartbeat task has not died with an exception.
+
+        The heartbeat service runs as an asyncio.Task created in ``run()``. If
+        it raises (for example ``FatalOrchestratorError`` after too many
+        consecutive heartbeat failures), the exception is stored in the task
+        object but does not propagate to this main loop automatically. We
+        poll the task state each iteration and re-raise any stored exception
+        so the orchestrator can terminate the run cleanly.
+        """
+        task = self._heartbeat_task
+        if task is None or not task.done():
+            return
+        # Task finished. If it has an exception, propagate it. If it exited
+        # cleanly (e.g. stop_event was set), nothing to do.
+        exc = task.exception()
+        if exc is not None:
+            raise exc
 
     def _check_fail_fast(self) -> None:
         """Check fail-fast condition."""
@@ -748,13 +785,30 @@ class WorkflowRunOrchestrator:
         )
 
     async def _handle_error(self) -> None:
-        """Transition to ERROR state on exception."""
+        """Transition to ERROR state on exception.
+
+        Best-effort only — this is called from the exception handler in
+        ``run()`` and must not raise, or it will mask the original exception.
+        If the status update fails (e.g. because the server is unreachable,
+        which is exactly the scenario that raised FatalOrchestratorError in
+        the first place), we log and continue. The server-side reaper will
+        eventually transition the run to ERROR once the heartbeat goes stale.
+        """
         try:
             await self._update_status(WorkflowRunStatus.ERROR)
         except TransitionError as e:
             logger.warning(
                 "Failed to update workflow run status to ERROR",
                 error=str(e),
+            )
+        except Exception as e:
+            # Cannot reach the server to set ERROR status. Log and continue
+            # so the original exception propagates unmasked.
+            logger.warning(
+                "Could not update workflow run status to ERROR "
+                "(server unreachable) — relying on server-side reaper",
+                error=str(e),
+                error_type=type(e).__name__,
             )
 
     async def _teardown(self) -> None:

--- a/jobmon_client/src/jobmon/client/swarm/run.py
+++ b/jobmon_client/src/jobmon/client/swarm/run.py
@@ -477,8 +477,16 @@ async def _run_orchestrator(
             return _build_result_from_state(state, start_time, error=e)
 
     finally:
-        # Cleanup
+        # Cleanup. Close both the original externally-owned session AND any
+        # gateway-owned replacement that may have been created by
+        # ``gateway._recycle_session`` during the run. The local ``session``
+        # variable here still points at the original — it goes stale after
+        # any recycle, and closing it becomes a no-op. ``gateway.close()``
+        # is idempotent and only closes sessions the gateway owns (i.e.
+        # those built by ``_ensure_session`` after a recycle), so it is
+        # safe to call in both the recycle and no-recycle paths.
         if not session.closed:
             await session.close()
+        await gateway.close()
         # Unbind workflow context
         unset_jobmon_context("workflow_run_id", "workflow_id")

--- a/jobmon_client/src/jobmon/client/swarm/run.py
+++ b/jobmon_client/src/jobmon/client/swarm/run.py
@@ -31,6 +31,7 @@ from jobmon.core.constants import TaskStatus, WorkflowRunStatus
 from jobmon.core.exceptions import (
     DistributorInterruptedError,
     DistributorNotAlive,
+    FatalOrchestratorError,
     TransitionError,
     WorkflowTestError,
 )
@@ -451,10 +452,18 @@ async def _run_orchestrator(
             )
             return _build_result_from_state(state, start_time, error=e)
 
-        except (DistributorNotAlive, DistributorInterruptedError, WorkflowTestError):
+        except (
+            DistributorNotAlive,
+            DistributorInterruptedError,
+            FatalOrchestratorError,
+            WorkflowTestError,
+        ):
             # Critical exceptions must propagate to callers
             # - DistributorNotAlive: Distributor died unexpectedly (documented in docstring)
             # - DistributorInterruptedError: Distributor received interrupt signal
+            # - FatalOrchestratorError: Sustained HTTP failure that recycling
+            #   and backoff could not recover from — user must restart the
+            #   workflow run on a fresh process/session.
             # - WorkflowTestError: Test infrastructure error that should fail tests
             raise
 

--- a/jobmon_client/src/jobmon/client/swarm/services/heartbeat.py
+++ b/jobmon_client/src/jobmon/client/swarm/services/heartbeat.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from jobmon.client.swarm.state import StateUpdate
+from jobmon.core.exceptions import FatalOrchestratorError
 
 if TYPE_CHECKING:
     from jobmon.client.swarm.gateway import ServerGateway
@@ -52,6 +53,13 @@ class HeartbeatService:
         await task
     """
 
+    #: After this many consecutive heartbeat failures in the background loop,
+    #: raise FatalOrchestratorError so the orchestrator terminates the
+    #: workflow run instead of silently looping forever with stale state. At
+    #: the default heartbeat interval of 30s this represents ~2.5 minutes of
+    #: total darkness before fatal exit.
+    MAX_CONSECUTIVE_HEARTBEAT_FAILURES: int = 5
+
     def __init__(
         self,
         gateway: "ServerGateway",
@@ -75,6 +83,9 @@ class HeartbeatService:
         # Initialize to current time so the main loop doesn't spin without sleeping
         # while waiting for the first heartbeat to be logged
         self._last_heartbeat_time: float = time.time()
+        #: Number of consecutive failed heartbeats in the background loop.
+        #: Reset on any successful heartbeat.
+        self._consecutive_failures: int = 0
 
     @property
     def interval(self) -> float:
@@ -139,17 +150,22 @@ class HeartbeatService:
     async def tick(self) -> StateUpdate:
         """Log a heartbeat and return any status change.
 
+        Successful ticks reset the consecutive-failure counter that drives
+        ``run_background``'s fatal-exit guard.
+
         Returns:
             StateUpdate with workflow_run_status if status changed,
             otherwise an empty StateUpdate.
 
         Raises:
-            Exception: If the heartbeat request fails.
+            Exception: If the heartbeat request fails. The caller is
+                responsible for deciding whether to retry or bail.
         """
         response = await self._gateway.log_heartbeat(
             status=self._current_status,
             next_report_increment=self.next_report_increment,
         )
+        self._consecutive_failures = 0
         return self._handle_heartbeat_response(response.status)
 
     def tick_sync(self) -> StateUpdate:
@@ -206,6 +222,34 @@ class HeartbeatService:
                 if self.is_heartbeat_due():
                     try:
                         update = await self.tick()
+                    except FatalOrchestratorError:
+                        # Already-fatal error from a downstream component (e.g.
+                        # gateway session recycle loop giving up). Propagate
+                        # directly so the orchestrator can terminate the run.
+                        raise
+                    except Exception:
+                        self._consecutive_failures += 1
+                        logger.exception(
+                            "Background heartbeat failed",
+                            consecutive_failures=self._consecutive_failures,
+                            threshold=self.MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+                        )
+                        if (
+                            self._consecutive_failures
+                            >= self.MAX_CONSECUTIVE_HEARTBEAT_FAILURES
+                        ):
+                            raise FatalOrchestratorError(
+                                "HeartbeatService: "
+                                f"{self._consecutive_failures} consecutive "
+                                "heartbeats failed — terminating workflow "
+                                "run. The server is unreachable or the "
+                                "aiohttp session is unrecoverable. See "
+                                "preceding exceptions for details."
+                            )
+                        # Keep trying heartbeats until we hit the threshold.
+                    else:
+                        # Successful heartbeat — reset the failure counter.
+                        self._consecutive_failures = 0
                         if update.workflow_run_status:
                             # Log that we received a status change
                             # The orchestrator should handle applying this
@@ -213,12 +257,13 @@ class HeartbeatService:
                                 "Background heartbeat detected status change",
                                 new_status=update.workflow_run_status,
                             )
-                    except Exception:
-                        logger.exception("Background heartbeat failed")
-                        # Don't re-raise - keep trying heartbeats
 
         except asyncio.CancelledError:
             logger.debug("Heartbeat background loop cancelled")
+            raise
+        except FatalOrchestratorError:
+            # Propagate fatal errors directly without logger.exception noise;
+            # the caller (orchestrator) is expected to handle termination.
             raise
         except Exception:
             logger.exception("Heartbeat loop error")

--- a/jobmon_client/src/jobmon/client/swarm/services/heartbeat.py
+++ b/jobmon_client/src/jobmon/client/swarm/services/heartbeat.py
@@ -150,8 +150,13 @@ class HeartbeatService:
     async def tick(self) -> StateUpdate:
         """Log a heartbeat and return any status change.
 
-        Successful ticks reset the consecutive-failure counter that drives
-        ``run_background``'s fatal-exit guard.
+        This is a pure "do one heartbeat" primitive: it does not touch
+        ``_consecutive_failures``. That counter is owned exclusively by
+        ``run_background``'s supervisor loop (the only site that reads
+        the threshold and raises ``FatalOrchestratorError``). Keeping
+        ownership in one place avoids a race where a direct ``tick()``
+        call from outside the supervisor could silently clear the
+        supervisor's failure state and mask a sustained outage.
 
         Returns:
             StateUpdate with workflow_run_status if status changed,
@@ -165,7 +170,6 @@ class HeartbeatService:
             status=self._current_status,
             next_report_increment=self.next_report_increment,
         )
-        self._consecutive_failures = 0
         return self._handle_heartbeat_response(response.status)
 
     def tick_sync(self) -> StateUpdate:

--- a/jobmon_client/src/jobmon/client/swarm/services/synchronizer.py
+++ b/jobmon_client/src/jobmon/client/swarm/services/synchronizer.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Optional
 import structlog
 
 from jobmon.client.swarm.state import StateUpdate
+from jobmon.core.exceptions import FatalOrchestratorError
 
 if TYPE_CHECKING:
     from jobmon.client.swarm.gateway import ServerGateway
@@ -49,6 +50,15 @@ class Synchronizer:
         state.apply_update(update)
     """
 
+    #: After this many consecutive ticks where *every* operation fails, raise
+    #: FatalOrchestratorError to terminate the workflow run. Individual
+    #: operation failures are still tolerated (other operations may still
+    #: succeed). With a default heartbeat_interval of 30s this is ~90s of
+    #: total-darkness before fatal exit, which is generous enough to ride
+    #: through a brief server restart but short enough to prevent an
+    #: unbounded wedge during a real outage.
+    MAX_CONSECUTIVE_TOTAL_FAILURE_TICKS: int = 3
+
     def __init__(
         self,
         gateway: "ServerGateway",
@@ -65,6 +75,9 @@ class Synchronizer:
         self._gateway = gateway
         self._task_ids = task_ids
         self._array_ids = array_ids
+        #: Number of consecutive tick() calls where every sync operation
+        #: failed. Reset when any operation succeeds.
+        self._consecutive_total_failure_ticks: int = 0
 
     @property
     def task_ids(self) -> set[int]:
@@ -136,8 +149,10 @@ class Synchronizer:
         if self._array_ids:
             op_names.append("array_concurrency")
 
+        num_failed = 0
         for i, result in enumerate(results):
             if isinstance(result, BaseException):
+                num_failed += 1
                 logger.warning(
                     f"Sync operation '{op_names[i]}' failed",
                     error=str(result),
@@ -145,6 +160,26 @@ class Synchronizer:
                 )
             elif isinstance(result, StateUpdate):
                 combined = combined.merge(result)
+
+        # Track sustained failure: if *every* operation in this tick failed,
+        # increment the consecutive-failure counter. Any successful operation
+        # resets it. After MAX_CONSECUTIVE_TOTAL_FAILURE_TICKS all-failed
+        # ticks, raise a fatal error so the orchestrator terminates the run
+        # instead of silently spinning forever on a broken connection.
+        if num_failed == len(results) and num_failed > 0:
+            self._consecutive_total_failure_ticks += 1
+            if (
+                self._consecutive_total_failure_ticks
+                >= self.MAX_CONSECUTIVE_TOTAL_FAILURE_TICKS
+            ):
+                raise FatalOrchestratorError(
+                    "Synchronizer: all sync operations failed for "
+                    f"{self._consecutive_total_failure_ticks} consecutive "
+                    "ticks — terminating workflow run. Check server "
+                    "reachability and see preceding warnings for details."
+                )
+        else:
+            self._consecutive_total_failure_ticks = 0
 
         logger.debug(
             "Synchronization complete",
@@ -210,6 +245,14 @@ class Synchronizer:
 
         Returns:
             StateUpdate with array_limits.
+
+        Raises:
+            RuntimeError: If every per-array query failed. This lets the
+                outer ``tick()`` count this operation as failed so the
+                consecutive-total-failure guard can fire during sustained
+                HTTP outages. A partial failure (some arrays succeed, some
+                fail) is still tolerated — we log the failures and return
+                whatever we got.
         """
         if not self._array_ids:
             return StateUpdate.empty()
@@ -224,8 +267,12 @@ class Synchronizer:
         )
 
         array_limits: dict[int, int] = {}
+        num_failed = 0
+        last_exception: Optional[BaseException] = None
         for result in results:
             if isinstance(result, BaseException):
+                num_failed += 1
+                last_exception = result
                 logger.warning(
                     "Failed to fetch array concurrency limit",
                     error=str(result),
@@ -234,6 +281,16 @@ class Synchronizer:
             else:
                 aid, limit = result
                 array_limits[aid] = limit
+
+        # If every per-array query failed, propagate as a single failure
+        # signal so the outer tick() can count this entire operation as
+        # failed. Keeping the old "return empty StateUpdate" behavior would
+        # hide complete outages from the consecutive-failure guard.
+        if num_failed == len(results) and num_failed > 0:
+            assert last_exception is not None
+            raise RuntimeError(
+                f"All {num_failed} array concurrency queries failed"
+            ) from last_exception
 
         return StateUpdate(array_limits=array_limits)
 

--- a/jobmon_core/src/jobmon/core/exceptions.py
+++ b/jobmon_core/src/jobmon/core/exceptions.py
@@ -102,5 +102,19 @@ class DistributorInterruptedError(Exception):
     """raised when signal is sent to distributor."""
 
 
+class FatalOrchestratorError(Exception):
+    """Raised when the orchestrator cannot recover from sustained HTTP failures.
+
+    This indicates the workflow run cannot continue in the current process and
+    must be terminated. It is raised by orchestrator services (Synchronizer,
+    HeartbeatService) after a configured number of consecutive failures to
+    signal that retries, backoff, and session recycling have all been exhausted.
+
+    Unlike transient errors, this must propagate out of ``run_workflow`` so the
+    user sees a clear failure message rather than a silent hang or a
+    result-from-state with stale data.
+    """
+
+
 class CyclicGraphError(Exception):
     """Cyclic graph detected."""

--- a/jobmon_core/src/jobmon/core/requester.py
+++ b/jobmon_core/src/jobmon/core/requester.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import functools
 import json
@@ -184,11 +185,18 @@ class Requester:
             return False
 
         # Retry for specific exceptions (sync and async compatible).
+        # Note: asyncio.TimeoutError is listed explicitly because on Python 3.10
+        # it is a distinct class that does NOT inherit from the builtin
+        # TimeoutError (that merge landed in 3.11). Without this entry, aiohttp
+        # ClientTimeout failures on 3.10 silently fall through to the
+        # non-retriable branch, which was the root-cause trigger of the
+        # "File descriptor N is used by transport" cascade seen in prod.
         return isinstance(
             exception,
             (
                 InvalidResponse,
                 TimeoutError,
+                asyncio.TimeoutError,
                 requests.ConnectionError,
                 requests.adapters.MaxRetryError,
                 requests.exceptions.ReadTimeout,

--- a/tests/unit/swarm/test_http_failure_resilience.py
+++ b/tests/unit/swarm/test_http_failure_resilience.py
@@ -561,10 +561,17 @@ class TestHeartbeatServiceFatalExit:
         )
 
     @pytest.mark.asyncio
-    async def test_successful_heartbeat_resets_counter(
+    async def test_tick_does_not_mutate_failure_counter(
         self, succeeding_gateway: MagicMock
     ) -> None:
-        """A successful tick must reset the counter."""
+        """``tick()`` must not touch ``_consecutive_failures``.
+
+        The counter is owned by ``run_background``'s supervisor loop.
+        ``tick()`` is a pure "do one heartbeat" primitive — if it also
+        reset the counter, a concurrent direct ``tick()`` call could
+        silently clear the supervisor's failure state and mask a
+        sustained outage.
+        """
         service = HeartbeatService(
             gateway=succeeding_gateway,
             interval=1.0,
@@ -575,7 +582,62 @@ class TestHeartbeatServiceFatalExit:
 
         await service.tick()
 
+        # Counter unchanged — tick() has no side effect on it
+        assert service._consecutive_failures == 3
+
+    @pytest.mark.asyncio
+    async def test_run_background_resets_counter_on_success(self) -> None:
+        """``run_background`` is the sole site that resets the counter.
+
+        Simulate a flaky gateway: first N-1 heartbeats fail (counter
+        climbs), then a success (counter must reset to 0), then a stop
+        signal to exit the loop cleanly.
+        """
+        call_count = {"n": 0}
+
+        async def flaky_log_heartbeat(
+            status: str, next_report_increment: float
+        ) -> HeartbeatResponse:
+            call_count["n"] += 1
+            if call_count["n"] < HeartbeatService.MAX_CONSECUTIVE_HEARTBEAT_FAILURES:
+                raise RuntimeError(f"transient failure #{call_count['n']}")
+            return HeartbeatResponse(status="R")
+
+        gateway = MagicMock()
+        gateway.log_heartbeat = AsyncMock(side_effect=flaky_log_heartbeat)
+
+        service = HeartbeatService(
+            gateway=gateway,
+            interval=0.01,  # force heartbeats to fire immediately
+            report_by_buffer=1.5,
+            initial_status="R",
+        )
+        stop_event = asyncio.Event()
+
+        async def stop_after_success() -> None:
+            # Wait until the success path has run (counter reset), then stop
+            deadline = asyncio.get_event_loop().time() + 5.0
+            while asyncio.get_event_loop().time() < deadline:
+                if (
+                    call_count["n"]
+                    >= HeartbeatService.MAX_CONSECUTIVE_HEARTBEAT_FAILURES
+                    and service._consecutive_failures == 0
+                ):
+                    stop_event.set()
+                    return
+                await asyncio.sleep(0.01)
+            stop_event.set()  # safety net
+
+        await asyncio.gather(
+            service.run_background(stop_event),
+            stop_after_success(),
+        )
+
+        # After the loop exits, the counter should be 0 (reset by the
+        # successful heartbeat) and we should have reached the success
+        # case without tripping the fatal-exit threshold.
         assert service._consecutive_failures == 0
+        assert call_count["n"] >= HeartbeatService.MAX_CONSECUTIVE_HEARTBEAT_FAILURES
 
     @pytest.mark.asyncio
     async def test_fatal_error_from_tick_propagates_through_background(

--- a/tests/unit/swarm/test_http_failure_resilience.py
+++ b/tests/unit/swarm/test_http_failure_resilience.py
@@ -201,6 +201,55 @@ class TestGatewaySessionRecycling:
         await gateway._recycle_session()
         assert gateway._session is None
 
+    @pytest.mark.asyncio
+    async def test_recycled_session_is_closed_by_gateway_close(
+        self,
+        gateway: ServerGateway,
+        mock_requester: MagicMock,
+    ) -> None:
+        """Regression guard for the cleanup-after-recycle leak.
+
+        When ``_run_orchestrator`` in run.py passes an externally-owned
+        session via ``set_session``, the gateway's ``_owns_session`` is
+        False. If ``_recycle_session`` then runs during the workflow (due
+        to sustained HTTP failure), the old session is closed and
+        ``_ensure_session`` creates a replacement with ``_owns_session``
+        flipped to True. At cleanup time, the run.py finally block's local
+        ``session`` variable points at the stale original, so it can't
+        close the replacement. ``gateway.close()`` must be called to
+        avoid leaking the recycle-created session and its TCPConnector.
+        """
+        # Simulate the run.py lifecycle: externally-owned session
+        external_session = aiohttp.ClientSession()
+        gateway.set_session(external_session)
+        assert gateway._owns_session is False
+
+        try:
+            # Simulate a recycle mid-run (the bug path)
+            await gateway._recycle_session()
+            assert external_session.closed
+            assert gateway._session is None
+            assert gateway._owns_session is False
+
+            # Next request-triggered _ensure_session creates a new one,
+            # which the gateway now owns.
+            replacement = await gateway._ensure_session()
+            assert replacement is not external_session
+            assert gateway._owns_session is True
+            assert not replacement.closed
+
+            # gateway.close() must close the gateway-owned replacement.
+            # This is what the fix in run.py's finally block invokes.
+            await gateway.close()
+            assert replacement.closed
+            assert gateway._session is None
+        finally:
+            # Belt and suspenders in case an assertion failed mid-test.
+            if not external_session.closed:
+                await external_session.close()
+            if gateway._session is not None and not gateway._session.closed:
+                await gateway._session.close()
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Layer 3 — Orchestrator main-loop sleep floor

--- a/tests/unit/swarm/test_http_failure_resilience.py
+++ b/tests/unit/swarm/test_http_failure_resilience.py
@@ -1,0 +1,486 @@
+"""Tests for HTTP-failure resilience layers.
+
+These tests cover the four-layer fix for the "File descriptor N is used by
+transport" cascade bug (see prod incident 2026-04-09 on wfr 383214):
+
+* Layer 1: Requester retries ``asyncio.TimeoutError`` on Python 3.10
+* Layer 2: Gateway recycles aiohttp session after sustained failures
+* Layer 3: Orchestrator main loop enforces MIN_LOOP_SLEEP floor
+* Layer 4: Synchronizer and HeartbeatService raise FatalOrchestratorError
+  after sustained failure; it propagates through run.py
+
+Each test is isolated and self-contained — no server or network required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from jobmon.client.swarm.gateway import (
+    HeartbeatResponse,
+    ServerGateway,
+    TaskStatusUpdatesResponse,
+)
+from jobmon.client.swarm.services.heartbeat import HeartbeatService
+from jobmon.client.swarm.services.synchronizer import Synchronizer
+from jobmon.client.swarm.state import StateUpdate
+from jobmon.core.exceptions import FatalOrchestratorError
+from jobmon.core.requester import Requester
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Layer 1 — Requester retry classifier
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestRequesterRetryClassifier:
+    """Verify _should_retry_exception covers timeout types on all Python versions."""
+
+    @pytest.fixture
+    def requester(self) -> Requester:
+        return Requester(service_url="http://example.invalid")
+
+    def test_asyncio_timeout_is_retriable(self, requester: Requester) -> None:
+        """asyncio.TimeoutError must be retried.
+
+        On Python 3.10, asyncio.TimeoutError does not inherit from builtin
+        TimeoutError. Before layer 1 the classifier returned False for this
+        exception, causing aiohttp ClientTimeout failures to propagate
+        immediately instead of being retried with tenacity backoff.
+        """
+        assert requester._should_retry_exception(asyncio.TimeoutError()) is True
+
+    def test_builtin_timeout_is_retriable(self, requester: Requester) -> None:
+        """The builtin TimeoutError is still retriable (regression guard)."""
+        assert requester._should_retry_exception(TimeoutError()) is True
+
+    def test_aiohttp_server_timeout_is_retriable(self, requester: Requester) -> None:
+        """aiohttp.ServerTimeoutError remains retriable (regression guard)."""
+        assert requester._should_retry_exception(aiohttp.ServerTimeoutError()) is True
+
+    def test_invalid_request_not_retriable(self, requester: Requester) -> None:
+        """4xx client errors must NOT be retried (regression guard)."""
+        from jobmon.core.exceptions import InvalidRequest
+
+        assert requester._should_retry_exception(InvalidRequest("bad")) is False
+
+    def test_generic_runtime_error_not_retriable(self, requester: Requester) -> None:
+        """The fd-cascade RuntimeError itself must not trigger retry.
+
+        If it did, every retry would hit the same leaked fd and we'd amplify
+        the log volume 10x per call instead of failing fast.
+        """
+        fd_error = RuntimeError(
+            "File descriptor 12 is used by transport "
+            "<_SelectorSocketTransport fd=12 read=polling write=<idle, bufsize=0>>"
+        )
+        assert requester._should_retry_exception(fd_error) is False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Layer 2 — Gateway session recycling
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestGatewaySessionRecycling:
+    """Verify the gateway recycles its aiohttp session on sustained failure."""
+
+    @pytest.fixture
+    def mock_requester(self) -> MagicMock:
+        requester = MagicMock(spec=Requester)
+        requester.send_request_async = AsyncMock()
+        return requester
+
+    @pytest.fixture
+    def gateway(self, mock_requester: MagicMock) -> ServerGateway:
+        return ServerGateway(
+            requester=mock_requester,
+            workflow_id=100,
+            workflow_run_id=200,
+        )
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_counter(
+        self,
+        gateway: ServerGateway,
+        mock_requester: MagicMock,
+    ) -> None:
+        """A successful call must reset the consecutive-failure counter."""
+        mock_requester.send_request_async.return_value = (200, {"status": "R"})
+
+        # Manually set a stale counter
+        gateway._consecutive_failures = 3
+
+        await gateway.log_heartbeat(status="R", next_report_increment=30.0)
+
+        assert gateway._consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_failure_increments_counter(
+        self,
+        gateway: ServerGateway,
+        mock_requester: MagicMock,
+    ) -> None:
+        """Each failed call below the threshold increments the counter."""
+        mock_requester.send_request_async.side_effect = RuntimeError("boom")
+
+        for expected in range(1, gateway.SESSION_RECYCLE_THRESHOLD):
+            with pytest.raises(RuntimeError):
+                await gateway.log_heartbeat(status="R", next_report_increment=30.0)
+            assert gateway._consecutive_failures == expected
+
+    @pytest.mark.asyncio
+    async def test_threshold_triggers_session_recycle(
+        self,
+        gateway: ServerGateway,
+        mock_requester: MagicMock,
+    ) -> None:
+        """Hitting the threshold must recycle the session and reset the counter."""
+        mock_requester.send_request_async.side_effect = RuntimeError(
+            "File descriptor 12 is used by transport"
+        )
+
+        # Seed a real session so we can verify it gets closed
+        first_session = aiohttp.ClientSession()
+        gateway._session = first_session
+        gateway._owns_session = True
+
+        try:
+            for _ in range(gateway.SESSION_RECYCLE_THRESHOLD):
+                with pytest.raises(RuntimeError):
+                    await gateway.log_heartbeat(status="R", next_report_increment=30.0)
+
+            # After crossing the threshold:
+            assert first_session.closed, "old session should be closed"
+            assert gateway._session is None or gateway._session is not first_session
+            assert gateway._consecutive_failures == 0
+        finally:
+            if not first_session.closed:
+                await first_session.close()
+            if gateway._session is not None and not gateway._session.closed:
+                await gateway._session.close()
+
+    @pytest.mark.asyncio
+    async def test_recycle_is_idempotent_under_concurrent_failures(
+        self,
+        gateway: ServerGateway,
+    ) -> None:
+        """Concurrent callers hitting the threshold must not double-close."""
+        # Seed a real session and pre-set counter near threshold
+        first_session = aiohttp.ClientSession()
+        gateway._session = first_session
+        gateway._owns_session = True
+
+        try:
+            # Directly invoke _recycle_session from multiple coroutines
+            await asyncio.gather(
+                gateway._recycle_session(),
+                gateway._recycle_session(),
+                gateway._recycle_session(),
+            )
+
+            assert first_session.closed
+            # No new session was created implicitly
+            assert gateway._session is None
+        finally:
+            if not first_session.closed:
+                await first_session.close()
+
+    @pytest.mark.asyncio
+    async def test_recycle_noop_when_session_already_none(
+        self,
+        gateway: ServerGateway,
+    ) -> None:
+        """Calling _recycle_session with no session must be a safe no-op."""
+        gateway._session = None
+        # Should not raise
+        await gateway._recycle_session()
+        assert gateway._session is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Layer 3 — Orchestrator main-loop sleep floor
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestOrchestratorLoopFloor:
+    """Verify MIN_LOOP_SLEEP prevents hot-spinning when heartbeat times collapse."""
+
+    def test_min_loop_sleep_class_attribute_exists(self) -> None:
+        """The floor constant must exist and be a positive value."""
+        from jobmon.client.swarm.orchestrator import WorkflowRunOrchestrator
+
+        assert hasattr(WorkflowRunOrchestrator, "MIN_LOOP_SLEEP")
+        assert WorkflowRunOrchestrator.MIN_LOOP_SLEEP > 0
+
+    def test_min_loop_sleep_reasonable_value(self) -> None:
+        """MIN_LOOP_SLEEP must be large enough to be a real floor, small enough
+        to not starve scheduling on healthy runs."""
+        from jobmon.client.swarm.orchestrator import WorkflowRunOrchestrator
+
+        assert 0.5 <= WorkflowRunOrchestrator.MIN_LOOP_SLEEP <= 5.0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Layer 4b — Synchronizer fatal exit on sustained total failure
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSynchronizerFatalExit:
+    """Verify Synchronizer raises FatalOrchestratorError on sustained total failure."""
+
+    @pytest.fixture
+    def all_failing_gateway(self) -> MagicMock:
+        """Gateway where every async method raises."""
+        gateway = MagicMock()
+        gateway.request_triage = AsyncMock(side_effect=RuntimeError("network down"))
+        gateway.get_task_status_updates = AsyncMock(
+            side_effect=RuntimeError("network down")
+        )
+        gateway.get_workflow_concurrency = AsyncMock(
+            side_effect=RuntimeError("network down")
+        )
+        gateway.get_array_concurrency = AsyncMock(
+            side_effect=RuntimeError("network down")
+        )
+        return gateway
+
+    @pytest.fixture
+    def mostly_healthy_gateway(self) -> MagicMock:
+        """Gateway where most calls succeed but one fails."""
+        gateway = MagicMock()
+        gateway.request_triage = AsyncMock(side_effect=RuntimeError("flaky"))
+        gateway.get_task_status_updates = AsyncMock(
+            return_value=TaskStatusUpdatesResponse(
+                time=datetime(2024, 1, 1), tasks_by_status={}
+            )
+        )
+        gateway.get_workflow_concurrency = AsyncMock(return_value=100)
+        gateway.get_array_concurrency = AsyncMock(return_value=50)
+        return gateway
+
+    @pytest.mark.asyncio
+    async def test_single_all_failed_tick_does_not_raise(
+        self, all_failing_gateway: MagicMock
+    ) -> None:
+        """One bad tick is tolerated — the Synchronizer swallows and continues.
+
+        This preserves the existing transient-failure resilience: a single
+        server blip should not terminate the workflow run.
+        """
+        sync = Synchronizer(gateway=all_failing_gateway, task_ids={1}, array_ids={10})
+        result = await sync.tick()
+        assert isinstance(result, StateUpdate)
+        assert sync._consecutive_total_failure_ticks == 1
+
+    @pytest.mark.asyncio
+    async def test_threshold_all_failed_ticks_raises_fatal(
+        self, all_failing_gateway: MagicMock
+    ) -> None:
+        """Crossing the threshold must raise FatalOrchestratorError."""
+        sync = Synchronizer(gateway=all_failing_gateway, task_ids={1}, array_ids={10})
+
+        # First (N-1) ticks increment the counter without raising
+        for _ in range(sync.MAX_CONSECUTIVE_TOTAL_FAILURE_TICKS - 1):
+            await sync.tick()
+
+        # Nth tick must raise
+        with pytest.raises(FatalOrchestratorError, match="consecutive"):
+            await sync.tick()
+
+    @pytest.mark.asyncio
+    async def test_any_success_resets_counter(
+        self, mostly_healthy_gateway: MagicMock
+    ) -> None:
+        """Even one successful operation per tick must reset the counter.
+
+        This ensures a single flaky endpoint can't wedge the run — as long
+        as other sync operations are working, we keep going.
+        """
+        sync = Synchronizer(
+            gateway=mostly_healthy_gateway, task_ids={1}, array_ids={10}
+        )
+
+        # Manually set a stale counter
+        sync._consecutive_total_failure_ticks = 2
+
+        await sync.tick()
+
+        assert sync._consecutive_total_failure_ticks == 0
+
+    @pytest.mark.asyncio
+    async def test_counter_resets_after_recovery(
+        self, all_failing_gateway: MagicMock
+    ) -> None:
+        """Counter returning below threshold must reset to 0 on next success."""
+        sync = Synchronizer(gateway=all_failing_gateway, task_ids={1}, array_ids={10})
+
+        # Build up to threshold-1 consecutive failures
+        for _ in range(sync.MAX_CONSECUTIVE_TOTAL_FAILURE_TICKS - 1):
+            await sync.tick()
+        assert (
+            sync._consecutive_total_failure_ticks
+            == sync.MAX_CONSECUTIVE_TOTAL_FAILURE_TICKS - 1
+        )
+
+        # Now flip the gateway to healthy
+        all_failing_gateway.request_triage.side_effect = None
+        all_failing_gateway.request_triage.return_value = None
+        all_failing_gateway.get_task_status_updates.side_effect = None
+        all_failing_gateway.get_task_status_updates.return_value = (
+            TaskStatusUpdatesResponse(time=datetime(2024, 1, 1), tasks_by_status={})
+        )
+        all_failing_gateway.get_workflow_concurrency.side_effect = None
+        all_failing_gateway.get_workflow_concurrency.return_value = 100
+        all_failing_gateway.get_array_concurrency.side_effect = None
+        all_failing_gateway.get_array_concurrency.return_value = 50
+
+        await sync.tick()
+        assert sync._consecutive_total_failure_ticks == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Layer 4c — HeartbeatService fatal exit on sustained failure
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestHeartbeatServiceFatalExit:
+    """Verify HeartbeatService raises FatalOrchestratorError on sustained failure."""
+
+    @pytest.fixture
+    def failing_gateway(self) -> MagicMock:
+        gateway = MagicMock()
+        gateway.log_heartbeat = AsyncMock(side_effect=RuntimeError("network down"))
+        return gateway
+
+    @pytest.fixture
+    def succeeding_gateway(self) -> MagicMock:
+        gateway = MagicMock()
+        gateway.log_heartbeat = AsyncMock(return_value=HeartbeatResponse(status="R"))
+        return gateway
+
+    @pytest.mark.asyncio
+    async def test_single_heartbeat_failure_does_not_raise(
+        self, failing_gateway: MagicMock
+    ) -> None:
+        """A single heartbeat failure must not raise from tick()."""
+        service = HeartbeatService(
+            gateway=failing_gateway,
+            interval=1.0,
+            report_by_buffer=1.5,
+            initial_status="R",
+        )
+        # tick() itself propagates the underlying error
+        with pytest.raises(RuntimeError):
+            await service.tick()
+
+    @pytest.mark.asyncio
+    async def test_consecutive_failure_counter_starts_zero(
+        self, failing_gateway: MagicMock
+    ) -> None:
+        """Freshly-constructed service has zero consecutive failures."""
+        service = HeartbeatService(
+            gateway=failing_gateway,
+            interval=1.0,
+            report_by_buffer=1.5,
+            initial_status="R",
+        )
+        assert service._consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_run_background_raises_fatal_after_threshold(
+        self, failing_gateway: MagicMock
+    ) -> None:
+        """run_background must raise FatalOrchestratorError after N failures."""
+        service = HeartbeatService(
+            gateway=failing_gateway,
+            interval=0.01,  # very short so is_heartbeat_due fires immediately
+            report_by_buffer=1.5,
+            initial_status="R",
+        )
+        stop_event = asyncio.Event()
+
+        # run_background should raise within a bounded number of ticks
+        with pytest.raises(FatalOrchestratorError, match="consecutive"):
+            await asyncio.wait_for(service.run_background(stop_event), timeout=5.0)
+
+        assert (
+            service._consecutive_failures >= service.MAX_CONSECUTIVE_HEARTBEAT_FAILURES
+        )
+
+    @pytest.mark.asyncio
+    async def test_successful_heartbeat_resets_counter(
+        self, succeeding_gateway: MagicMock
+    ) -> None:
+        """A successful tick must reset the counter."""
+        service = HeartbeatService(
+            gateway=succeeding_gateway,
+            interval=1.0,
+            report_by_buffer=1.5,
+            initial_status="R",
+        )
+        service._consecutive_failures = 3
+
+        await service.tick()
+
+        assert service._consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_fatal_error_from_tick_propagates_through_background(
+        self, failing_gateway: MagicMock
+    ) -> None:
+        """FatalOrchestratorError raised by tick() must propagate immediately.
+
+        This covers the case where the gateway itself raised
+        FatalOrchestratorError (e.g. after exhausting session recycles).
+        """
+        failing_gateway.log_heartbeat.side_effect = FatalOrchestratorError(
+            "gateway gave up"
+        )
+        service = HeartbeatService(
+            gateway=failing_gateway,
+            interval=0.01,
+            report_by_buffer=1.5,
+            initial_status="R",
+        )
+        stop_event = asyncio.Event()
+
+        with pytest.raises(FatalOrchestratorError, match="gateway gave up"):
+            await asyncio.wait_for(service.run_background(stop_event), timeout=5.0)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Layer 4d — FatalOrchestratorError propagation through run.py
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestFatalErrorPropagation:
+    """Verify FatalOrchestratorError is in run.py's re-raise tuple."""
+
+    def test_fatal_orchestrator_error_is_exported(self) -> None:
+        """The exception class must be importable from core.exceptions."""
+        from jobmon.core.exceptions import FatalOrchestratorError as imported
+
+        assert issubclass(imported, Exception)
+
+    def test_run_py_imports_fatal_error(self) -> None:
+        """run.py must import FatalOrchestratorError for its re-raise list."""
+        import jobmon.client.swarm.run as run_module
+
+        assert hasattr(run_module, "FatalOrchestratorError")
+
+    def test_orchestrator_check_heartbeat_task_healthy_exists(self) -> None:
+        """The orchestrator must expose the heartbeat-health check method.
+
+        _check_heartbeat_task_healthy is the surfacing point for background
+        heartbeat task failures (including FatalOrchestratorError) into the
+        main loop. If this method is removed or renamed, heartbeat-initiated
+        fatal exits will be invisible until teardown.
+        """
+        from jobmon.client.swarm.orchestrator import WorkflowRunOrchestrator
+
+        assert hasattr(WorkflowRunOrchestrator, "_check_heartbeat_task_healthy")

--- a/tests/unit/swarm/test_http_failure_resilience.py
+++ b/tests/unit/swarm/test_http_failure_resilience.py
@@ -275,6 +275,105 @@ class TestOrchestratorLoopFloor:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Orchestrator — _check_heartbeat_task_healthy behavior
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckHeartbeatTaskHealthy:
+    """Verify _check_heartbeat_task_healthy handles all Task states correctly."""
+
+    def _make_orchestrator(self) -> "WorkflowRunOrchestrator":  # type: ignore[name-defined]
+        """Construct a bare orchestrator without running the full constructor chain."""
+        from jobmon.client.swarm.orchestrator import WorkflowRunOrchestrator
+
+        orch = WorkflowRunOrchestrator.__new__(WorkflowRunOrchestrator)
+        orch._heartbeat_task = None
+        return orch
+
+    def test_no_task_is_noop(self) -> None:
+        """With no heartbeat task set, the check must not raise."""
+        orch = self._make_orchestrator()
+        orch._check_heartbeat_task_healthy()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_running_task_is_noop(self) -> None:
+        """With a running task, the check must not raise."""
+        orch = self._make_orchestrator()
+
+        async def never_finishes() -> None:
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(never_finishes())
+        orch._heartbeat_task = task
+        try:
+            orch._check_heartbeat_task_healthy()  # Should not raise
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_cleanly_completed_task_is_noop(self) -> None:
+        """A task that completed without exception must not raise."""
+        orch = self._make_orchestrator()
+
+        async def finishes_cleanly() -> None:
+            return None
+
+        task = asyncio.create_task(finishes_cleanly())
+        await task
+        orch._heartbeat_task = task
+        orch._check_heartbeat_task_healthy()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_failed_task_propagates_exception(self) -> None:
+        """A task that raised must have its exception re-raised here."""
+        orch = self._make_orchestrator()
+
+        async def raises_fatal() -> None:
+            raise FatalOrchestratorError("heartbeat gave up")
+
+        task = asyncio.create_task(raises_fatal())
+        try:
+            await task
+        except FatalOrchestratorError:
+            pass  # Expected — task stores the exception
+        orch._heartbeat_task = task
+        with pytest.raises(FatalOrchestratorError, match="gave up"):
+            orch._check_heartbeat_task_healthy()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_task_does_not_raise_cancelled_error(self) -> None:
+        """Regression guard for the Task.exception() + CancelledError footgun.
+
+        ``asyncio.Task.exception()`` *raises* ``CancelledError`` (a
+        ``BaseException``) rather than returning it for cancelled tasks.
+        If ``_check_heartbeat_task_healthy`` called ``.exception()``
+        unconditionally, a cancelled heartbeat task would leak
+        ``CancelledError`` past every ``except Exception`` handler in the
+        orchestrator's main loop, bypassing clean termination.
+        """
+        orch = self._make_orchestrator()
+
+        async def never_finishes() -> None:
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(never_finishes())
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        assert task.cancelled()
+        orch._heartbeat_task = task
+        # Must not raise — especially not CancelledError
+        orch._check_heartbeat_task_healthy()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Layer 4b — Synchronizer fatal exit on sustained total failure
 # ──────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes the `File descriptor N is used by transport <_SelectorSocketTransport>` runaway cascade where a single aiohttp `ClientTimeout` could leak an asyncio transport and cause the orchestrator main loop to spin at ~300 errors/sec indefinitely. Observed in prod on **2026-04-09** (wfr 383214, user `fwahab`, pid 738326): **559,788 errors in ~30 minutes** on a single process, all from one jobmon 3.7.0 orchestrator. A smaller 3,550-error burst hit `rmbarber` on 2026-03-24.

Root-cause chain (see investigation in incident notes):

1. An `asyncio.ClientTimeout` fires during an aiohttp connect
2. The cancellation path leaks an `_SelectorSocketTransport` in the asyncio loop's `_transports` map (upstream aiohttp/happyeyeballs bug)
3. Every subsequent connect gets the same fd from the OS and collides in `_ensure_fd_no_transport` with a non-retriable `RuntimeError`
4. The orchestrator silently swallows these errors in `asyncio.gather(return_exceptions=True)` and spins the main loop because `time_till_next_sync` collapses to 0 when heartbeats aren't advancing `_last_heartbeat_time`

Four independent defects compounded to produce the cascade. Each is fixed at its own layer. **Tenacity's per-request retry semantics are fully preserved** — a transient 500 or brief server restart still rides through the 300s retry budget without the gateway counter incrementing.

## The four layers

### Layer 1 — Retry `asyncio.TimeoutError` (`jobmon_core/core/requester.py`)

Added `asyncio.TimeoutError` to `_should_retry_exception`'s whitelist. On Python 3.10 it does not inherit from the builtin `TimeoutError` (that merge landed in 3.11), so aiohttp `ClientTimeout` failures silently bypassed tenacity entirely. This alone would likely have prevented the initial fd leak from propagating on the prod incident. Affects **every** async requester caller (orchestrator gateway, distributor heartbeats, task-resources bind).

### Layer 2 — Session recycling in `ServerGateway._request`

Added `_consecutive_failures` counter and `_recycle_session` method. Every call routes through the existing `_request` chokepoint, so no per-method refactor was needed. After `SESSION_RECYCLE_THRESHOLD=5` consecutive **post-tenacity** failures, close the old `aiohttp.ClientSession` and let `_ensure_session` build a new one on the next call. A fresh `ClientSession` creates a fresh `TCPConnector`, which clears any leaked transport state in the asyncio selector. `_recycle_session` is idempotent under concurrent callers (critical for `Synchronizer.tick`'s `asyncio.gather` pattern).

### Layer 3 — Main-loop `MIN_LOOP_SLEEP = 1.0` floor (`orchestrator.py`)

Added a hard per-iteration floor independent of `time_till_next_sync`. Caps worst-case log volume by ~2 orders of magnitude even if the other layers are bypassed. No practical impact on healthy runs (normal sync interval is 30s).

### Layer 4 — Fatal-exit guards (`synchronizer.py`, `heartbeat.py`, `orchestrator.py`, `run.py`)

New `FatalOrchestratorError` exception in `jobmon_core/core/exceptions.py`.

- **`Synchronizer.tick()`** tracks `_consecutive_total_failure_ticks` and raises `FatalOrchestratorError` after 3 consecutive all-failed ticks (~90s of total darkness at default intervals).
- **`Synchronizer._get_array_concurrency_limits()`** now raises when every per-array query fails, so complete array-concurrency outages are counted by the outer guard instead of silently returning an empty `StateUpdate`.
- **`HeartbeatService.run_background()`** tracks consecutive failures and raises `FatalOrchestratorError` after 5 in a row (~2.5 minutes at default intervals). `tick()` resets the counter on success so any working heartbeat clears the guard.
- **`WorkflowRunOrchestrator._check_heartbeat_task_healthy()`** (new) polls the background heartbeat task each main-loop iteration and re-raises any stored exception, so heartbeat-initiated fatal errors surface into the main loop instead of sitting until teardown.
- **`WorkflowRunOrchestrator._handle_error()`** hardened to tolerate a failing `_update_status` (e.g. during HTTP outage) so the original exception is not masked during shutdown. Falls back to letting the server-side reaper transition the run to ERROR.
- **`run.py:_run_orchestrator`** adds `FatalOrchestratorError` to the re-raise tuple alongside `DistributorNotAlive` so it surfaces to users via the `4db75f63` swarm-error-surfacing path instead of being swallowed by `_build_result_from_state`.

## Interaction with tenacity

Tenacity is unchanged. The gateway counter sits **on top of** tenacity, observing calls only after tenacity has already given up. Mental model:

| Scenario | Tenacity behavior | Gateway counter |
|---|---|---|
| One-off 500, recovers on attempt 2 | 1 retry, ~1s | stays at 0 |
| 90s of 500s, recovers on attempt 7 | 6 retries, ~63s | stays at 0 |
| Sustained 500s (full outage) | 10 attempts or 300s, then raises wrapped RuntimeError | increments by 1 per call |
| fd-leak cascade (non-retriable) | gives up at attempt 1, ~0ms | increments by 1 per call |

For a sustained 500 outage this means **~15 minutes** until fatal exit (3 sync ticks × ~300s tenacity budget). For the fd-leak fast-fail case, it's **~3 seconds** (3 iterations at the `MIN_LOOP_SLEEP=1.0` floor).

## Scope audit

Checked the other async-requester callers for the same patterns:

- **DistributorService._log_heartbeats** creates a fresh `aiohttp.ClientSession` per 30s heartbeat cycle via `asyncio.run(...)`. Any leaked fd dies with the event loop — layer 2 is unnecessary there. Layer 1's classifier fix still benefits it.
- **TaskResources.bind_async** reaches into `gateway._ensure_session()` directly and bypasses the `_request` chokepoint. Its failures don't increment the counter, but they propagate cleanly through `scheduler.tick` → `_do_scheduling` → `_main_loop` → caught in `run.py`, so a resource-binding cascade still terminates the run (just via a different path). A follow-up refactor to route binding through the gateway chokepoint is noted in the investigation but deferred.
- **worker_node_task_instance** only uses `asyncio.gather` for subprocess streams, not HTTP — not affected.

## Test plan

### Automated — all green on worktree

- [x] **24 new resilience tests** in `tests/unit/swarm/test_http_failure_resilience.py` covering all four layers in isolation
- [x] **160 existing swarm unit tests** (test_heartbeat, test_synchronizer, test_gateway, test_orchestrator, test_run, test_builder, test_scheduler, test_state) all pass
- [x] **275 tests in `tests/unit/swarm/` under `-n 10` parallel** all pass
- [x] **599 tests in full `tests/unit/`** pass (2 skipped, 0 failed)
- [x] **18 `test_requester.py` integration tests** (retry, timeout, async-connection-retry) pass
- [x] **208 swarm + client integration tests** pass (2 skipped, 0 failed)
- [x] **55 distributor + core tests** pass
- [x] `uv run nox -s format lint typecheck` — all green

### Manual verification recommended before merge

- [ ] Six-job docker E2E: `docker compose exec jobmon_client python /app/test_scripts/six_job_test.py sequential`
- [ ] Confirm a healthy long-running workflow still behaves normally (sanity check that layer 3's 1s floor doesn't introduce observable latency at the 30s sync cadence)
- [ ] Spot-check one sustained-failure scenario (e.g. block the jobmon server port mid-run with `iptables` / `pfctl` and confirm the orchestrator exits with `FatalOrchestratorError` within ~15 minutes instead of spinning)

## Rollout

This is targeted at `release/3.7` so it can be tagged as `core-3.7.12` and `client-3.7.4` and deployed to the FHS environment that hit the cascade today. Users on jobmon 3.7.0 (like `fwahab`) would need to upgrade to pick this up — their currently-running orchestrators would still need to be killed manually.

The same fix should be forward-ported to `release/3.8` in a follow-up PR. The 3.8 session-management code (`65c3acca`, `85621f7a`) uses a `Requester._async_session` pattern that is structured slightly differently but has the same gap — `_needs_new_session` only detects loop-identity mismatch, not session-state corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workflow-run execution paths (HTTP retry classification, gateway session lifecycle, orchestrator loop timing, and fatal error propagation), which can change failure/termination behavior during outages. Main risk is unintended premature termination or session churn under intermittent network issues despite safeguards and added unit coverage.
> 
> **Overview**
> Prevents the orchestrator from spinning indefinitely during sustained HTTP/connect failures by **making timeouts retriable**, **recycling broken `aiohttp.ClientSession`s after repeated post-retry failures**, and enforcing a **`MIN_LOOP_SLEEP` floor** in the main loop.
> 
> Introduces `FatalOrchestratorError` and new sustained-failure guards in `HeartbeatService` and `Synchronizer` (including treating “all array concurrency queries failed” as a tick failure), surfaces background heartbeat task exceptions into the main loop, and propagates this fatal error out of `run.py` with improved cleanup (`gateway.close()`) and best-effort ERROR status updates.
> 
> Adds a comprehensive unit test suite (`tests/unit/swarm/test_http_failure_resilience.py`) covering the four-layer resilience behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e36ae33ef20af0a607c8d15002e8b2476ca3e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->