### PR TITLE
Log stuck-task diagnostics at swarm premature exit

### DIFF
--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -416,8 +416,63 @@ class WorkflowRunOrchestrator:
                         active=self._state.get_active_task_count(),
                         ready_to_run=self._state.get_ready_to_run_count(),
                     )
+                    self._dump_stuck_registering_tasks()
                     await self._do_sync(full_sync=True)
                     time_since_last_full_sync = 0.0
+
+    def _dump_stuck_registering_tasks(self) -> None:
+        """Log per-task diagnostics for REGISTERING tasks at premature exit.
+
+        Three signatures we want to distinguish:
+          1. counter under-count (num_upstreams_done < num_upstreams but all
+             upstreams in DONE status in the swarm) — missed propagation
+          2. counter fine, status stuck (num_upstreams_done == num_upstreams
+             and all upstreams DONE, but task still REGISTERING) — enqueue
+             step dropped the task
+          3. num_upstreams inflated (num_upstreams != count of reverse edges
+             observed in the swarm graph) — build-time graph corruption
+
+        Only logs tasks matching one of the above signatures, so benign
+        cascade-blocked tasks do not flood the log.
+        """
+        # Build reverse-edge index once: task_id -> list of upstream SwarmTasks
+        reverse: dict[int, list] = {}
+        for t in self._state.tasks.values():
+            for d in t.downstream_swarm_tasks:
+                reverse.setdefault(d.task_id, []).append(t)
+
+        for t in self._state.get_tasks_by_status(TaskStatus.REGISTERING):
+            upstreams = reverse.get(t.task_id, [])
+            rev_count = len(upstreams)
+            done_upstreams = sum(1 for u in upstreams if u.status == TaskStatus.DONE)
+            # all_upstreams_done raises RuntimeError when overcounted
+            try:
+                all_done_prop: object = t.all_upstreams_done
+            except RuntimeError as e:
+                all_done_prop = f"RAISE: {e}"
+
+            all_up_done_in_swarm = rev_count > 0 and done_upstreams == rev_count
+            counter_mismatch = t.num_upstreams != rev_count
+
+            if all_up_done_in_swarm:
+                logger.warning(
+                    "Stuck task: all upstreams DONE in swarm but task still "
+                    "REGISTERING",
+                    task_id=t.task_id,
+                    num_upstreams=t.num_upstreams,
+                    num_upstreams_done=t.num_upstreams_done,
+                    reverse_edge_count=rev_count,
+                    all_upstreams_done_property=all_done_prop,
+                    sample_upstream_ids=[u.task_id for u in upstreams[:10]],
+                )
+            elif counter_mismatch:
+                logger.warning(
+                    "Stuck task: num_upstreams != reverse edge count",
+                    task_id=t.task_id,
+                    num_upstreams=t.num_upstreams,
+                    num_upstreams_done=t.num_upstreams_done,
+                    reverse_edge_count=rev_count,
+                )
 
     def _should_continue(self) -> bool:
         """Determine if the main loop should continue."""

--- a/jobmon_client/src/jobmon/client/swarm/orchestrator.py
+++ b/jobmon_client/src/jobmon/client/swarm/orchestrator.py
@@ -451,7 +451,11 @@ class WorkflowRunOrchestrator:
             except RuntimeError as e:
                 all_done_prop = f"RAISE: {e}"
 
-            all_up_done_in_swarm = rev_count > 0 and done_upstreams == rev_count
+            # ``done_upstreams == rev_count`` is vacuously true for root
+            # tasks (both sides zero). That's the correct signal — a
+            # root task stuck in REGISTERING is signature #2 (nothing
+            # blocking it, but never enqueued), so we want to log it.
+            all_up_done_in_swarm = done_upstreams == rev_count
             counter_mismatch = t.num_upstreams != rev_count
 
             if all_up_done_in_swarm:


### PR DESCRIPTION
## Summary

When the swarm's main loop exits with non-final tasks still in the graph, dump one WARNING per stuck task so the next occurrence can be diagnosed from logs alone — no Elasticsearch-side correlation or post-hoc attach required.

Logs tasks matching one of three stuck signatures:

1. **Counter under-count** — `num_upstreams_done < num_upstreams` but every upstream is already `DONE` in the in-memory swarm graph. Indicates missed propagation.
2. **Counter fine, status stuck** — `num_upstreams_done == num_upstreams` and upstreams are `DONE`, but the task is still `REGISTERING`. Indicates the enqueue step dropped the task.
3. **Graph corruption** — `num_upstreams` doesn't match the reverse-edge count observed in the swarm graph. Indicates a build-time defect.

Cascade-blocked tasks with genuinely non-`DONE` upstreams are suppressed, so large workflows don't flood the log.

The implementation builds a reverse-edge index once per exit event from `SwarmTask.downstream_swarm_tasks`, so cost is O(edges) and only paid at the one premature-exit site.

## Why

Recent prod incidents left the swarm exiting early with `REGISTERING` tasks still in the graph, and diagnosis required pulling heap dumps or instrumenting live runs. This keeps the next recurrence self-contained in the workflow log.

## Test plan

- [x] `uv run nox -s lint`
- [x] `uv run nox -s typecheck` (219 files)
- [x] `uv run pytest -n 10 tests/unit/` — 581 passed (3 xdist-isolation flakes in `test_output_capture.py` unrelated to this branch; pass in serial)
- [ ] Observed post-deploy: next premature-exit incident emits the WARNING lines with actionable payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds warning-only diagnostics during a rare premature-exit path, without changing scheduling or state transitions. Minor risk of extra log volume/iteration cost when this exit condition occurs.
> 
> **Overview**
> When the orchestrator main loop is about to exit while tasks are still non-final, it now emits per-task WARNING diagnostics for tasks stuck in `REGISTERING` before forcing a final full sync.
> 
> The new `_dump_stuck_registering_tasks()` builds a reverse-edge index from `downstream_swarm_tasks` and logs only tasks matching specific “stuck” signatures (upstreams DONE but still registering, upstream counter mismatches, or `all_upstreams_done` raising due to overcounts) to avoid flooding logs with legitimately blocked tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e414b8385a4dc13eb9bf27df8304e0f88e0c8d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->