### PR TITLE
Run log-dir creation and heartbeats concurrently to survive slow fs

### DIFF
--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -680,11 +680,18 @@ class WorkerNodeTaskInstance:
                 if not task.cancelled() and task.exception() is not None:
                     task.result()
             # Defensive: _heartbeat_loop is infinite, so reaching "done
-            # without exception" would mean it was cancelled externally,
-            # which nothing in this method does. Bail to avoid a tight
-            # loop on a stable done set if that assumption is ever
-            # broken.
-            if heartbeat_task.done() and heartbeat_task.exception() is None:
+            # without a visible exception" would mean it was cancelled
+            # externally, which nothing in this method does. Bail to
+            # avoid a tight loop on a stable done set if that assumption
+            # is ever broken. The cancelled() check must come first —
+            # asyncio.Task.exception() raises CancelledError on a
+            # cancelled task rather than returning None, and that
+            # CancelledError would bypass the caller's ``except
+            # Exception`` (it inherits from BaseException) and crash the
+            # worker.
+            if heartbeat_task.done() and (
+                heartbeat_task.cancelled() or heartbeat_task.exception() is None
+            ):
                 break
 
         # Subprocess has exited (or heartbeat terminated unexpectedly).

--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -644,9 +644,18 @@ class WorkerNodeTaskInstance:
         completion. Any task exception (heartbeat ``TransitionError``,
         stream drain errors) surfaces via ``task.result()``; on the normal
         happy path no task has a stored exception and this loop is a
-        no-op. After the first completion, the remaining work tasks are
-        awaited — typically ``process_wait_task`` finishes first and we
-        wait for the stdout/stderr drains to hit EOF.
+        no-op.
+
+        Once a work task completes successfully (typically
+        ``process_wait_task`` after the subprocess exits), the heartbeat
+        task is cancelled before the remaining drain tasks are awaited.
+        This matches the old ``_process_poller`` behavior of stopping
+        heartbeats as soon as ``process.wait()`` returned, and prevents a
+        KILL_SELF race during the drain phase from raising a
+        ``TransitionError`` on a heartbeat task that nobody is watching —
+        such an exception would be silently swallowed by
+        ``_stop_heartbeat_task`` in the outer ``finally``, mutating
+        ``self._status`` behind ``run()``'s back.
         """
         done, _pending = await asyncio.wait(
             [heartbeat_task, *work_tasks],
@@ -655,6 +664,14 @@ class WorkerNodeTaskInstance:
         for task in done:
             if not task.cancelled() and task.exception() is not None:
                 task.result()
+
+        # A work task completed first (heartbeat errors were raised above
+        # and never reach this point). Stop heartbeating before draining
+        # the remaining stdout/stderr EOFs, so a KILL_SELF race during
+        # drain can't silently update self._status.
+        if not heartbeat_task.done():
+            heartbeat_task.cancel()
+
         still_pending = [t for t in work_tasks if not t.done()]
         if still_pending:
             await asyncio.gather(*still_pending)

--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -510,6 +510,14 @@ class WorkerNodeTaskInstance:
         don't abort the whole task — ``log_report_by`` only raises after
         the sync requester's tenacity retry budget is exhausted, and even
         then we want to keep ticking in case the next attempt recovers.
+
+        The first heartbeat is deliberately deferred by one full
+        ``_task_instance_heartbeat_interval``. For short subprocesses
+        that finish in less than an interval, no async heartbeat ever
+        fires — which is fine because the sync ``log_running()`` HTTP
+        call already set ``report_by_date`` to
+        ``now + interval * buffer`` on the server, so the TI remains
+        in-date on the server throughout the entire short run.
         """
         while True:
             await asyncio.sleep(self._task_instance_heartbeat_interval)
@@ -688,6 +696,20 @@ class WorkerNodeTaskInstance:
             done, pending = await asyncio.wait(
                 pending, return_when=asyncio.FIRST_COMPLETED
             )
+            # Surface exceptions with heartbeat_task prioritized. If
+            # multiple tasks completed in the same wait round — e.g. a
+            # drain task hit an IOError at the same instant the
+            # heartbeat raised TransitionError — set iteration order is
+            # non-deterministic, so check heartbeat_task explicitly first
+            # to guarantee the KILL_SELF path (which depends on the
+            # TransitionError surfacing to run() via __cause__) takes
+            # priority over incidental drain errors.
+            if (
+                heartbeat_task in done
+                and not heartbeat_task.cancelled()
+                and heartbeat_task.exception() is not None
+            ):
+                heartbeat_task.result()
             for task in done:
                 if not task.cancelled() and task.exception() is not None:
                     task.result()

--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -5,9 +5,11 @@ import os
 import signal
 import socket
 from time import time
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import aiofiles
+import aiofiles.os
+import aiohttp
 import structlog
 
 from jobmon.core.cluster_protocol import ClusterWorkerNode
@@ -366,8 +368,16 @@ class WorkerNodeTaskInstance:
         )
 
     @bind_method_context(task_instance_id="_task_instance_id")
-    def log_report_by(self) -> None:
-        """Log the heartbeat to show that the task instance is still alive."""
+    async def log_report_by(self, session: aiohttp.ClientSession) -> None:
+        """Log the heartbeat to show that the task instance is still alive.
+
+        Uses the async requester with an aiohttp ClientSession so heartbeats
+        can run concurrently with other asyncio work (subprocess pipe drain,
+        lazy log-directory creation in ``_communicate``). Running on the event
+        loop instead of the default thread-pool avoids the executor pressure
+        that ``asyncio.to_thread`` would add when multiple slow I/O paths are
+        in flight at the same time.
+        """
         logger.info("Worker node sending heartbeat")
         message: Dict = {
             "next_report_increment": (
@@ -383,7 +393,8 @@ class WorkerNodeTaskInstance:
             logger.debug("No distributor_id was found in the sbatch env at this time")
 
         app_route = f"/task_instance/{self.task_instance_id}/log_report_by"
-        _, response = self.requester.send_request(
+        _, response = await self.requester.send_request_async(
+            session=session,
             app_route=app_route,
             message=message,
             request_type="post",
@@ -489,87 +500,125 @@ class WorkerNodeTaskInstance:
         finally:
             return mem_buffer
 
-    async def _process_poller(self, process: asyncio.subprocess.Process) -> int:
-        keep_polling = True
-        while keep_polling:
-            time_till_next_heartbeat = self._task_instance_heartbeat_interval - (
-                time() - self.last_heartbeat_time
-            )
+    async def _heartbeat_loop(self, session: aiohttp.ClientSession) -> None:
+        """Periodically send heartbeats for the entire duration of ``_run_cmd``.
+
+        Runs concurrently with pre-subprocess log-directory creation, the
+        subprocess itself, and the stream-drain phase. The caller in
+        ``_run_cmd`` races this task against the subprocess work tasks via
+        ``asyncio.wait(FIRST_COMPLETED)``, so a ``TransitionError`` raised
+        from ``log_report_by`` (e.g. the server moved the TI out of R)
+        triggers immediate subprocess cleanup instead of being discovered
+        only when the subprocess finishes on its own.
+
+        Transient network/server errors are logged and swallowed so they
+        don't abort the whole task — ``log_report_by`` only raises after
+        the sync requester's tenacity retry budget is exhausted, and even
+        then we want to keep ticking in case the next attempt recovers.
+        """
+        while True:
+            await asyncio.sleep(self._task_instance_heartbeat_interval)
             try:
-                await asyncio.wait_for(process.wait(), timeout=time_till_next_heartbeat)
-                keep_polling = False
-            except asyncio.TimeoutError:
-                self.log_report_by()
+                await self.log_report_by(session)
+            except TransitionError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "Worker node heartbeat failed, retrying next tick",
+                    error=str(e),
+                )
 
-        # keep typecheck happy
-        returncode = process.returncode
-        if returncode is None:
-            raise AttributeError(
-                "process finished polling but does not a a return code."
-            )
+    async def _ensure_logfile_parent_dir(self, output_path: str) -> None:
+        """Create the parent directory of a logfile path if needed.
 
-        return returncode
+        Uses ``aiofiles.os.makedirs`` so the underlying syscall runs on the
+        event loop's default executor while the coroutine awaits the
+        future. The event loop stays responsive throughout, so a concurrent
+        ``_heartbeat_loop`` task keeps firing heartbeats even if the
+        filesystem stalls for minutes.
+        """
+        if not output_path or output_path == "/dev/null":
+            return
+        parent = os.path.dirname(output_path)
+        if not parent:
+            return
+        await aiofiles.os.makedirs(parent, exist_ok=True)
 
     async def _run_cmd(self) -> None:
-        # Copy the current environment variables and update them with additional settings
-        env = os.environ.copy()
-        env.update(self.command_add_env)
+        """Run the user's command under a concurrent heartbeat task.
 
-        # capture stdout and stderr for asynchronous reading
-        process = await asyncio.create_subprocess_shell(
-            self.command,
-            env=env,
-            stdout=asyncio.subprocess.PIPE,  # Captures stdout
-            stderr=asyncio.subprocess.PIPE,  # Captures stderr
-        )
+        The heartbeat loop runs for the entire lifetime of this method —
+        from pre-subprocess log-dir creation through subprocess exit and
+        stream drain — so a slow filesystem or long subprocess can't
+        starve the TI's ``report_by_date`` on the server.
+        """
+        async with aiohttp.ClientSession() as session:
+            heartbeat_task = asyncio.create_task(self._heartbeat_loop(session))
+            try:
+                await self._run_subprocess_with_heartbeat_race(heartbeat_task)
+            finally:
+                await self._stop_heartbeat_task(heartbeat_task)
 
-        # Assert that stdout and stderr are not None for the type checker.
-        assert process.stdout is not None
-        assert process.stderr is not None
+    async def _run_subprocess_with_heartbeat_race(
+        self, heartbeat_task: "asyncio.Task[None]"
+    ) -> None:
+        """Pre-create log dirs, spawn the subprocess, and race it.
 
-        # Initialize task variables to None. These will hold the asyncio tasks for
-        # communicating with and monitoring the subprocess.
-        stdout_task = stderr_task = heartbeat_task = None
-
+        All failures — pre-create ``OSError``, heartbeat
+        ``TransitionError``, stream drain errors, subprocess spawn
+        errors — are caught and re-raised wrapped in ``RuntimeError`` via
+        ``raise ... from e``. The outer ``run()`` method's
+        ``except RuntimeError`` block depends on
+        ``isinstance(e.__cause__, TransitionError)`` to route KILL_SELF
+        handling, so the wrap must happen here regardless of whether the
+        subprocess ever actually started.
+        """
+        process: Optional[asyncio.subprocess.Process] = None
+        stdout_task: Optional["asyncio.Task[str]"] = None
+        stderr_task: Optional["asyncio.Task[str]"] = None
+        process_wait_task: Optional["asyncio.Task[int]"] = None
         try:
-            # Create asyncio tasks for reading subprocess stdout and stderr.
-            # File I/O is handled via aiofiles inside _communicate so that
-            # slow NFS writes cannot block the event loop or delay heartbeats.
+            env = os.environ.copy()
+            env.update(self.command_add_env)
+
+            # Pre-create log parent directories. If the shared filesystem
+            # stalls here, ``heartbeat_task`` keeps the TI alive on the
+            # server. Because we wait to spawn the subprocess until the
+            # directories exist, the subprocess's stdout/stderr pipes can
+            # never fill while we're blocked on a metadata op.
+            await self._ensure_logfile_parent_dir(self.stdout)
+            await self._ensure_logfile_parent_dir(self.stderr)
+
+            # Surface an early heartbeat failure (e.g. KILL_SELF) before
+            # we spawn a subprocess we'll immediately have to kill.
+            if heartbeat_task.done():
+                heartbeat_task.result()
+
+            process = await asyncio.create_subprocess_shell(
+                self.command,
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            assert process.stdout is not None
+            assert process.stderr is not None
+
             stdout_task = asyncio.create_task(
                 self._communicate(process.stdout, self.stdout)
             )
             stderr_task = asyncio.create_task(
                 self._communicate(process.stderr, self.stderr)
             )
-            # Task for monitoring the subprocess (e.g., for timeouts or heartbeats).
-            heartbeat_task = asyncio.create_task(self._process_poller(process))
+            process_wait_task = asyncio.create_task(process.wait())
 
-            # Await the completion of communication and monitoring tasks.
-            valid_tasks = [stdout_task, stderr_task, heartbeat_task]
-            await asyncio.gather(*valid_tasks)
+            await self._race_work_tasks(
+                heartbeat_task, [stdout_task, stderr_task, process_wait_task]
+            )
 
         except Exception as e:
-            # If an exception occurs, cancel all ongoing tasks to prevent dangling operations.
-            tasks_to_cancel = [
-                t for t in [stdout_task, stderr_task, heartbeat_task] if t is not None
-            ]
-            for task in tasks_to_cancel:
-                task.cancel()
-            # Await cancellation, ignoring any exceptions raised from cancellation.
-            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
-
-            # Attempt a graceful shutdown of the subprocess if it's still running.
-            process.send_signal(signal.SIGINT)
-            try:
-                # Wait for the process to terminate, with a specified timeout.
-                await asyncio.wait_for(
-                    process.wait(), timeout=self._command_interrupt_timeout
-                )
-            except asyncio.TimeoutError:
-                # Forcefully terminate the subprocess
-                process.kill()
-                await process.wait()
-
+            await self._abort_subprocess(
+                process, [stdout_task, stderr_task, process_wait_task]
+            )
             logger.exception(
                 "Task instance command execution failed",
                 error=str(e),
@@ -580,20 +629,120 @@ class WorkerNodeTaskInstance:
             ) from e
 
         finally:
-            # After tasks have been handled and the subprocess is ensured to be terminated,
-            # retrieve the results from the tasks if they were successfully completed.
-            stdout_result = stderr_result = ""
-            if stdout_task and stdout_task.done():
-                stdout_result = stdout_task.result()
-            if stderr_task and stderr_task.done():
-                stderr_result = stderr_task.result()
+            await self._record_final_command_output(process, stdout_task, stderr_task)
 
-            # Ensure the subprocess is fully terminated before exiting this method.
+    @staticmethod
+    async def _race_work_tasks(
+        heartbeat_task: "asyncio.Task[None]",
+        work_tasks: List["asyncio.Task"],
+    ) -> None:
+        """Wait for work tasks while watching the heartbeat.
+
+        Uses ``asyncio.wait(FIRST_COMPLETED)`` so a heartbeat failure wakes
+        us immediately — we want to cancel the subprocess the moment the
+        server says the TI is no longer ours, not after it runs to
+        completion. Any task exception (heartbeat ``TransitionError``,
+        stream drain errors) surfaces via ``task.result()``; on the normal
+        happy path no task has a stored exception and this loop is a
+        no-op. After the first completion, the remaining work tasks are
+        awaited — typically ``process_wait_task`` finishes first and we
+        wait for the stdout/stderr drains to hit EOF.
+        """
+        done, _pending = await asyncio.wait(
+            [heartbeat_task, *work_tasks],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in done:
+            if not task.cancelled() and task.exception() is not None:
+                task.result()
+        still_pending = [t for t in work_tasks if not t.done()]
+        if still_pending:
+            await asyncio.gather(*still_pending)
+
+    async def _abort_subprocess(
+        self,
+        process: Optional[asyncio.subprocess.Process],
+        work_tasks: List[Optional["asyncio.Task"]],
+    ) -> None:
+        """Cancel work tasks and gracefully terminate the subprocess.
+
+        Safe to call even if the subprocess never started. The escalation
+        is SIGINT → wait up to ``_command_interrupt_timeout`` → SIGKILL.
+        """
+        tasks_to_cancel = [t for t in work_tasks if t is not None and not t.done()]
+        for task in tasks_to_cancel:
+            task.cancel()
+        await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
+
+        if process is not None and process.returncode is None:
+            process.send_signal(signal.SIGINT)
+            try:
+                await asyncio.wait_for(
+                    process.wait(), timeout=self._command_interrupt_timeout
+                )
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+
+    async def _record_final_command_output(
+        self,
+        process: Optional[asyncio.subprocess.Process],
+        stdout_task: Optional["asyncio.Task[str]"],
+        stderr_task: Optional["asyncio.Task[str]"],
+    ) -> None:
+        """Collect the final command output and store it on ``self``.
+
+        Gathers the stdout/stderr tails from the drain tasks, awaits the
+        subprocess return code, and calls ``set_command_output``. If the
+        subprocess never spawned (e.g. a ``TransitionError`` during
+        pre-create), falls back to a sentinel return code so the outer
+        ``run()`` method's KILL_SELF handler can still access
+        ``command_returncode`` without ``AttributeError``.
+        """
+        stdout_result = self._get_drain_result(stdout_task)
+        stderr_result = self._get_drain_result(stderr_task)
+
+        if process is not None:
             returncode = await process.wait()
+        else:
+            returncode = -1
 
-            # Update the task instance with the final results of command execution.
-            self.set_command_output(
-                returncode=returncode,
-                stdout=stdout_result,
-                stderr=stderr_result,
-            )
+        self.set_command_output(
+            returncode=returncode,
+            stdout=stdout_result,
+            stderr=stderr_result,
+        )
+
+    @staticmethod
+    def _get_drain_result(task: Optional["asyncio.Task[str]"]) -> str:
+        """Return a stream drain task's accumulated output, or empty.
+
+        Returns an empty string if the task is None, still running,
+        cancelled, or raised an exception.
+        """
+        if task is None or not task.done() or task.cancelled():
+            return ""
+        try:
+            return task.result()
+        except Exception:
+            return ""
+
+    @staticmethod
+    async def _stop_heartbeat_task(
+        heartbeat_task: "asyncio.Task[None]",
+    ) -> None:
+        """Cancel and consume the heartbeat task.
+
+        Called from an outer ``finally`` — swallows the task's final
+        exception (``TransitionError``, ``CancelledError``, etc.) so it
+        can't mask the real in-flight error. The relevant exception has
+        already been surfaced by ``_race_work_tasks`` or the early
+        ``heartbeat_task.result()`` check in
+        ``_run_subprocess_with_heartbeat_race``.
+        """
+        if not heartbeat_task.done():
+            heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except BaseException:
+            pass

--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -612,7 +612,9 @@ class WorkerNodeTaskInstance:
             process_wait_task = asyncio.create_task(process.wait())
 
             await self._race_work_tasks(
-                heartbeat_task, [stdout_task, stderr_task, process_wait_task]
+                heartbeat_task=heartbeat_task,
+                process_wait_task=process_wait_task,
+                drain_tasks=[stdout_task, stderr_task],
             )
 
         except Exception as e:
@@ -634,47 +636,67 @@ class WorkerNodeTaskInstance:
     @staticmethod
     async def _race_work_tasks(
         heartbeat_task: "asyncio.Task[None]",
-        work_tasks: List["asyncio.Task"],
+        process_wait_task: "asyncio.Task[int]",
+        drain_tasks: List["asyncio.Task[str]"],
     ) -> None:
-        """Wait for work tasks while watching the heartbeat.
+        """Wait for the subprocess to exit while watching the heartbeat.
 
-        Uses ``asyncio.wait(FIRST_COMPLETED)`` so a heartbeat failure wakes
-        us immediately — we want to cancel the subprocess the moment the
-        server says the TI is no longer ours, not after it runs to
-        completion. Any task exception (heartbeat ``TransitionError``,
-        stream drain errors) surfaces via ``task.result()``; on the normal
-        happy path no task has a stored exception and this loop is a
-        no-op.
+        Loops over ``asyncio.wait(FIRST_COMPLETED)`` until
+        ``process_wait_task`` is specifically the one that completed —
+        **not** just any work task. A drain task finishing early does NOT
+        mean work is done: ``_communicate`` has a ``finally: return
+        mem_buffer`` that silently absorbs ``IOError`` during shared-fs
+        writes, so a failed drain task looks identical to a successful
+        one (no stored exception, empty-string result). The subprocess
+        may still be running and writing to the now-undrained pipe, in
+        which case we must keep heartbeating until the subprocess
+        actually exits — otherwise the pipe fills, the subprocess
+        blocks on its next write, and the server marks the TI overdue,
+        reproducing the exact failure mode this refactor fixes.
 
-        Once a work task completes successfully (typically
-        ``process_wait_task`` after the subprocess exits), the heartbeat
-        task is cancelled before the remaining drain tasks are awaited.
-        This matches the old ``_process_poller`` behavior of stopping
+        Any task exception (heartbeat ``TransitionError``, unexpected
+        drain error) surfaces immediately via ``task.result()`` inside
+        the loop and propagates out to
+        ``_run_subprocess_with_heartbeat_race``'s except block. On the
+        normal happy path, ``task.exception()`` is ``None`` for every
+        completed task and the check is a no-op.
+
+        Once ``process_wait_task`` has completed, the heartbeat task is
+        cancelled before the remaining drain tasks are awaited. This
+        matches the old ``_process_poller`` behavior of stopping
         heartbeats as soon as ``process.wait()`` returned, and prevents a
-        KILL_SELF race during the drain phase from raising a
+        KILL_SELF race during the final drain phase from raising a
         ``TransitionError`` on a heartbeat task that nobody is watching —
         such an exception would be silently swallowed by
         ``_stop_heartbeat_task`` in the outer ``finally``, mutating
         ``self._status`` behind ``run()``'s back.
         """
-        done, _pending = await asyncio.wait(
-            [heartbeat_task, *work_tasks],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        for task in done:
-            if not task.cancelled() and task.exception() is not None:
-                task.result()
+        pending: set = {heartbeat_task, process_wait_task, *drain_tasks}
+        while process_wait_task in pending:
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
+                if not task.cancelled() and task.exception() is not None:
+                    task.result()
+            # Defensive: _heartbeat_loop is infinite, so reaching "done
+            # without exception" would mean it was cancelled externally,
+            # which nothing in this method does. Bail to avoid a tight
+            # loop on a stable done set if that assumption is ever
+            # broken.
+            if heartbeat_task.done() and heartbeat_task.exception() is None:
+                break
 
-        # A work task completed first (heartbeat errors were raised above
-        # and never reach this point). Stop heartbeating before draining
-        # the remaining stdout/stderr EOFs, so a KILL_SELF race during
-        # drain can't silently update self._status.
+        # Subprocess has exited (or heartbeat terminated unexpectedly).
+        # Stop the heartbeat so a KILL_SELF race during the final drain
+        # phase can't silently update self._status, then wait for any
+        # remaining drain tasks to hit EOF.
         if not heartbeat_task.done():
             heartbeat_task.cancel()
 
-        still_pending = [t for t in work_tasks if not t.done()]
-        if still_pending:
-            await asyncio.gather(*still_pending)
+        remaining_drains = [t for t in drain_tasks if not t.done()]
+        if remaining_drains:
+            await asyncio.gather(*remaining_drains)
 
     async def _abort_subprocess(
         self,

--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -90,9 +90,6 @@ class WorkerNodeTaskInstance:
         self._stdout: Optional[str] = None
         self._stderr: Optional[str] = None
 
-        # set last heartbeat
-        self.last_heartbeat_time = time()
-
     @property
     def task_instance_id(self) -> int:
         """Returns a task instance ID if it's been bound."""
@@ -350,7 +347,6 @@ class WorkerNodeTaskInstance:
         self._command_add_env = {
             f"JOBMON_{k.upper()}": str(v) for k, v in kwargs.items()
         }
-        self.last_heartbeat_time = time()
         if self.status != TaskInstanceStatus.RUNNING:
             logger.error(
                 "Task instance failed to transition to RUNNING",
@@ -401,7 +397,6 @@ class WorkerNodeTaskInstance:
         )
 
         self._status = response["status"]
-        self.last_heartbeat_time = time()
 
         if self.status != TaskInstanceStatus.RUNNING:
             raise TransitionError(
@@ -631,7 +626,24 @@ class WorkerNodeTaskInstance:
             ) from e
 
         finally:
-            await self._record_final_command_output(process, stdout_task, stderr_task)
+            # Protect the pending exception (if any) from being masked
+            # by a cleanup error. If the except block above raised a
+            # RuntimeError whose __cause__ is TransitionError, run()'s
+            # KILL_SELF handler depends on that chain; an uncaught
+            # exception from _record_final_command_output would replace
+            # the propagating exception and strip the __cause__ link.
+            # set_command_output is the only state-mutating call and
+            # cannot raise, so the worst case here is losing the
+            # stdout/stderr tails from the log_done/log_error payload.
+            try:
+                await self._record_final_command_output(
+                    process, stdout_task, stderr_task
+                )
+            except Exception as cleanup_exc:
+                logger.exception(
+                    "Failed to record final command output during cleanup",
+                    error=str(cleanup_exc),
+                )
 
     @staticmethod
     async def _race_work_tasks(

--- a/tests/integration/client/test_worker.py
+++ b/tests/integration/client/test_worker.py
@@ -234,6 +234,173 @@ def test_ti_kill_self_state(db_engine, tool):
     assert worker_node_task_instance.status == TaskInstanceStatus.ERROR_FATAL
 
 
+def _build_running_worker_node_ti(
+    db_engine, tool, name: str, command: str, heartbeat_interval: int = 1
+):
+    """Set up a workflow → workflow run → DistributorService pipeline and
+    return a ``WorkerNodeTaskInstance`` that has already called
+    ``log_running()`` (i.e. is in RUNNING state on the server).
+    """
+    workflow = tool.create_workflow(name=name)
+    task_a = tool.active_task_templates["simple_template"].create_task(arg=command)
+    workflow.add_task(task_a)
+    workflow.bind()
+    workflow._bind_tasks()
+    factory = WorkflowRunFactory(workflow.workflow_id)
+    wfr = factory.create_workflow_run()
+    wfr._update_status(WorkflowRunStatus.BOUND)
+
+    state, gateway, orchestrator = create_test_context(
+        workflow, wfr.workflow_run_id, workflow.requester
+    )
+    prepare_and_queue_tasks(state, gateway, orchestrator)
+
+    distributor_service = DistributorService(
+        DoNothingDistributor("dummy"),
+        requester=workflow.requester,
+        raise_on_error=True,
+    )
+    distributor_service.set_workflow_run(wfr.workflow_run_id)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.QUEUED)
+    distributor_service.process_status(TaskInstanceStatus.QUEUED)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.INSTANTIATED)
+    distributor_service.process_status(TaskInstanceStatus.INSTANTIATED)
+
+    with Session(bind=db_engine) as session:
+        task_instance_id = session.execute(
+            select(TaskInstance.id).where(TaskInstance.task_id == task_a.task_id)
+        ).scalar()
+
+    cluster = Cluster.get_cluster("dummy")
+    worker_node_task_instance = WorkerNodeTaskInstance(
+        task_instance_id=task_instance_id,
+        cluster_interface=cluster.get_worker_node(),
+        task_instance_heartbeat_interval=heartbeat_interval,
+    )
+    worker_node_task_instance.log_running()
+    return worker_node_task_instance, task_a
+
+
+def test_heartbeats_fire_during_slow_logfile_init(db_engine, tool):
+    """Regression test for PR #388: heartbeats must fire during a slow
+    ``_ensure_logfile_parent_dir``.
+
+    Simulates a slow shared-filesystem metadata op by patching
+    ``_ensure_logfile_parent_dir`` to ``asyncio.sleep(3)``, and patches
+    ``log_report_by`` to count how many times it gets called during the
+    stall. The subprocess itself is fast (``true``). If the event loop
+    is properly sharing time between the heartbeat task and the slow
+    coroutine, several heartbeat ticks should fire before the subprocess
+    even starts.
+
+    This is the core property the refactor is meant to provide — the
+    old sync ``os.makedirs`` inside ``log_running`` blocked the main
+    thread and starved heartbeats, which is the failure mode PR #388
+    fixes. A regression that reintroduces the starvation would make
+    ``heartbeat_call_count`` stay at zero.
+    """
+    wnti, _ = _build_running_worker_node_ti(
+        db_engine,
+        tool,
+        name="test_heartbeats_fire_during_slow_logfile_init",
+        command="true",
+        heartbeat_interval=1,
+    )
+
+    heartbeat_call_count = 0
+    original_log_report_by = WorkerNodeTaskInstance.log_report_by
+
+    async def counting_log_report_by(self, session):
+        nonlocal heartbeat_call_count
+        heartbeat_call_count += 1
+        await original_log_report_by(self, session)
+
+    original_ensure = WorkerNodeTaskInstance._ensure_logfile_parent_dir
+
+    async def slow_ensure(self, output_path):
+        await asyncio.sleep(3)
+        await original_ensure(self, output_path)
+
+    worker_node = "jobmon.worker_node."
+    WNTI = "worker_node_task_instance.WorkerNodeTaskInstance."
+    with patch(worker_node + WNTI + "log_report_by", new=counting_log_report_by):
+        with patch(worker_node + WNTI + "_ensure_logfile_parent_dir", new=slow_ensure):
+            wnti.run()
+
+    # With interval=1s and a 3s stall, we expect at least 2 heartbeat
+    # calls to fire during the stall. Give some slack for scheduling
+    # jitter by requiring only >= 2.
+    assert heartbeat_call_count >= 2, (
+        f"Expected heartbeats to fire during slow _ensure_logfile_parent_dir, "
+        f"but only {heartbeat_call_count} fired"
+    )
+    # Subprocess should still complete normally despite the pre-subprocess stall
+    assert wnti.status == TaskInstanceStatus.DONE
+
+
+def test_drain_task_finishes_before_subprocess_keeps_heartbeating(db_engine, tool):
+    """Regression test for PR #388 round-2 fix (``1f069be6``): if a drain
+    task finishes before ``process_wait_task`` (e.g. because
+    ``_communicate`` hit an internal error and its
+    ``finally: return mem_buffer`` absorbed it into a clean return),
+    ``_race_work_tasks`` must keep heartbeating instead of cancelling
+    the heartbeat task and leaving the still-running subprocess with no
+    heartbeats.
+
+    Simulates the scenario by patching one of the ``_communicate`` calls
+    to return early while the subprocess is still running, and counts
+    heartbeats during the remaining subprocess lifetime. At least one
+    heartbeat should fire after the drain task finishes but before the
+    subprocess exits — if the heartbeat was cancelled prematurely
+    (the regression), zero would fire in that window.
+    """
+    wnti, _ = _build_running_worker_node_ti(
+        db_engine,
+        tool,
+        name="test_drain_task_finishes_before_subprocess_keeps_heartbeating",
+        command="sleep 3",
+        heartbeat_interval=1,
+    )
+
+    heartbeat_calls_after_drain_finished = 0
+    drain_finished_marker = False
+    original_log_report_by = WorkerNodeTaskInstance.log_report_by
+
+    async def counting_log_report_by(self, session):
+        nonlocal heartbeat_calls_after_drain_finished
+        if drain_finished_marker:
+            heartbeat_calls_after_drain_finished += 1
+        await original_log_report_by(self, session)
+
+    original_communicate = WorkerNodeTaskInstance._communicate
+
+    async def early_exit_stdout_communicate(async_stream, output_path, chunk_size=64):
+        nonlocal drain_finished_marker
+        drain_finished_marker = True
+        # Return immediately with empty tail — simulates the silent
+        # _communicate failure mode that bugbot flagged (an IOError
+        # absorbed by `finally: return mem_buffer`).
+        return ""
+
+    worker_node = "jobmon.worker_node."
+    WNTI = "worker_node_task_instance.WorkerNodeTaskInstance."
+    # Only patch stdout drain — stderr keeps normal behavior. This leaves
+    # the subprocess running while the stdout drain task is "done".
+    with patch(worker_node + WNTI + "log_report_by", new=counting_log_report_by):
+        with patch(
+            worker_node + WNTI + "_communicate",
+            new=staticmethod(early_exit_stdout_communicate),
+        ):
+            wnti.run()
+
+    assert heartbeat_calls_after_drain_finished >= 1, (
+        "Expected at least one heartbeat to fire after the drain task "
+        "finished but while the subprocess was still running; got "
+        f"{heartbeat_calls_after_drain_finished}. A zero count means the "
+        "heartbeat was cancelled prematurely (round-2 regression)."
+    )
+
+
 def test_limited_error_log(tool, db_engine):
     thisdir = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
 
@@ -383,7 +550,6 @@ def test_worker_node_add_attributes(tool, db_engine):
 class UnicodeInstance(WorkerNodeTaskInstance):
     def __init__(self, command):
         self._command = command
-        self.last_heartbeat_time = time.time()
 
         # config
         config = JobmonConfig()


### PR DESCRIPTION
## Summary

Fixes the false-failure mode where a slow shared-filesystem metadata op in the worker's `log_running()` path causes the server's heartbeat monitor to move the TI to TRIAGING while the worker is actually still alive. Observed in prod on dismod_at workflows hitting Qumulo metadata stalls — workers would hang for 5–7 minutes inside `os.makedirs()` before the subprocess even started, long enough for the server to mark them overdue. When the worker eventually recovered and called `log_done`, the server rejected the transition (`T → D` invalid) and the task failed despite completing successfully.

## What changed

- **`log_report_by`** is now async and uses `Requester.send_request_async` with an `aiohttp.ClientSession` (which the requester already supports).
- **`_heartbeat_loop`** is a dedicated coroutine that runs for the entire duration of `_run_cmd` — through pre-subprocess log-dir creation, subprocess execution, and stream drain. Sole heartbeat source; replaces the old `_process_poller` interleave.
- **`_ensure_logfile_parent_dir`** creates log parents via `aiofiles.os.makedirs` so the syscall runs on the event loop's default executor while the coroutine awaits the future. A multi-minute NFS stall no longer blocks the loop — heartbeats keep ticking concurrently.
- **Subprocess is spawned only after log directories exist**, so its stdout/stderr pipes can never fill while we wait on a slow makedirs.
- **Work tasks race against the heartbeat task** via `asyncio.wait(FIRST_COMPLETED)`. A `TransitionError` from the heartbeat (server moved TI to KILL_SELF) cancels the subprocess immediately instead of being discovered only at gather time.
- **All failures are wrapped in `RuntimeError` via `raise ... from e`** so `run()`'s existing `isinstance(e.__cause__, TransitionError)` check still routes the KILL_SELF path correctly — including the case where the TransitionError fires *before* the subprocess has been spawned.
- **`_run_cmd` refactored into 7 small single-purpose methods** for readability:
    - `_run_cmd` — thin outer wrapper: session + heartbeat lifecycle (8 lines)
    - `_run_subprocess_with_heartbeat_race` — orchestration + error wrapping
    - `_race_work_tasks` — the `asyncio.wait(FIRST_COMPLETED)` dance
    - `_abort_subprocess` — SIGINT → timeout → SIGKILL escalation
    - `_record_final_command_output` — collect tails + set command output
    - `_get_drain_result` — drain-result accessor helper
    - `_stop_heartbeat_task` — outer finally cleanup

## Coupling with jobmon_slurm

Pairs with jobmon_slurm's `fix/pure-initialize-logfile` change (already merged to `main`) that drops the sync `makedirs` from `SlurmWorkerNode.initialize_logfile`. Compatibility matrix:

| jobmon_core | jobmon_slurm | Status |
|---|---|---|
| **new** | **new** | ✅ Fully fixed |
| new | old | ✅ Works. Plugin's sync makedirs runs, then core's async makedirs is a no-op. Bug still present until both upgrade. |
| old | new | ❌ Broken. `aiofiles.open` in `_communicate` fails with `FileNotFoundError`. |
| old | old | Buggy (current state) |

Upgrade order if deploying separately: **jobmon_core first, then jobmon_slurm.**

## Test plan

- [x] Lint (`uv run nox -s lint`) — passes
- [x] Typecheck (`uv run nox -s typecheck`) — passes, 0 issues in 219 files
- [x] `test_ti_kill_self_state` — passes (the specific KILL_SELF flow we were most concerned about)
- [x] `tests/integration/client/test_worker.py` — 7/7 passing
- [x] `tests/integration/client/test_resume_kill_self.py` — 6/6 passing
- [x] `tests/integration/distributor/test_killed.py` — 1/1 passing
- [x] Full suite pre-refactor: 941 passed, 6 skipped, 0 failures
- [x] Full suite post-refactor: running locally; CI on this PR will be the authoritative check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worker subprocess/heartbeat lifecycle and error propagation; bugs here can cause stuck/incorrect task instance states or orphaned subprocesses, though changes are localized and covered by new regression tests.
> 
> **Overview**
> Prevents false task failures under slow shared filesystems by running the heartbeat loop concurrently with pre-subprocess log-dir creation, subprocess execution, and stream draining.
> 
> `WorkerNodeTaskInstance` now sends heartbeats via async `log_report_by()` using `Requester.send_request_async`/`aiohttp`, replaces the old polling approach with a dedicated `_heartbeat_loop`, and restructures `_run_cmd` into smaller helpers that *race* heartbeat vs subprocess completion, pre-create log parent dirs asynchronously, and ensure robust cleanup/exception chaining (including early `KILL_SELF`).
> 
> Adds integration regressions to verify heartbeats fire during slow log-dir init and continue even if a drain task finishes early while the subprocess is still running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 250661dcfa2f50da80800a772fc44aff245cd925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->