### PR TITLE
Count ADJUSTING_RESOURCES as pending work to prevent premature orchestrator exit

### DIFF
--- a/jobmon_client/src/jobmon/client/swarm/state.py
+++ b/jobmon_client/src/jobmon/client/swarm/state.py
@@ -313,8 +313,16 @@ class SwarmState:
         return len(self.tasks) == self.get_done_count() + self.get_failed_count()
 
     def has_pending_work(self) -> bool:
-        """True if there's in-flight or ready-to-run work."""
-        return self.get_active_task_count() > 0 or len(self.ready_to_run) > 0
+        """True if there's in-flight or ready-to-run work.
+
+        Tasks in ADJUSTING_RESOURCES count as pending: they are transient and will be
+        re-queued on the next scheduling pass. Excluding them causes the orchestrator
+        main loop to exit prematurely when the only in-flight work is adjusting, even
+        though downstream REGISTERING tasks are still waiting on them.
+        """
+        if self.get_active_task_count() > 0 or len(self.ready_to_run) > 0:
+            return True
+        return len(self._task_status_map[TaskStatus.ADJUSTING_RESOURCES]) > 0
 
     def get_available_capacity(self) -> int:
         """How many more tasks can be queued at workflow level."""

--- a/tests/unit/swarm/test_orchestrator.py
+++ b/tests/unit/swarm/test_orchestrator.py
@@ -692,6 +692,40 @@ class TestShouldContinue:
 
         assert orchestrator._should_continue() is True
 
+    def test_should_continue_only_adjusting_resources(
+        self, mock_task, mock_array, mock_gateway, default_config
+    ):
+        """Regression: a DAG whose only in-flight work is ADJUSTING_RESOURCES must
+        keep the main loop running. Previously _should_continue() returned False
+        because ADJUSTING wasn't counted as active or ready_to_run, causing the
+        orchestrator to finalize as ERROR with downstream REGISTERING tasks still
+        waiting. See workflow 565558 (Apr 2026)."""
+        adjusting = mock_task(1, status=TaskStatus.ADJUSTING_RESOURCES)
+        waiting = mock_task(2, status=TaskStatus.REGISTERING, all_upstreams_done=False)
+        done = mock_task(3, status=TaskStatus.DONE)
+        array = mock_array(1)
+        array.tasks.update({adjusting, waiting, done})
+
+        state = create_state_with_tasks(
+            tasks={1: adjusting, 2: waiting, 3: done},
+            arrays={1: array},
+            task_status_map={
+                TaskStatus.REGISTERING: {waiting},
+                TaskStatus.QUEUED: set(),
+                TaskStatus.INSTANTIATING: set(),
+                TaskStatus.LAUNCHED: set(),
+                TaskStatus.RUNNING: set(),
+                TaskStatus.DONE: {done},
+                TaskStatus.ADJUSTING_RESOURCES: {adjusting},
+                TaskStatus.ERROR_FATAL: set(),
+            },
+            status=WorkflowRunStatus.RUNNING,
+            max_concurrently_running=100,
+        )
+        orchestrator = WorkflowRunOrchestrator(state, mock_gateway, default_config)
+
+        assert orchestrator._should_continue() is True
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Test Status Updates

--- a/tests/unit/swarm/test_state.py
+++ b/tests/unit/swarm/test_state.py
@@ -323,6 +323,30 @@ class TestSwarmStateQueries:
         state.ready_to_run.append(MockSwarmTask(2))  # type: ignore
         assert state.has_pending_work()
 
+    def test_has_pending_work_adjusting_resources(self) -> None:
+        """ADJUSTING_RESOURCES tasks must count as pending work.
+
+        Regression guard for orchestrator premature exit: when the only in-flight
+        work was in ADJUSTING_RESOURCES, has_pending_work() incorrectly returned
+        False, causing the main loop to finalize the run as ERROR with downstream
+        REGISTERING tasks still waiting. See workflow 565558 (Apr 2026).
+        """
+        state = SwarmState(workflow_id=1, workflow_run_id=1, dag_id=1)
+        # Mix: some DONE tasks, an upstream in ADJUSTING, downstream REGISTERING.
+        state.add_task(MockSwarmTask(1, status=TaskStatus.DONE))  # type: ignore
+        state.add_task(MockSwarmTask(2, status=TaskStatus.ADJUSTING_RESOURCES))  # type: ignore
+        state.add_task(MockSwarmTask(3, status=TaskStatus.REGISTERING))  # type: ignore
+
+        # No QUEUED/INSTANTIATING/LAUNCHED/RUNNING and ready_to_run is empty — but
+        # Adjusting is transient and will re-queue, so the run still has pending work.
+        assert state.get_active_task_count() == 0
+        assert len(state.ready_to_run) == 0
+        assert state.has_pending_work()
+
+        # Transition the Adjusting task to DONE; now truly nothing pending.
+        state.update_task_status(2, TaskStatus.DONE)
+        assert not state.has_pending_work()
+
     def test_get_available_capacity(self, state_with_tasks: SwarmState) -> None:
         """Test calculating available capacity."""
         # max=100, active=2


### PR DESCRIPTION
## Summary
- `has_pending_work()` now treats `ADJUSTING_RESOURCES` tasks as pending, so the orchestrator main loop does not exit while upstream tasks are transiently adjusting
- Added regression tests at both the `SwarmState` and `WorkflowRunOrchestrator._should_continue()` layers

## Background
Observed on workflow **565558** / WFR 383877 (`fhs-pipeline-dalys`, 2026-04-14):

```
Main loop exiting with non-final tasks — forcing full sync before exit.
{'status': 'R', 'total_tasks': 1071, 'done': 296, 'failed': 0, 'active': 0, 'ready_to_run': 0}
Workflow run finalizing as ERROR — main loop exited with incomplete tasks.
```

DB state at exit: 296 DONE, **8 ADJUSTING**, 767 REGISTERING. No reaper kill, no exception, distributor healthy (had just submitted a batch ~65s earlier). The orchestrator self-terminated because `has_pending_work()` only considers `ACTIVE_TASK_STATUSES` (Q/I/L/R) and `ready_to_run`, and `ADJUSTING_RESOURCES` is in neither.

## Why not add ADJUSTING to `ACTIVE_TASK_STATUSES`?
That constant also drives `get_available_capacity()` and array capacity. Adjusting tasks aren't consuming cluster slots, so counting them against concurrency would be semantically wrong. Fixing only the pending-work predicate keeps capacity math unchanged.

## Regression scope
Pre-async-scheduler code (`release/3.4`) had the same active-status exclusion but a defensive fallback in `_decide_run_loop_continue` that forced a full sync before exiting. The async refactor (`40ef11c1`, released in `3.5`) and the orchestrator refactor (`9dae208d`, in `3.6`) replaced it with a pure `has_pending_work()` check, making any DAG whose only in-flight work is Adjusting vulnerable to premature termination.

## Test plan
- [x] `uv run pytest tests/unit/swarm/test_state.py tests/unit/swarm/test_orchestrator.py` — 116 passed
- [x] `uv run nox -s lint` — clean
- [ ] Full `uv run pytest -n 10` in CI
- [ ] Re-run a workflow that hits ADJUSTING_RESOURCES and confirm it progresses past the adjust step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the orchestrator loop’s exit condition for runs with only `ADJUSTING_RESOURCES` tasks, which can affect when workflow runs finalize. Logic is small and covered by new regression tests, but it touches workflow-run lifecycle behavior.
> 
> **Overview**
> Prevents premature workflow-run finalization by updating `SwarmState.has_pending_work()` to treat `TaskStatus.ADJUSTING_RESOURCES` as pending work (without changing capacity calculations based on active statuses).
> 
> Adds regression tests in `test_state.py` and `test_orchestrator.py` to ensure `_should_continue()` remains true when the only in-flight work is resource-adjustment and downstream tasks are still waiting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca41647fda44a67d8d79114ebd85c09cc46de0b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->