### PR TITLE
Wrap user task exceptions in UserTaskFunctionError marker

### DIFF
--- a/jobmon_core/src/jobmon/core/exceptions.py
+++ b/jobmon_core/src/jobmon/core/exceptions.py
@@ -104,3 +104,12 @@ class DistributorInterruptedError(Exception):
 
 class CyclicGraphError(Exception):
     """Cyclic graph detected."""
+
+
+class UserTaskFunctionError(Exception):
+    """Raised when a user's task function raises an exception.
+
+    Used as a marker to distinguish user task failures from jobmon-internal
+    errors at log boundaries. The original exception is chained via ``raise
+    ... from e`` so the full traceback is preserved.
+    """

--- a/jobmon_core/src/jobmon/core/task_generator.py
+++ b/jobmon_core/src/jobmon/core/task_generator.py
@@ -31,6 +31,7 @@ from sphinx.util import nodes as sphinx_nodes  # type: ignore
 from jobmon.client.api import Tool
 from jobmon.client.task import Task
 from jobmon.client.workflow import Workflow
+from jobmon.core.exceptions import UserTaskFunctionError
 
 SIMPLE_TYPES = {str, int, float, bool}
 BUILT_IN_COLLECTIONS = {list, tuple, set}
@@ -860,7 +861,13 @@ class TaskGenerator:
                 )
 
         # Run the task_function
-        return self.task_function(**deserialized_args)
+        try:
+            return self.task_function(**deserialized_args)
+        except Exception as e:
+            # Wrap user task failures so they can be distinguished from
+            # jobmon-internal errors at log boundaries. Preserve the original
+            # traceback via exception chaining.
+            raise UserTaskFunctionError(str(e)) from e
 
     def help(self) -> str:
         """Return help text for the task_function."""

--- a/jobmon_core/src/jobmon/worker_node/cli.py
+++ b/jobmon_core/src/jobmon/worker_node/cli.py
@@ -11,6 +11,7 @@ from typing import Optional
 import structlog
 
 from jobmon.core.cli import CLI
+from jobmon.core.exceptions import UserTaskFunctionError
 from jobmon.core.logging import set_jobmon_context
 from jobmon.core.task_generator import TaskGenerator
 
@@ -162,6 +163,11 @@ class WorkerNodeCLI(CLI):
 
             task_generator.run(args.args[0])
             return ReturnCodes.OK
+        except UserTaskFunctionError:
+            # User's task function raised — not a jobmon error. The original
+            # exception is chained and will surface in the task instance
+            # stderr_log via normal propagation.
+            raise
         except Exception as e:
             logger.exception("Worker node task generator error", error=str(e))
             raise e

--- a/tests/integration/client/test_task_generator.py
+++ b/tests/integration/client/test_task_generator.py
@@ -1791,3 +1791,30 @@ def test_complex_string_annotations(client_env) -> None:
     # List[str] should be a parameterized list
     assert hasattr(tg.params["b"], "__origin__")
     assert tg.params["b"].__origin__ is list
+
+
+def test_user_task_function_error_wraps_exception(client_env) -> None:
+    """User task function exceptions should be wrapped in UserTaskFunctionError.
+
+    This lets log boundaries (e.g. WorkerNodeCLI.run_task_generator) distinguish
+    user task failures from jobmon-internal errors. The original exception must
+    remain chained so stderr capture still shows the real traceback.
+    """
+    from jobmon.core.exceptions import UserTaskFunctionError
+
+    def raising_task(x: int) -> None:
+        raise RuntimeError("user code boom")
+
+    tg = task_generator.TaskGenerator(
+        task_function=raising_task,
+        serializers={},
+        tool_name="test_tool",
+        default_cluster_name="sequential",
+    )
+
+    with pytest.raises(UserTaskFunctionError, match="user code boom") as exc_info:
+        tg.run(["x=1"])
+
+    # Original exception is chained via `raise ... from e`
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "user code boom"


### PR DESCRIPTION
## Summary
- When a user's task function raises, the worker node CLI was logging it as `"Worker node task generator error"` at ERROR level, polluting jobmon's OTLP/ES dashboards with user application bugs (e.g. FHS provenance errors, user `RuntimeError`s, etc.)
- `task_generator.run()` now wraps any exception from the user's function in a new `UserTaskFunctionError` and chains the original via `raise ... from e`
- The worker node CLI catches `UserTaskFunctionError` and re-raises without logging, keeping jobmon's error logs focused on jobmon-internal failures
- The user's original traceback is still captured in the task instance `stderr_log` via normal propagation, so nothing changes for user-facing diagnostics in the GUI

## Context
Follow-up to investigation of an FHS task failing with `RuntimeError: Provenance is only offered through an FHS release environment`. That exception originated in user code (`fhs_lib_file_interface`) but was surfacing in jobmon's telemetry as a jobmon error. The boundary should be declared explicitly at the one place that knows where user code starts (`task_generator.run()`) rather than inferred via filename heuristics at the log site.

## Test plan
- [x] New unit test verifies `UserTaskFunctionError` wraps user exceptions and preserves `__cause__`
- [x] All 80 task_generator tests pass
- [x] Full suite: 942 passed, 6 skipped
- [x] Format, lint, typecheck all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only exception wrapping/logging boundaries for task execution, but could affect how failures are classified and logged in the worker CLI.
> 
> **Overview**
> User task-function failures are now wrapped in a new `UserTaskFunctionError` (with exception chaining) when `TaskGenerator.run()` executes user code.
> 
> `WorkerNodeCLI.run_task_generator` explicitly re-raises `UserTaskFunctionError` without emitting the "Worker node task generator error" log, keeping ERROR-level telemetry focused on Jobmon-internal failures. A new integration test asserts the wrapping behavior and preserved `__cause__` traceback chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d34c87f76b100684c09d35a8a07679bbb6378499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->