### PR TITLE
Keep heartbeat running through drain phase to survive slow shared-fs

### DIFF
--- a/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
+++ b/jobmon_core/src/jobmon/worker_node/worker_node_task_instance.py
@@ -659,20 +659,28 @@ class WorkerNodeTaskInstance:
         process_wait_task: "asyncio.Task[int]",
         drain_tasks: List["asyncio.Task[str]"],
     ) -> None:
-        """Wait for the subprocess to exit while watching the heartbeat.
+        """Run the subprocess and its drain tasks while the heartbeat ticks.
 
-        Loops over ``asyncio.wait(FIRST_COMPLETED)`` until
-        ``process_wait_task`` is specifically the one that completed —
-        **not** just any work task. A drain task finishing early does NOT
-        mean work is done: ``_communicate`` has a ``finally: return
-        mem_buffer`` that silently absorbs ``IOError`` during shared-fs
-        writes, so a failed drain task looks identical to a successful
-        one (no stored exception, empty-string result). The subprocess
-        may still be running and writing to the now-undrained pipe, in
-        which case we must keep heartbeating until the subprocess
-        actually exits — otherwise the pipe fills, the subprocess
-        blocks on its next write, and the server marks the TI overdue,
-        reproducing the exact failure mode this refactor fixes.
+        Loops over ``asyncio.wait(FIRST_COMPLETED)`` until **every** work
+        task (``process_wait_task`` and all ``drain_tasks``) has
+        completed. Heartbeats run concurrently for the entire window,
+        including the post-exit drain phase, so the server's
+        ``report_by_date`` can't expire while the worker is still
+        finalizing. On a slow shared filesystem a fast subprocess can be
+        followed by minutes of ``aiofiles`` flush/close work, which the
+        old "cancel heartbeat as soon as ``process_wait_task`` returns"
+        policy left uncovered — the server would mark the TI TRIAGING
+        mid-drain and the subsequent ``log_done`` would fail.
+
+        A drain task finishing early does NOT mean work is done:
+        ``_communicate`` has a ``finally: return mem_buffer`` that
+        silently absorbs ``IOError`` during shared-fs writes, so a failed
+        drain task looks identical to a successful one (no stored
+        exception, empty-string result). The subprocess may still be
+        running and writing to the now-undrained pipe, in which case we
+        must keep heartbeating until the subprocess actually exits —
+        otherwise the pipe fills, the subprocess blocks on its next
+        write, and the server marks the TI overdue.
 
         Any task exception (heartbeat ``TransitionError``, unexpected
         drain error) surfaces immediately via ``task.result()`` inside
@@ -681,18 +689,20 @@ class WorkerNodeTaskInstance:
         normal happy path, ``task.exception()`` is ``None`` for every
         completed task and the check is a no-op.
 
-        Once ``process_wait_task`` has completed, the heartbeat task is
-        cancelled before the remaining drain tasks are awaited. This
-        matches the old ``_process_poller`` behavior of stopping
-        heartbeats as soon as ``process.wait()`` returned, and prevents a
-        KILL_SELF race during the final drain phase from raising a
-        ``TransitionError`` on a heartbeat task that nobody is watching —
-        such an exception would be silently swallowed by
-        ``_stop_heartbeat_task`` in the outer ``finally``, mutating
-        ``self._status`` behind ``run()``'s back.
+        A server-initiated KILL_SELF arriving while drain is in flight
+        is handled via the same exception path: the next heartbeat call
+        observes the ``K`` status from the server, raises
+        ``TransitionError``, gets surfaced here, and propagates up
+        through ``_run_subprocess_with_heartbeat_race``'s
+        ``except Exception`` wrap so ``run()``'s ``except RuntimeError``
+        block can route to ``ERROR_FATAL`` via the ``__cause__`` chain.
+        This replaces the old "cancel heartbeat eagerly" policy that
+        closed the KILL_SELF race by silencing it — exceptions are now
+        surfaced rather than swallowed.
         """
-        pending: set = {heartbeat_task, process_wait_task, *drain_tasks}
-        while process_wait_task in pending:
+        work_tasks = {process_wait_task, *drain_tasks}
+        pending: set = {heartbeat_task, *work_tasks}
+        while work_tasks & pending:
             done, pending = await asyncio.wait(
                 pending, return_when=asyncio.FIRST_COMPLETED
             )
@@ -728,16 +738,11 @@ class WorkerNodeTaskInstance:
             ):
                 break
 
-        # Subprocess has exited (or heartbeat terminated unexpectedly).
-        # Stop the heartbeat so a KILL_SELF race during the final drain
-        # phase can't silently update self._status, then wait for any
-        # remaining drain tasks to hit EOF.
+        # All work tasks have completed (subprocess exit + drains) or
+        # the heartbeat terminated unexpectedly. Cancel the heartbeat so
+        # no further HTTP requests fire between here and log_done.
         if not heartbeat_task.done():
             heartbeat_task.cancel()
-
-        remaining_drains = [t for t in drain_tasks if not t.done()]
-        if remaining_drains:
-            await asyncio.gather(*remaining_drains)
 
     async def _abort_subprocess(
         self,

--- a/tests/integration/client/test_worker.py
+++ b/tests/integration/client/test_worker.py
@@ -500,6 +500,78 @@ def test_drain_task_finishes_before_subprocess_keeps_heartbeating(db_engine, too
     )
 
 
+def test_heartbeats_fire_during_slow_drain_tail_after_subprocess_exits(db_engine, tool):
+    """Regression test for the production failure mode where a fast
+    subprocess followed by a slow drain phase starved heartbeats and
+    caused the server to move the TI to TRIAGING before ``log_done``.
+
+    The subprocess itself exits immediately (``true``). ``_communicate``
+    is patched so that once the pipe hits EOF (subprocess closed its
+    end), the drain coroutine sleeps for several seconds before
+    returning — simulating ``aiofiles`` ``flush()``/``close()`` stalling
+    on a slow shared filesystem during the final write phase.
+
+    The previous policy cancelled the heartbeat task as soon as
+    ``process_wait_task`` returned and then awaited the drain tasks,
+    leaving a multi-minute window in which no heartbeats fired. On a
+    slow NFS mount that window exceeded ``report_by_date``, the server
+    moved the TI to ``T``, and the subsequent ``log_done`` failed with
+    ``"Current status is T"``. This test fails against that regression
+    (``heartbeat_calls_during_drain_tail == 0``) and passes once the
+    heartbeat keeps running through the drain phase.
+    """
+    wnti, _ = _build_running_worker_node_ti(
+        db_engine,
+        tool,
+        name="test_heartbeats_fire_during_slow_drain_tail_after_subprocess_exits",
+        command="true",
+        heartbeat_interval=1,
+    )
+
+    drain_tail_started = False
+    heartbeat_calls_during_drain_tail = 0
+    original_log_report_by = WorkerNodeTaskInstance.log_report_by
+
+    async def counting_log_report_by(self, session):
+        nonlocal heartbeat_calls_during_drain_tail
+        if drain_tail_started:
+            heartbeat_calls_during_drain_tail += 1
+        await original_log_report_by(self, session)
+
+    original_communicate = WorkerNodeTaskInstance._communicate
+
+    async def slow_tail_communicate(async_stream, output_path, chunk_size=64):
+        nonlocal drain_tail_started
+        # Let the normal pipe-drain complete (fast because ``true`` wrote
+        # nothing and exited immediately).
+        result = await original_communicate(async_stream, output_path, chunk_size)
+        # Pipe is at EOF; simulate a slow final ``aiofiles`` flush/close
+        # on a stalled shared filesystem. The real bug surfaces when the
+        # subprocess exits fast but this phase takes minutes.
+        drain_tail_started = True
+        await asyncio.sleep(3)
+        return result
+
+    worker_node = "jobmon.worker_node."
+    WNTI = "worker_node_task_instance.WorkerNodeTaskInstance."
+    with patch(worker_node + WNTI + "log_report_by", new=counting_log_report_by):
+        with patch(
+            worker_node + WNTI + "_communicate",
+            new=staticmethod(slow_tail_communicate),
+        ):
+            wnti.run()
+
+    assert heartbeat_calls_during_drain_tail >= 2, (
+        "Expected heartbeats to fire during the slow drain tail after the "
+        f"subprocess exited, but only {heartbeat_calls_during_drain_tail} "
+        "fired. A zero count means the heartbeat was cancelled as soon as "
+        "process_wait_task completed, which lets report_by_date expire on "
+        "slow shared filesystems and causes log_done to fail with "
+        "'Current status is T'."
+    )
+    assert wnti.status == TaskInstanceStatus.DONE
+
+
 def test_limited_error_log(tool, db_engine):
     thisdir = os.path.dirname(os.path.realpath(os.path.expanduser(__file__)))
 


### PR DESCRIPTION
## Summary

- ``_race_work_tasks`` now loops until **every** work task (``process_wait_task`` + all ``drain_tasks``) completes, keeping heartbeats alive through the post-exit drain phase so ``report_by_date`` can't expire on a slow shared filesystem.
- KILL_SELF race during drain is still handled, but via exception surfacing rather than eager heartbeat cancellation — the existing in-loop ``heartbeat_task in done / .result()`` check propagates ``TransitionError`` up to ``run()``'s ``except RuntimeError`` block, which routes to ``ERROR_FATAL``.
- New regression test ``test_heartbeats_fire_during_slow_drain_tail_after_subprocess_exits`` exercises the slow-drain-tail path via a patched ``_communicate`` that sleeps after hitting EOF. Fails against the old policy, passes against this fix.

## Why

Production investigation of client 3.7.4 surfaced 5 U-status TIs on ``dismod_at_gbd`` workflows on 2026-04-10, all matching ``"could not transition to D. Current status is T"`` on ``log_done``. One case (TI 350649837) was actively computing and heartbeating normally for 12 minutes, then went silent for 5 minutes before ``log_done`` failed:

| Time (UTC) | Event |
|---|---|
| 21:48:09 → 22:00:10 | 13 successful heartbeats, every 90s |
| ~22:00:10 | Subprocess exited (``process_wait_task`` done) |
| 22:00:10 → 22:05:27 | ``_race_work_tasks`` cancelled heartbeat, then sat in ``asyncio.gather(*remaining_drains)`` during a slow NFS flush |
| 22:04:49 | Server's ``report_by_date`` expired (``22:00:10 + 279s``), reaper moved TI to ``T`` |
| 22:05:27 | Drain finished, ``log_done`` → ``TransitionError: Current status is T`` |

The other 4 cases fit the same shape with the compute phase being fast enough that no heartbeats fired at all before ``process_wait_task`` completed and the heartbeat was cancelled. In all 5 cases, the drain phase was the multi-minute window during which ``report_by_date`` expired.

``da944363`` (the previous fix in this area) cancelled heartbeats at ``process_wait_task`` completion to close a KILL_SELF race during drain. That tradeoff assumed drain would always be fast. On a hard-mounted NFS with ``retrans=1400``, drain can block uninterruptibly for minutes. This PR keeps the KILL_SELF coverage (via exception surfacing) while removing the cancel-then-drain window.

Independent infra context: venus-fs was logged as ``"not responding, timed out"`` at 11:43 PDT on 2026-04-10, with kernel ``hung_task`` backtraces showing processes blocked in ``stat()`` through ``d_alloc_parallel`` during the same window. The filesystem instability was real; this PR makes jobmon survive it.

## Test plan

- [x] ``uv run pytest tests/integration/client/test_worker.py -k "heartbeat or drain_task"`` — 3 passed (including new regression test)
- [x] ``uv run nox -s lint`` — clean
- [x] ``uv run nox -s typecheck`` — clean
- [ ] Observe 3.7.5 (or whatever ships this fix) in prod: zero ``7e06e8968c1d985b`` grouping_key TransitionErrors on the ``D``-transition path over the next 24h of dismod_at_gbd runs

## Related

- Builds on #388 (``fix/worker-heartbeat-during-logfile-init``, merged as ``3664f255``)
- Supersedes the drain-phase cancel policy introduced in ``da944363`` and refined in ``1f069be6`` / ``8db2c194``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the worker’s subprocess/heartbeat race logic and error propagation, which can affect task state transitions and shutdown behavior under load or KILL_SELF scenarios. Covered by new integration regression test, but concurrency timing changes still carry some operational risk.
> 
> **Overview**
> Keeps heartbeats alive through the *entire* subprocess lifecycle, including the post-exit stdout/stderr drain phase, by updating `_race_work_tasks` to wait for `process_wait_task` **and** all `drain_tasks` before cancelling the heartbeat.
> 
> Adjusts KILL_SELF handling during drain to surface `TransitionError` (instead of avoiding it via early heartbeat cancellation), and adds an integration regression test `test_heartbeats_fire_during_slow_drain_tail_after_subprocess_exits` that simulates a slow drain tail and asserts heartbeats continue until completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8ec5b3eac92676adf5781a7c61873d5c8f8cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->