### PR TITLE
Fix stuck-I batch stranding: W-state transition + retry on malformed JSON

### DIFF
--- a/jobmon_core/src/jobmon/core/requester.py
+++ b/jobmon_core/src/jobmon/core/requester.py
@@ -406,9 +406,25 @@ class Requester:
         if "application/json" in content_type:
             try:
                 content = await response.json()
-            except (json.decoder.JSONDecodeError, ValueError, aiohttp.ContentTypeError):
-                # For cases where the response body is empty or malformed JSON
-                content = await response.text()
+            except (
+                json.decoder.JSONDecodeError,
+                ValueError,
+                aiohttp.ContentTypeError,
+            ) as e:
+                # application/json header but unparseable body. Historically we
+                # fell through and returned response.text() (a str), which
+                # crashed callers downstream with "string indices must be
+                # integers" when they indexed the "dict" (see the W-state
+                # stranding bug this branch fixes). Almost always a transient
+                # truncation/empty-body on a 2xx (stale keep-alive, LB hiccup),
+                # so raise InvalidResponse to let the retry layer handle it. A
+                # persistent bad body exhausts the retry budget and surfaces
+                # with real context instead of a stranded batch.
+                body = await response.text()
+                raise InvalidResponse(
+                    f"Malformed application/json body (status={response.status}, "
+                    f"len={len(body)}, parse_err={e!r}, body_head={body[:200]!r})"
+                ) from e
         else:
             content = await response.read()
         return response.status, content
@@ -501,9 +517,18 @@ def get_content(response: Any) -> Tuple[int, Any]:
         except TypeError:
             # for test_client, response.json is a dict not fn
             content = response.json
-        except (json.decoder.JSONDecodeError, ValueError):
-            # For cases where the response body is empty or malformed JSON
-            content = response.text
+        except (json.decoder.JSONDecodeError, ValueError) as e:
+            # application/json header but unparseable body. Previously this
+            # silently returned response.text (a str), which crashed callers
+            # downstream with "string indices must be integers". Raise
+            # InvalidResponse so the Requester retry layer can recover from
+            # transient truncation/empty-body on 2xx responses.
+            body = response.text
+            raise InvalidResponse(
+                f"Malformed application/json body (status={response.status_code}, "
+                f"len={len(body) if body is not None else 0}, parse_err={e!r}, "
+                f"body_head={(body or '')[:200]!r})"
+            ) from e
     else:
         content = response.content
     return response.status_code, content

--- a/jobmon_core/src/jobmon/distributor/distributor_service.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_service.py
@@ -382,82 +382,99 @@ class DistributorService:
                 task_instance_id=ti.task_instance_id,
             )
 
-        # record batch info in db
-        task_instance_batch.prepare_task_instance_batch_for_launch()
-
-        # build worker node command
-        command = self.cluster_interface.build_worker_node_command(
-            task_instance_id=None,
-            array_id=task_instance_batch.array_id,
-            batch_number=task_instance_batch.batch_number,
-        )
         distributor_commands: List[DistributorCommand] = []
 
         try:
-            # submit array to batch distributor
-            logger.debug(
-                "Submitting batch to cluster",
+            # Prepare + build + submit share one failure policy: on any
+            # uncaught exception, mark the batch's TIs as W
+            # (NO_DISTRIBUTOR_ID) so the task FSM retries via
+            # REGISTERING. Previously only submission failures were
+            # covered, which let prep-time errors (e.g. a malformed
+            # /task_resources response that made ``response`` a string
+            # instead of a dict) strand the batch's TIs in INSTANTIATED
+            # forever while the distributor looped every 30s on
+            # "Batch already removed from tracking".
+            task_instance_batch.prepare_task_instance_batch_for_launch()
+
+            # build worker node command
+            command = self.cluster_interface.build_worker_node_command(
+                task_instance_id=None,
                 array_id=task_instance_batch.array_id,
-                array_batch_num=task_instance_batch.batch_number,
-                batch_size=batch_size,
-                submission_name=task_instance_batch.submission_name,
-            )
-            distributor_id_map = (
-                self.cluster_interface.submit_array_to_batch_distributor(
-                    command=command,
-                    name=task_instance_batch.submission_name,
-                    requested_resources=task_instance_batch.requested_resources,
-                    array_length=batch_size,
-                )
-            )
-            task_instance_batch.set_distributor_ids(distributor_id_map)
-            logger.info(
-                "Batch submitted to cluster successfully",
-                array_id=task_instance_batch.array_id,
-                array_batch_num=task_instance_batch.batch_number,
-                batch_size=batch_size,
+                batch_number=task_instance_batch.batch_number,
             )
 
-        except NotImplementedError:
-            # create DistributorCommands to submit the launch if array isn't implemented
-            logger.debug(
-                "Array submission not supported, launching individually",
-                batch_size=batch_size,
-            )
-            for task_instance in task_instance_batch.task_instances:
-                distributor_command = DistributorCommand(
-                    self.launch_task_instance,
-                    task_instance,
+            try:
+                # submit array to batch distributor
+                logger.debug(
+                    "Submitting batch to cluster",
+                    array_id=task_instance_batch.array_id,
+                    array_batch_num=task_instance_batch.batch_number,
+                    batch_size=batch_size,
+                    submission_name=task_instance_batch.submission_name,
                 )
-                distributor_commands.append(distributor_command)
+                distributor_id_map = (
+                    self.cluster_interface.submit_array_to_batch_distributor(
+                        command=command,
+                        name=task_instance_batch.submission_name,
+                        requested_resources=task_instance_batch.requested_resources,
+                        array_length=batch_size,
+                    )
+                )
+                task_instance_batch.set_distributor_ids(distributor_id_map)
+
+            except NotImplementedError:
+                # Cluster plugin doesn't support array submission; fall
+                # back to launching each TI individually.
+                logger.debug(
+                    "Array submission not supported, launching individually",
+                    batch_size=batch_size,
+                )
+                for task_instance in task_instance_batch.task_instances:
+                    distributor_commands.append(
+                        DistributorCommand(
+                            self.launch_task_instance,
+                            task_instance,
+                        )
+                    )
+
+            else:
+                # Successful array submission.
+                logger.info(
+                    "Batch submitted to cluster successfully",
+                    array_id=task_instance_batch.array_id,
+                    array_batch_num=task_instance_batch.batch_number,
+                    batch_size=batch_size,
+                )
+                distributor_commands.append(
+                    DistributorCommand(
+                        task_instance_batch.transition_to_launched,
+                        self._next_report_increment,
+                    )
+                )
+                distributor_commands.append(
+                    DistributorCommand(task_instance_batch.log_distributor_ids)
+                )
 
         except Exception as e:
-            # if other error, transition to No ID status
+            # Unrecoverable prep/build/submit failure → mark TIs as W
+            # (NO_DISTRIBUTOR_ID) so the task FSM retries via
+            # REGISTERING. Discard any partial commands queued in the
+            # inner block (none should be populated on this path, but
+            # be defensive in case a future refactor adds early
+            # appends).
             stack_trace = traceback.format_exc()
             logger.exception(
                 "Batch launch failed",
                 error=str(e),
                 batch_size=batch_size,
             )
-            for task_instance in task_instance_batch.task_instances:
-                distributor_command = DistributorCommand(
+            distributor_commands = [
+                DistributorCommand(
                     task_instance.transition_to_no_distributor_id,
                     no_id_err_msg=stack_trace,
                 )
-                distributor_commands.append(distributor_command)
-
-        else:
-            # if successful log a transition to launched
-            launch_command = DistributorCommand(
-                task_instance_batch.transition_to_launched, self._next_report_increment
-            )
-            # Log the distributor IDs
-            log_distributor_ids_command = DistributorCommand(
-                task_instance_batch.log_distributor_ids
-            )
-
-            distributor_commands.append(launch_command)
-            distributor_commands.append(log_distributor_ids_command)
+                for task_instance in task_instance_batch.task_instances
+            ]
 
         finally:
             self._distributor_commands = it.chain(

--- a/tests/integration/client/test_requester.py
+++ b/tests/integration/client/test_requester.py
@@ -313,10 +313,11 @@ async def test_async_get_content_json(client_env, mocker):
 
 @pytest.mark.asyncio
 async def test_async_get_content_malformed_json(client_env, mocker):
-    """Test async content parsing for malformed JSON responses."""
+    """Malformed application/json bodies raise InvalidResponse for retry."""
+    from jobmon.core.exceptions import InvalidResponse
+
     requester = Requester(client_env)
 
-    # Mock aiohttp response with malformed JSON
     mock_response = mocker.MagicMock()
     mock_response.status = 200
     mock_response.headers = {"Content-Type": "application/json"}
@@ -325,10 +326,8 @@ async def test_async_get_content_malformed_json(client_env, mocker):
     )
     mock_response.text = mocker.AsyncMock(return_value="malformed json")
 
-    status, content = await requester._get_content_async(mock_response)
-
-    assert status == 200
-    assert content == "malformed json"
+    with pytest.raises(InvalidResponse, match="Malformed application/json body"):
+        await requester._get_content_async(mock_response)
     mock_response.text.assert_called_once()
 
 

--- a/tests/integration/distributor/test_instantiate.py
+++ b/tests/integration/distributor/test_instantiate.py
@@ -386,7 +386,9 @@ def test_array_submit_error_no_stuck_batch(db_engine, tool):
     )
 
 
-def test_prepare_batch_raises_transitions_to_no_distributor_id(db_engine, tool):
+def test_prepare_batch_raises_transitions_to_no_distributor_id(
+    db_engine, tool, monkeypatch
+):
     """Regression test: if ``prepare_task_instance_batch_for_launch`` raises
     (e.g. ``load_requested_resources`` gets a malformed server response and
     hits ``TypeError: string indices must be integers``), the batch's TIs
@@ -404,12 +406,8 @@ def test_prepare_batch_raises_transitions_to_no_distributor_id(db_engine, tool):
     from jobmon.distributor.task_instance_batch import TaskInstanceBatch
     from jobmon.server.web.models.task_instance import TaskInstance
 
-    original_prepare = TaskInstanceBatch.prepare_task_instance_batch_for_launch
-
     def boom_prepare(self) -> None:
-        # Invoke the real code up to the point that normally raises, then
-        # substitute a realistic TypeError. Using ``TypeError`` directly
-        # matches the prod signature (malformed /task_resources response
+        # Matches the prod signature (malformed /task_resources response
         # where ``response`` became ``response.text`` — a str — so
         # ``response["requested_resources"]`` raised
         # "string indices must be integers").
@@ -443,11 +441,11 @@ def test_prepare_batch_raises_transitions_to_no_distributor_id(db_engine, tool):
     distributor_service.process_status(TaskInstanceStatus.QUEUED)
     distributor_service.refresh_status_from_db(TaskInstanceStatus.INSTANTIATED)
 
-    TaskInstanceBatch.prepare_task_instance_batch_for_launch = boom_prepare
-    try:
-        distributor_service.process_status(TaskInstanceStatus.INSTANTIATED)
-    finally:
-        TaskInstanceBatch.prepare_task_instance_batch_for_launch = original_prepare
+    monkeypatch.setattr(
+        TaskInstanceBatch, "prepare_task_instance_batch_for_launch", boom_prepare
+    )
+    distributor_service.process_status(TaskInstanceStatus.INSTANTIATED)
+    monkeypatch.undo()
 
     with Session(bind=db_engine) as session:
         select_stmt = (

--- a/tests/integration/distributor/test_instantiate.py
+++ b/tests/integration/distributor/test_instantiate.py
@@ -386,6 +386,160 @@ def test_array_submit_error_no_stuck_batch(db_engine, tool):
     )
 
 
+def test_prepare_batch_raises_transitions_to_no_distributor_id(db_engine, tool):
+    """Regression test: if ``prepare_task_instance_batch_for_launch`` raises
+    (e.g. ``load_requested_resources`` gets a malformed server response and
+    hits ``TypeError: string indices must be integers``), the batch's TIs
+    must transition to ``W`` (NO_DISTRIBUTOR_ID) so the task FSM can retry
+    via REGISTERING.
+
+    Before this fix, the prepare call ran *outside* ``launch_task_instance_batch``'s
+    try/except. Any exception escaped to ``DistributorCommand.__call__`` which
+    swallowed it after the batch had already been popped from
+    ``_task_instance_batches``. Subsequent distributor cycles saw the TIs
+    still in INSTANTIATED, re-enqueued launch commands, and looped forever
+    on "Batch already removed from tracking, skipping launch" — 5000+
+    warnings per stranded batch observed in prod.
+    """
+    from jobmon.distributor.task_instance_batch import TaskInstanceBatch
+    from jobmon.server.web.models.task_instance import TaskInstance
+
+    original_prepare = TaskInstanceBatch.prepare_task_instance_batch_for_launch
+
+    def boom_prepare(self) -> None:
+        # Invoke the real code up to the point that normally raises, then
+        # substitute a realistic TypeError. Using ``TypeError`` directly
+        # matches the prod signature (malformed /task_resources response
+        # where ``response`` became ``response.text`` — a str — so
+        # ``response["requested_resources"]`` raised
+        # "string indices must be integers").
+        raise TypeError("string indices must be integers")
+
+    tool.set_default_compute_resources_from_dict(
+        cluster_name="multiprocess", compute_resources={"queue": "null.q"}
+    )
+    t1 = tool.active_task_templates["simple_template"].create_task(arg="echo 1")
+    t2 = tool.active_task_templates["simple_template"].create_task(arg="echo 2")
+    workflow = tool.create_workflow(
+        name="test_prepare_batch_raises_transitions_to_no_distributor_id"
+    )
+    workflow.add_tasks([t1, t2])
+    workflow.bind()
+    workflow._bind_tasks()
+    factory = WorkflowRunFactory(workflow.workflow_id)
+    wfr = factory.create_workflow_run()
+
+    state, gateway, orchestrator = create_test_context(
+        workflow, wfr.workflow_run_id, workflow.requester
+    )
+    prepare_and_queue_tasks(state, gateway, orchestrator)
+
+    distributor_service = DistributorService(
+        MultiprocessDistributor("sequential"),
+        requester=workflow.requester,
+    )
+    distributor_service.set_workflow_run(wfr.workflow_run_id)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.QUEUED)
+    distributor_service.process_status(TaskInstanceStatus.QUEUED)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.INSTANTIATED)
+
+    TaskInstanceBatch.prepare_task_instance_batch_for_launch = boom_prepare
+    try:
+        distributor_service.process_status(TaskInstanceStatus.INSTANTIATED)
+    finally:
+        TaskInstanceBatch.prepare_task_instance_batch_for_launch = original_prepare
+
+    with Session(bind=db_engine) as session:
+        select_stmt = (
+            select(TaskInstance)
+            .where(TaskInstance.task_id.in_([t1.task_id, t2.task_id]))
+            .order_by(TaskInstance.id)
+        )
+        task_instances = session.execute(select_stmt).scalars().all()
+        session.commit()
+        for ti in task_instances:
+            assert ti.status == "W", (
+                f"Expected TI {ti.id} to transition to W after prepare failure, "
+                f"got {ti.status}. A non-W status means the TI is stranded in "
+                f"INSTANTIATED and will trigger the 'Batch already removed from "
+                f"tracking' infinite loop."
+            )
+
+    # Second cycle must see zero TIs still in INSTANTIATED (i.e. no
+    # recurrence of the stuck-batch loop).
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.INSTANTIATED)
+    distributor_service.process_status(TaskInstanceStatus.INSTANTIATED)
+    assert (
+        len(
+            distributor_service._task_instance_status_map[
+                TaskInstanceStatus.INSTANTIATED
+            ]
+        )
+        == 0
+    )
+
+
+def test_build_worker_node_command_raises_transitions_to_no_distributor_id(
+    db_engine, tool
+):
+    """Regression test: if ``cluster_interface.build_worker_node_command`` raises
+    during launch, the batch's TIs must transition to ``W`` instead of being
+    stranded in INSTANTIATED. Covers the same widened try/except as the prepare
+    case — any unrecoverable error in the prep + build + submit path must
+    funnel through the NO_DISTRIBUTOR_ID path.
+    """
+    from jobmon.server.web.models.task_instance import TaskInstance
+
+    class BadCommandDistributor(MultiprocessDistributor):
+        def build_worker_node_command(
+            self,
+            task_instance_id=None,
+            array_id=None,
+            batch_number=None,
+        ) -> str:
+            raise RuntimeError("build_worker_node_command failed")
+
+    tool.set_default_compute_resources_from_dict(
+        cluster_name="multiprocess", compute_resources={"queue": "null.q"}
+    )
+    t1 = tool.active_task_templates["simple_template"].create_task(arg="echo 1")
+    t2 = tool.active_task_templates["simple_template"].create_task(arg="echo 2")
+    workflow = tool.create_workflow(
+        name="test_build_worker_node_command_raises_transitions_to_no_distributor_id"
+    )
+    workflow.add_tasks([t1, t2])
+    workflow.bind()
+    workflow._bind_tasks()
+    factory = WorkflowRunFactory(workflow.workflow_id)
+    wfr = factory.create_workflow_run()
+
+    state, gateway, orchestrator = create_test_context(
+        workflow, wfr.workflow_run_id, workflow.requester
+    )
+    prepare_and_queue_tasks(state, gateway, orchestrator)
+
+    distributor_service = DistributorService(
+        BadCommandDistributor("sequential"),
+        requester=workflow.requester,
+    )
+    distributor_service.set_workflow_run(wfr.workflow_run_id)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.QUEUED)
+    distributor_service.process_status(TaskInstanceStatus.QUEUED)
+    distributor_service.refresh_status_from_db(TaskInstanceStatus.INSTANTIATED)
+    distributor_service.process_status(TaskInstanceStatus.INSTANTIATED)
+
+    with Session(bind=db_engine) as session:
+        select_stmt = (
+            select(TaskInstance)
+            .where(TaskInstance.task_id.in_([t1.task_id, t2.task_id]))
+            .order_by(TaskInstance.id)
+        )
+        task_instances = session.execute(select_stmt).scalars().all()
+        session.commit()
+        for ti in task_instances:
+            assert ti.status == "W"
+
+
 def test_workflow_concurrency_limiting(tool, task_template):
     """tests that we only return a subset of queued jobs based on the n_queued
     parameter"""

--- a/tests/unit/logging/conftest.py
+++ b/tests/unit/logging/conftest.py
@@ -10,6 +10,47 @@ from typing import Any, Callable, Optional
 from unittest.mock import MagicMock
 
 import pytest
+import structlog
+
+
+@pytest.fixture(autouse=True)
+def _reset_structlog_state_between_logging_tests():
+    """Restore structlog global state after every test in tests/unit/logging.
+
+    Many tests in this directory call ``structlog.configure(...)`` with
+    ``structlog.stdlib.LoggerFactory`` or custom factories to exercise
+    jobmon's reconfigure hook. Without a teardown, the final test to run on
+    an xdist worker leaves that factory installed, and any non-logging
+    test subsequently scheduled on the same worker process (e.g.
+    ``tests/unit/swarm/test_builder.py``) fails with
+    ``TypeError: Logger.debug() missing 1 required positional argument:
+    'msg'`` because structlog is now producing stdlib Loggers that reject
+    structlog's kwargs-only call convention.
+
+    Cross-module leakage is invisible in serial runs and only surfaces
+    under ``pytest -n>1`` where xdist packs multiple test modules into
+    one worker.
+    """
+    yield
+    structlog.reset_defaults()
+    structlog.contextvars.clear_contextvars()
+    # Reset jobmon's own "already configured" flags so the next test gets
+    # a clean reconfigure path.
+    try:
+        from jobmon.client import logging as jobmon_client_logging
+
+        jobmon_client_logging._structlog_configured_by_jobmon = False
+    except (ImportError, AttributeError):
+        pass
+    try:
+        from jobmon.core.config import structlog_config as core_structlog_config
+
+        if hasattr(core_structlog_config, "_structlog_configured"):
+            core_structlog_config._structlog_configured = False
+        if hasattr(core_structlog_config, "_reset_structlog_reconfigure_hook"):
+            core_structlog_config._reset_structlog_reconfigure_hook()
+    except (ImportError, AttributeError):
+        pass
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Two related fixes for the "stuck in INSTANTIATED with no distributor_id" failure mode that has been leaking tasks in prod:

- **Transition batch TIs to NO_DISTRIBUTOR_ID on any prep/build/submit error** (`96f21c2f`). `launch_task_instance_batch` previously ran `prepare_task_instance_batch_for_launch()` and `cluster_interface.build_worker_node_command()` *outside* the try/except. Any exception there (including the `TypeError: string indices must be integers` seen in prod) escaped to `DistributorCommand.__call__`, which swallowed it after the batch had already been popped from `_task_instance_batches` — stranding the batch's TIs in INSTANTIATED forever while the distributor logged "Batch already removed from tracking, skipping launch" every ~30s indefinitely. Observed 2026-04-10 → 2026-04-14 across dismod_at_gbd and fhs_pipeline_fertility (e.g. wfr 383859, 935 warnings over 8h). Widen the try/except so any uncaught exception in prepare + build + submit routes TIs to `NO_DISTRIBUTOR_ID` (status "W"), which the FSM treats as retryable.

- **Retry malformed application/json responses instead of silently returning text** (`c5a90fc8`). The `TypeError` that triggered the prep-path failure comes from `get_content` / `_get_content_async` silently falling back to `response.text` when `application/json` Content-Type is set but the body doesn't parse. Callers then index the "content dict" and blow up. Root cause for the recent occurrences is not server-side: server-side `ast.literal_eval` errors are zero since `4c62ad2f` landed in `server-3.7.13`, APM traces for the failing calls show HTTP 200, in-cluster hammering of the offending endpoint returned 500/500 identical responses. That leaves transient truncation / empty body on the client side (stale keep-alive, LB hiccup, aiohttp session reuse). Raise `InvalidResponse` from the fallback branch — it is already in the Requester retry allowlist, so transient cases recover silently and persistent ones surface with real diagnostic context (status, body length, first 200 chars, parse error).

- **Use pytest monkeypatch for prepare-raises test** (`98c0d5e8`). Test-only cleanup.

## Test plan

- [x] `uv run nox -s lint` — clean
- [x] `uv run pytest tests/integration/client/test_requester.py` — 18/18 pass
- [x] `uv run pytest tests/integration/distributor/test_instantiate.py` — W-state transition tests added in 96f21c2f
- [ ] Deploy to prod and confirm (a) no new stuck-I TIs with the grouping_key `c18463843a0c6d35` signature, and (b) if the JSON fallback fires, it shows up as an `InvalidResponse` retry in logs with body details rather than a `TypeError` downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling and retry behavior in the HTTP requester and distributor launch path; mistakes could alter when tasks are retried vs. failed and impact batch state transitions in production.
> 
> **Overview**
> Prevents task-instance batches from being stranded in `INSTANTIATED` by expanding `DistributorService.launch_task_instance_batch` error handling to cover *prepare*, *command build*, and *submission* failures, transitioning affected task instances to `NO_DISTRIBUTOR_ID` (`W`) so the FSM can retry.
> 
> Changes `Requester` content parsing (`get_content` and `_get_content_async`) to **raise `InvalidResponse`** when an `application/json` response has an unparseable/empty body (including diagnostic body head/length), enabling the existing retry layer instead of silently returning text that breaks downstream callers.
> 
> Adds/updates integration regression tests for malformed JSON retry behavior and for batch launch failures during prepare/command-build, plus a unit-test fixture to reset global `structlog` state between logging tests to avoid xdist cross-test contamination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cd2b4cebcd07be53c7c9d449e3169412ab2a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->