### PR TITLE
Rescue log_error to ERROR_FATAL when TI is in KILL_SELF

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_instance.py
@@ -454,6 +454,47 @@ async def log_error_worker_node(
             db.add(error)
             # release locks immediately
             db.commit()
+        elif (
+            result["error"] == "untimely_transition"
+            and task_instance.status == constants.TaskInstanceStatus.KILL_SELF
+        ):
+            # Worker is trying to report an error but the workflow resume
+            # machinery has already moved the TI to KILL_SELF. The error
+            # states (ERROR/UNKNOWN_ERROR/RESOURCE_ERROR) are all in
+            # TI_UNTIMELY_TRANSITIONS from KILL_SELF, so the first
+            # TransitionService call refused the transition silently and
+            # left the TI stuck in K. Transition directly to ERROR_FATAL
+            # instead — (KILL_SELF, ERROR_FATAL) is in TI_VALID_TRANSITIONS
+            # and is exactly the terminal state this race should produce.
+            # Mirrors the existing KILL_SELF rescue in the log_running
+            # handler above.
+            logger.info(
+                "Worker reported error while TI was in KILL_SELF; "
+                "rescuing to ERROR_FATAL",
+                original_error_state=error_state,
+            )
+            result = TransitionService.transition_task_instance(
+                session=db,
+                task_instance_id=task_instance.id,
+                task_id=task_instance.task_id,
+                current_ti_status=task_instance.status,
+                new_ti_status=constants.TaskInstanceStatus.ERROR_FATAL,
+                task_num_attempts=task_instance.task.num_attempts,
+                task_max_attempts=task_instance.task.max_attempts,
+            )
+            if result["ti_updated"]:
+                error = TaskInstanceErrorLog(
+                    task_instance_id=task_instance.id,
+                    description=error_description,
+                )
+                db.add(error)
+                db.commit()
+                db.refresh(task_instance)
+            else:
+                logger.error(
+                    "KILL_SELF rescue to ERROR_FATAL failed",
+                    rescue_error=result["error"],
+                )
         else:
             if result["error"] == "untimely_transition":
                 logger.warning(

--- a/tests/integration/client/test_worker.py
+++ b/tests/integration/client/test_worker.py
@@ -234,6 +234,105 @@ def test_ti_kill_self_state(db_engine, tool):
     assert worker_node_task_instance.status == TaskInstanceStatus.ERROR_FATAL
 
 
+def test_log_error_kill_self_rescue(db_engine, tool):
+    """log_error on a KILL_SELF-state TI should rescue to ERROR_FATAL.
+
+    Regression test for the race where the workflow resume machinery
+    moves a TI to KILL_SELF while the worker is in the middle of
+    reporting an error. (KILL_SELF, ERROR) is in
+    ``TI_UNTIMELY_TRANSITIONS`` on the server, so the first transition
+    attempt is silently refused and the TI gets stuck in K state. The
+    ``log_error_worker_node`` route detects this case and re-issues the
+    transition as (KILL_SELF, ERROR_FATAL), which is in
+    ``TI_VALID_TRANSITIONS``. Mirrors the existing KILL_SELF rescue in
+    the ``log_running`` handler.
+    """
+    workflow = tool.create_workflow(name="test_log_error_kill_self_rescue")
+    task_a = tool.active_task_templates["simple_template"].create_task(arg="sleep 1")
+    workflow.add_task(task_a)
+    workflow.bind()
+    workflow._bind_tasks()
+    factory = WorkflowRunFactory(workflow.workflow_id)
+    wfr = factory.create_workflow_run()
+    wfr._update_status(WorkflowRunStatus.BOUND)
+
+    # Get the TI into RUNNING state via the normal distributor path
+    state, gateway, orchestrator = create_test_context(
+        workflow, wfr.workflow_run_id, workflow.requester
+    )
+    prepare_and_queue_tasks(state, gateway, orchestrator)
+
+    distributor_service = DistributorService(
+        DoNothingDistributor("dummy"),
+        requester=workflow.requester,
+        raise_on_error=True,
+    )
+    distributor_service.set_workflow_run(wfr.workflow_run_id)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.QUEUED)
+    distributor_service.process_status(TaskInstanceStatus.QUEUED)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.INSTANTIATED)
+    distributor_service.process_status(TaskInstanceStatus.INSTANTIATED)
+
+    with Session(bind=db_engine) as session:
+        task_instance_id = session.execute(
+            select(TaskInstance.id).where(TaskInstance.task_id == task_a.task_id)
+        ).scalar()
+
+    cluster = Cluster.get_cluster("dummy")
+    worker_node_task_instance = WorkerNodeTaskInstance(
+        task_instance_id=task_instance_id,
+        cluster_interface=cluster.get_worker_node(),
+        task_instance_heartbeat_interval=5,
+    )
+    worker_node_task_instance.log_running()
+
+    # Simulate the race: workflow resume moves the TI to KILL_SELF after
+    # log_running but before the worker has a chance to call log_error.
+    with Session(bind=db_engine) as session:
+        session.execute(
+            text(
+                f"UPDATE task_instance SET status = '{TaskInstanceStatus.KILL_SELF}' "
+                f"WHERE id = {task_instance_id}"
+            )
+        )
+        session.commit()
+
+    # Worker tries to report an error (e.g. non-zero exit code from
+    # the subprocess). (KILL_SELF, ERROR) is untimely — the server
+    # should rescue it to ERROR_FATAL instead of leaving the TI in K.
+    workflow.requester.send_request(
+        app_route=f"/task_instance/{task_instance_id}/log_error_worker_node",
+        message={
+            "error_state": TaskInstanceStatus.ERROR,
+            "error_description": "simulated task failure during KILL_SELF race",
+            "nodename": "test-node",
+            "distributor_id": worker_node_task_instance.distributor_id,
+        },
+        request_type="post",
+    )
+
+    # TI should now be in ERROR_FATAL, not stuck in KILL_SELF.
+    with Session(bind=db_engine) as session:
+        row = session.execute(
+            select(TaskInstance.status).where(TaskInstance.id == task_instance_id)
+        ).one()
+    assert (
+        row.status == TaskInstanceStatus.ERROR_FATAL
+    ), f"Expected rescue to ERROR_FATAL, got {row.status}"
+
+    # And an error log entry should have been created with the worker's
+    # original error description (not silently dropped by the rescue).
+    with Session(bind=db_engine) as session:
+        descriptions = session.execute(
+            text(
+                "SELECT description FROM task_instance_error_log "
+                f"WHERE task_instance_id = {task_instance_id}"
+            )
+        ).fetchall()
+    assert len(descriptions) == 1
+    assert "simulated task failure during KILL_SELF race" in descriptions[0][0]
+
+
 def test_limited_error_log(tool, db_engine):
     thisdir = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing gap in `log_error_worker_node`: if the workflow resume machinery moves a TI to `KILL_SELF` between the worker's `log_running` and its `log_error` call, the worker's error report is silently refused by the server and the TI gets stuck in K state with no terminal transition.

Surfaced during PR #388's review — bugbot's heartbeat race analysis highlighted this downstream gap as a pre-existing issue worth fixing on its own track.

## What's broken today

1. Worker's subprocess exits non-zero → `run()` calls `log_error(error_state, msg)` (e.g. `ERROR`, `UNKNOWN_ERROR`, or `RESOURCE_ERROR`)
2. Meanwhile, workflow resume moves the TI to `KILL_SELF` in the DB
3. Server's `log_error_worker_node` calls `TransitionService.transition_task_instance(current=K, new=ERROR)`
4. `(KILL_SELF, ERROR)` is in `TI_UNTIMELY_TRANSITIONS` (`transition_service.py:85-87`) — the service returns `{ti_updated: False, error: "untimely_transition"}` and refuses silently
5. Route logs a warning, returns 200 with the unchanged `K` status
6. Worker reads back `self.status != error_state`, raises `TransitionError`
7. `run()` doesn't catch `TransitionError` from `log_error` (only from `_run_cmd`'s wrapped form), cli.py's `except Exception` catches it, worker exits `WORKER_NODE_CLI_FAILURE`
8. **TI is stuck in KILL_SELF on the server, no error log entry, no terminal transition**

## What changes

Add a rescue branch in `log_error_worker_node` that mirrors the existing `log_running` KILL_SELF rescue (same file, line 74-89). On `untimely_transition` from `KILL_SELF`:

- Re-issue the transition as `(KILL_SELF, ERROR_FATAL)` — this IS in `TI_VALID_TRANSITIONS` (`transition_service.py:69`), so it succeeds
- Create the `TaskInstanceErrorLog` entry with the worker's original error description
- Return 200 with `status=ERROR_FATAL`

The worker's `log_error` then sees a clean terminal transition, no `TransitionError` is raised, and the TI has an audit trail explaining why it was killed.

## Why this is the right fix

- **Mirrors an existing pattern** — `log_running` already has the exact same rescue for the log_running-during-KILL_SELF race
- **Uses an already-valid transition** — `(KILL_SELF, ERROR_FATAL)` is in `TI_VALID_TRANSITIONS`; no new server-side rules
- **Server-side only** — works for all worker versions, no client update needed
- **Semantically correct** — a worker reporting a failure after being killed is exactly what `ERROR_FATAL` means

## Test plan

Added `test_log_error_kill_self_rescue` in `tests/integration/client/test_worker.py`:

1. Set up a workflow, get a TI to `RUNNING` via the normal distributor path + `log_running`
2. Manually `UPDATE task_instance SET status='K'` via the DB
3. POST to `/task_instance/{id}/log_error_worker_node` with `error_state=ERROR`
4. Assert the TI is now `ERROR_FATAL` (not stuck in `K`)
5. Assert the error log entry was created with the worker's original description

Test log output confirms the rescue fires:
```
[WARNING] Untimely TI transition rejected
[INFO] Worker reported error while TI was in KILL_SELF; rescuing to ERROR_FATAL
[INFO] Task transitioned via TI
```

- [x] `uv run nox -s lint` — passes
- [x] `uv run nox -s typecheck` — passes (219 files, 0 issues)
- [x] New test passes
- [x] Full worker/KILL_SELF test files (15/15): `test_worker.py`, `test_resume_kill_self.py`, `test_killed.py`

## Relationship to PR #388

This is an **independent** fix. PR #388 (the worker-side heartbeat refactor) addresses the log_running-hang bug on slow shared filesystems. This PR fixes a separate server-side gap that the PR #388 review surfaced. Neither depends on the other — both can land in either order and have independent value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task-instance state transition handling in a core worker-facing route; incorrect behavior could leave instances in the wrong terminal state or hide error logs, but the change is narrowly scoped and covered by an integration regression test.
> 
> **Overview**
> Fixes a race in `log_error_worker_node` where a worker reporting an error after the server-side resume logic has already moved the task instance to `KILL_SELF` would previously be rejected as an `untimely_transition` and leave the TI stuck.
> 
> The route now detects `untimely_transition` from `KILL_SELF` and *rescues* by transitioning the TI to `ERROR_FATAL` and persisting the worker’s `TaskInstanceErrorLog` entry. Adds an integration test (`test_log_error_kill_self_rescue`) that reproduces the race and asserts both the terminal status and error log creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b8c0e26dd4823093e330c4fa41d1fa79165197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->