### PR TITLE
Allow WFR B->R and I->R to unblock orchestrator startup race

### DIFF
--- a/jobmon_server/src/jobmon/server/web/models/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/models/workflow.py
@@ -76,6 +76,12 @@ class Workflow(Base):
         (WorkflowStatus.LAUNCHED, WorkflowStatus.FAILED),
         # workflow runs. normal happy path
         (WorkflowStatus.LAUNCHED, WorkflowStatus.RUNNING),
+        # Mirror of the WorkflowRun B->R and I->R shortcuts: when the
+        # orchestrator transitions a WFR directly from BOUND or INSTANTIATED
+        # to RUNNING, the cascading Workflow.transition(RUNNING) must also
+        # succeed from its current Q or I state.
+        (WorkflowStatus.QUEUED, WorkflowStatus.RUNNING),
+        (WorkflowStatus.INSTANTIATING, WorkflowStatus.RUNNING),
         # workflow run was running and then got moved to a resume state
         (WorkflowStatus.RUNNING, WorkflowStatus.HALTED),
         # workflow run was bound, and then got moved to a resume state

--- a/jobmon_server/src/jobmon/server/web/models/workflow_run.py
+++ b/jobmon_server/src/jobmon/server/web/models/workflow_run.py
@@ -68,6 +68,16 @@ class WorkflowRun(Base):
         (WorkflowRunStatus.INSTANTIATED, WorkflowRunStatus.LAUNCHED),
         # a workflow run moves from launched to running
         (WorkflowRunStatus.LAUNCHED, WorkflowRunStatus.RUNNING),
+        # The orchestrator may request RUNNING from any pre-R non-terminal
+        # state. The distributor's B->I->O chain is driven by a sibling
+        # subprocess; the orchestrator only knows its own stale snapshot
+        # (BOUND) from before the distributor was spawned. Allowing B->R
+        # and I->R directly lets the orchestrator succeed regardless of
+        # where the distributor's chain currently is, eliminating a
+        # startup race where a slow I->O commit caused the orchestrator's
+        # update_status(R) to fail with InvalidStateTransition.
+        (WorkflowRunStatus.BOUND, WorkflowRunStatus.RUNNING),
+        (WorkflowRunStatus.INSTANTIATED, WorkflowRunStatus.RUNNING),
         # a workflow run can't be launched for some reason. TODO: implement triaging
         (WorkflowRunStatus.INSTANTIATED, WorkflowRunStatus.ERROR),
         (WorkflowRunStatus.LAUNCHED, WorkflowRunStatus.ERROR),

--- a/tests/unit/server/test_workflow_run_fsm.py
+++ b/tests/unit/server/test_workflow_run_fsm.py
@@ -1,0 +1,62 @@
+"""Unit tests for WorkflowRun and Workflow valid_transitions.
+
+Covers the B->R and I->R shortcuts added to unblock the orchestrator
+startup race. See workflow_run.py valid_transitions comment for context.
+"""
+
+from jobmon.core.constants import WorkflowRunStatus, WorkflowStatus
+from jobmon.server.web.models.workflow import Workflow
+from jobmon.server.web.models.workflow_run import WorkflowRun
+
+
+class TestWorkflowRunTransitions:
+    """WorkflowRun state machine shortcuts for orchestrator startup."""
+
+    def test_bound_to_running_is_valid(self) -> None:
+        assert (
+            WorkflowRunStatus.BOUND,
+            WorkflowRunStatus.RUNNING,
+        ) in WorkflowRun.valid_transitions
+
+    def test_instantiated_to_running_is_valid(self) -> None:
+        assert (
+            WorkflowRunStatus.INSTANTIATED,
+            WorkflowRunStatus.RUNNING,
+        ) in WorkflowRun.valid_transitions
+
+    def test_launched_to_running_still_valid(self) -> None:
+        assert (
+            WorkflowRunStatus.LAUNCHED,
+            WorkflowRunStatus.RUNNING,
+        ) in WorkflowRun.valid_transitions
+
+    def test_legacy_chain_still_valid(self) -> None:
+        """The old B->I->O->R chain must remain valid for older distributors."""
+        for pair in [
+            (WorkflowRunStatus.BOUND, WorkflowRunStatus.INSTANTIATED),
+            (WorkflowRunStatus.INSTANTIATED, WorkflowRunStatus.LAUNCHED),
+            (WorkflowRunStatus.LAUNCHED, WorkflowRunStatus.RUNNING),
+        ]:
+            assert pair in WorkflowRun.valid_transitions
+
+
+class TestWorkflowTransitions:
+    """Workflow state machine shortcuts that mirror the WFR cascade."""
+
+    def test_queued_to_running_is_valid(self) -> None:
+        assert (
+            WorkflowStatus.QUEUED,
+            WorkflowStatus.RUNNING,
+        ) in Workflow.valid_transitions
+
+    def test_instantiating_to_running_is_valid(self) -> None:
+        assert (
+            WorkflowStatus.INSTANTIATING,
+            WorkflowStatus.RUNNING,
+        ) in Workflow.valid_transitions
+
+    def test_launched_to_running_still_valid(self) -> None:
+        assert (
+            WorkflowStatus.LAUNCHED,
+            WorkflowStatus.RUNNING,
+        ) in Workflow.valid_transitions


### PR DESCRIPTION
## Summary

The orchestrator's first call is `update_status(RUNNING)`, using a stale local snapshot of the WFR status from before the distributor subprocess was spawned. The distributor drives `B→I→O` concurrently in a sibling process. If the orchestrator's request lands on a server pod before the distributor's `I→O` commit is visible there, the transition is rejected as invalid and **silently** swallowed by the `update_status` handler (which returns 200 with the stale status). The orchestrator then raises `TransitionError` and the run dies ~10 seconds after creation.

Observed in prod on WFR 383865 (workflow 565548, `fhs-pipeline-vaccine-ratio`). The APM trace for the failing server pod showed a single `SELECT` and no `UPDATE` — exactly the shape of `_validate_transition` rejecting the call. Server app logs for that request were dropped due to a 4-second OTLP stall on the pod, which is what made the failure hard to diagnose.

## Change

Additive. No existing transition is removed.

**`WorkflowRun.valid_transitions`** — add:
- `(BOUND, RUNNING)`
- `(INSTANTIATED, RUNNING)`

`(LAUNCHED, RUNNING)` was already present.

**`Workflow.valid_transitions`** — add the mirroring pairs for the cascade:
- `(QUEUED, RUNNING)`
- `(INSTANTIATING, RUNNING)`

Without these, the WFR transition would succeed but the cascading `workflow.transition(RUNNING)` call inside `WorkflowRun.transition()` would raise, and the raise is **not** wrapped by the route's `except InvalidStateTransition` — so we'd trade one silent failure for another.

## Why additive and not a removal

Cross-version compatibility:

- **New server + old client:** distributor still walks `B→I→O→R`; those transitions remain valid. No behavior change.
- **New server + new client:** orchestrator's `update_status(R)` now tolerates any of `B`, `I`, or `O` as the starting state. The race class disappears.

Removal of the intermediate states is deferred to a future major release once all deployed distributors are upgraded.

## Files

- `jobmon_server/src/jobmon/server/web/models/workflow_run.py` — 2 tuples added, with a comment explaining why.
- `jobmon_server/src/jobmon/server/web/models/workflow.py` — 2 cascade tuples added.
- `tests/unit/server/test_workflow_run_fsm.py` — new file, 7 tests covering both the new shortcuts and the legacy chain.

## Companion PR

[#392](https://github.com/ihmeuw-scicomp/jobmon/pull/392) improves the client-side `TransitionError` message to include the server's returned status. They're orthogonal and can merge in either order.

## Test plan

- [x] \`uv run pytest tests/unit/server/test_workflow_run_fsm.py\` — 7/7 pass
- [ ] Full suite: \`uv run pytest -n 10\`
- [ ] Six-job E2E via Docker: \`docker compose exec jobmon_client python /app/test_scripts/six_job_test.py sequential\`
- [ ] Manual: confirm new runs still progress through \`B→I→O→R\` on the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the workflow/workflow-run state machines to permit new shortcut transitions; while additive, it affects core lifecycle validation and could allow unexpected skips in state progression if misused.
> 
> **Overview**
> Unblocks an orchestrator startup race by allowing `WorkflowRun` to transition directly to `RUNNING` from `BOUND` or `INSTANTIATED`, in addition to the existing launched path.
> 
> Updates `Workflow.valid_transitions` to mirror these shortcuts (`QUEUED`/`INSTANTIATING` -> `RUNNING`) so the cascading workflow status update doesn’t fail when a workflow-run jumps straight to `RUNNING`.
> 
> Adds unit tests covering the new shortcuts and asserting the legacy `BOUND -> INSTANTIATED -> LAUNCHED -> RUNNING` chain remains valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c0dc588717634f7b274c8d67011e4fd54d3a47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->