### PR TITLE
Include server-returned status in orchestrator TransitionError

### DIFF
--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -676,8 +676,9 @@ class WorkflowRunOrchestrator:
 
         if new_status != status:
             raise TransitionError(
-                f"Cannot transition WFR {self._state.workflow_run_id} from current status "
-                f"{self._state.status} to {status}."
+                f"Cannot transition WFR {self._state.workflow_run_id}: "
+                f"requested={status}, local_cached={self._state.status}, "
+                f"server_returned={new_status}."
             )
 
         self._state.status = new_status


### PR DESCRIPTION
## Summary

When the orchestrator's `update_status` response comes back with a status that doesn't match what was requested, the raised `TransitionError` only named the local cache and the requested value — the server's view of the world (the authoritative one) was invisible.

This turned a routine diagnosis ("why did the orchestrator refuse to transition to R?") into an APM-trace archaeology exercise just to learn what state the server was actually in when it rejected the transition.

Include all three values — `requested`, `local_cached`, `server_returned` — in the error message so future instances of this class of failure are diagnosable from the message alone.

## Motivating example

Investigation of WFR 383865 (workflow 565548) spent significant time chasing a \`\`\`Cannot transition WFR 383865 from current status B to R\`\`\` message. The \`B\` in that message is the orchestrator's *stale local cache* from 7 seconds earlier — not what the server reported. Pulling the APM trace eventually revealed the server had returned a different status, but the client-side error gave no hint of that.

With this change, the same failure would read:

\`\`\`
Cannot transition WFR 383865: requested=R, local_cached=B, server_returned=I.
\`\`\`

— which names the actual cause (server-side state machine saw I, not O) in the message itself.

## Test plan

- [ ] Format / lint / typecheck pass (pre-commit)
- [ ] No existing tests assert the exact string format of this error
- [ ] Message change is purely additive / informational; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `TransitionError` message formatting during status-transition mismatches, with no change to control flow or data handling.
> 
> **Overview**
> Improves diagnostics when `_update_status` detects a server/client status mismatch by expanding the raised `TransitionError` message to include **all three** values: the requested status, the orchestrator’s locally cached status, and the server-returned status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56cf45e3f8aeda5673709811660812af76672eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->