### PR TITLE
Add server-side aggregates endpoint for task-template KPIs

### DIFF
--- a/jobmon_gui/src/configs/ApiUrls.ts
+++ b/jobmon_gui/src/configs/ApiUrls.ts
@@ -8,6 +8,8 @@ export const userInfoURL = oidcBaseUrl + '/userinfo';
 export const task_table_url = api_base_url + '/task_table_viz/';
 
 export const usage_url = api_base_url + '/task_template_resource_usage';
+export const usage_aggregates_url =
+    api_base_url + '/task_template_resource_aggregates';
 
 export const workflow_details_url = api_base_url + '/workflow_details_viz/';
 export const workflow_tt_status_url = api_base_url + '/workflow_tt_status_viz/';

--- a/jobmon_gui/src/hooks/useUsageFilters.ts
+++ b/jobmon_gui/src/hooks/useUsageFilters.ts
@@ -11,6 +11,10 @@ type TaskResourceVizItem = components['schemas']['TaskResourceVizItem'];
 
 interface UseUsageFiltersProps {
     rawTaskNodesFromApi: TaskResourceVizItem[];
+    // Server-computed cluster list from the aggregates endpoint. When
+    // present, takes precedence over deriving from streaming scatter rows
+    // so the filter UI is complete on first paint.
+    serverResourceClusters?: ResourceCluster[];
 }
 
 interface UseUsageFiltersReturn {
@@ -22,14 +26,18 @@ interface UseUsageFiltersReturn {
 
 export const useUsageFilters = ({
     rawTaskNodesFromApi,
+    serverResourceClusters,
 }: UseUsageFiltersProps): UseUsageFiltersReturn => {
     const [selectedResourceClusters, setSelectedResourceClusters] = useState<
         Set<string>
     >(new Set());
 
     const availableResourceClusters = useMemo(() => {
+        if (serverResourceClusters && serverResourceClusters.length > 0) {
+            return serverResourceClusters;
+        }
         return extractResourceClusters(rawTaskNodesFromApi);
-    }, [rawTaskNodesFromApi]);
+    }, [serverResourceClusters, rawTaskNodesFromApi]);
 
     // Initialize filters when data changes
     useEffect(() => {

--- a/jobmon_gui/src/queries/GetTaskTemplateAggregates.ts
+++ b/jobmon_gui/src/queries/GetTaskTemplateAggregates.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { QueryFunctionContext } from '@tanstack/react-query';
+
+import { usage_aggregates_url } from '@jobmon_gui/configs/ApiUrls.ts';
+import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
+import { components } from '@jobmon_gui/types/apiSchema';
+
+type TaskTemplateResourceAggregatesResponse =
+    components['schemas']['TaskTemplateResourceAggregatesResponse'];
+
+export type TaskTemplateAggregatesQueryKey = readonly [
+    string,
+    string,
+    string | number | undefined,
+    string | number | undefined,
+    boolean,
+];
+
+export const getTaskTemplateAggregatesQueryFn = async (
+    context: QueryFunctionContext<TaskTemplateAggregatesQueryKey>
+): Promise<TaskTemplateResourceAggregatesResponse | undefined> => {
+    const { queryKey } = context;
+    if (
+        !queryKey ||
+        queryKey.length !== 5 ||
+        queryKey[2] === undefined ||
+        queryKey[3] === undefined
+    ) {
+        return undefined;
+    }
+    const taskTemplateVersionId = queryKey[2];
+    const workflowId = queryKey[3];
+    const latestOnly = queryKey[4];
+
+    const response = await axios.post<TaskTemplateResourceAggregatesResponse>(
+        usage_aggregates_url,
+        {
+            task_template_version_id: taskTemplateVersionId,
+            workflows: [workflowId],
+            latest_only: latestOnly,
+        },
+        jobmonAxiosConfig
+    );
+    return response.data;
+};

--- a/jobmon_gui/src/queries/GetWorkflowUsage.ts
+++ b/jobmon_gui/src/queries/GetWorkflowUsage.ts
@@ -48,32 +48,3 @@ export const getWorkflowUsageQueryFn = async (
     );
     return response.data; // This should now be TaskTemplateResourceUsageResponse
 };
-
-export const getWorkflowUsagePageQueryFn = async (
-    context: QueryFunctionContext<WorkflowUsageQueryKey, number>
-): Promise<TaskTemplateResourceUsageResponse | undefined> => {
-    const { queryKey, pageParam = 0 } = context;
-    if (
-        !queryKey ||
-        queryKey.length !== 4 ||
-        queryKey[2] === undefined ||
-        queryKey[3] === undefined
-    ) {
-        return undefined;
-    }
-    const taskTemplateVersionId = queryKey[2];
-    const workflowId = queryKey[3];
-
-    const response = await axios.post<TaskTemplateResourceUsageResponse>(
-        usage_url,
-        {
-            task_template_version_id: taskTemplateVersionId,
-            workflows: [workflowId],
-            viz: true,
-            page: pageParam,
-            page_size: USAGE_PAGE_SIZE,
-        },
-        jobmonAxiosConfig
-    );
-    return response.data;
-};

--- a/jobmon_gui/src/queries/GetWorkflowUsage.ts
+++ b/jobmon_gui/src/queries/GetWorkflowUsage.ts
@@ -16,6 +16,8 @@ export type WorkflowUsageQueryKey = readonly [
     string | number | undefined,
 ];
 
+export const USAGE_PAGE_SIZE = 2000;
+
 export const getWorkflowUsageQueryFn = async (
     context: QueryFunctionContext<WorkflowUsageQueryKey>
 ): Promise<TaskTemplateResourceUsageResponse | undefined> => {
@@ -45,4 +47,33 @@ export const getWorkflowUsageQueryFn = async (
         jobmonAxiosConfig
     );
     return response.data; // This should now be TaskTemplateResourceUsageResponse
+};
+
+export const getWorkflowUsagePageQueryFn = async (
+    context: QueryFunctionContext<WorkflowUsageQueryKey, number>
+): Promise<TaskTemplateResourceUsageResponse | undefined> => {
+    const { queryKey, pageParam = 0 } = context;
+    if (
+        !queryKey ||
+        queryKey.length !== 4 ||
+        queryKey[2] === undefined ||
+        queryKey[3] === undefined
+    ) {
+        return undefined;
+    }
+    const taskTemplateVersionId = queryKey[2];
+    const workflowId = queryKey[3];
+
+    const response = await axios.post<TaskTemplateResourceUsageResponse>(
+        usage_url,
+        {
+            task_template_version_id: taskTemplateVersionId,
+            workflows: [workflowId],
+            viz: true,
+            page: pageParam,
+            page_size: USAGE_PAGE_SIZE,
+        },
+        jobmonAxiosConfig
+    );
+    return response.data;
 };

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -1,7 +1,9 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import axios from 'axios';
 import {
     InfiniteData,
+    QueryFunctionContext,
     useInfiniteQuery,
     useQuery,
     useQueryClient,
@@ -29,10 +31,9 @@ import ErrorClustersCard from '@jobmon_gui/components/task_template_details/usag
 import { useTaskTemplateDetails } from '@jobmon_gui/queries/GetTaskTemplateDetails.ts';
 import { getWorkflowDetailsQueryFn } from '@jobmon_gui/queries/GetWorkflowDetails.ts';
 import { getWorkflowTTStatusQueryFn } from '@jobmon_gui/queries/GetWorkflowTTStatus.ts';
-import {
-    getWorkflowUsagePageQueryFn,
-    WorkflowUsageQueryKey,
-} from '@jobmon_gui/queries/GetWorkflowUsage.ts';
+import { USAGE_PAGE_SIZE } from '@jobmon_gui/queries/GetWorkflowUsage.ts';
+import { usage_url } from '@jobmon_gui/configs/ApiUrls.ts';
+import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
 import {
     getTaskTemplateAggregatesQueryFn,
     TaskTemplateAggregatesQueryKey,
@@ -72,6 +73,7 @@ dayjs.extend(utc);
 
 type TaskTemplateResourceUsageResponse =
     components['schemas']['TaskTemplateResourceUsageResponse'];
+type TaskResourceVizItem = components['schemas']['TaskResourceVizItem'];
 type TaskTemplateResourceAggregatesResponse =
     components['schemas']['TaskTemplateResourceAggregatesResponse'];
 
@@ -97,31 +99,63 @@ export default function TaskTemplateDetails() {
         TaskTemplateDetailsData.data?.task_template_version_id;
     const taskTemplateName = TaskTemplateDetailsData.data?.task_template_name;
 
-    const queryKeyForWorkflowUsage: WorkflowUsageQueryKey = [
-        'workflow_details',
-        'usage_paged',
-        taskTemplateVersionId,
-        workflowId,
+    // Page-drain concurrency. Three parallel useInfiniteQuery "streams"
+    // each drain a strided subset of pages (stream 0: 0, 3, 6, 9...;
+    // stream 1: 1, 4, 7, 10...; stream 2: 2, 5, 8, 11...). Each stream
+    // drains sequentially via its own ``fetchNextPage``, so the three
+    // together run 3 HTTP requests concurrently — chosen to stay under
+    // the 6-per-host browser cap and leave headroom for prod MySQL
+    // under load.
+    const USAGE_STREAMS = 3;
+    type StreamKey = readonly [
+        string,
+        string,
+        string | number | undefined,
+        string | number | undefined,
+        number,
     ];
-
-    const usageInfo = useInfiniteQuery<
-        TaskTemplateResourceUsageResponse | undefined,
-        Error,
-        InfiniteData<TaskTemplateResourceUsageResponse | undefined>,
-        WorkflowUsageQueryKey,
-        number
-    >({
-        queryKey: queryKeyForWorkflowUsage,
-        queryFn: getWorkflowUsagePageQueryFn,
-        initialPageParam: 0,
-        getNextPageParam: (lastPage, allPages) => {
+    const makeStreamKey = (streamIndex: number): StreamKey =>
+        [
+            'workflow_details',
+            'usage_paged',
+            taskTemplateVersionId,
+            workflowId,
+            streamIndex,
+        ] as const;
+    const usageStreamFn = async (
+        context: QueryFunctionContext<StreamKey, number>
+    ): Promise<TaskTemplateResourceUsageResponse | undefined> => {
+        const { queryKey, pageParam = 0 } = context;
+        if (queryKey[2] === undefined || queryKey[3] === undefined) {
+            return undefined;
+        }
+        const response = await axios.post<TaskTemplateResourceUsageResponse>(
+            usage_url,
+            {
+                task_template_version_id: queryKey[2],
+                workflows: [queryKey[3]],
+                viz: true,
+                page: pageParam,
+                page_size: USAGE_PAGE_SIZE,
+            },
+            jobmonAxiosConfig
+        );
+        return response.data;
+    };
+    const usageStreamOptions = (streamIndex: number) => ({
+        queryKey: makeStreamKey(streamIndex),
+        queryFn: usageStreamFn,
+        initialPageParam: streamIndex,
+        getNextPageParam: (
+            lastPage: TaskTemplateResourceUsageResponse | undefined,
+            _allPages: (TaskTemplateResourceUsageResponse | undefined)[],
+            lastPageParam: number
+        ) => {
             const total = lastPage?.total_count;
             if (total == null) return undefined;
-            const fetched = allPages.reduce(
-                (sum, p) => sum + (p?.result_viz?.length ?? 0),
-                0
-            );
-            return fetched < total ? allPages.length : undefined;
+            const totalPages = Math.ceil(total / USAGE_PAGE_SIZE);
+            const next = lastPageParam + USAGE_STREAMS;
+            return next < totalPages ? next : undefined;
         },
         staleTime: 5000,
         enabled:
@@ -129,24 +163,73 @@ export default function TaskTemplateDetails() {
             !!workflowId &&
             !TaskTemplateDetailsData.isLoading,
     });
+    const usageStream0 = useInfiniteQuery<
+        TaskTemplateResourceUsageResponse | undefined,
+        Error,
+        InfiniteData<TaskTemplateResourceUsageResponse | undefined>,
+        StreamKey,
+        number
+    >(usageStreamOptions(0));
+    const usageStream1 = useInfiniteQuery<
+        TaskTemplateResourceUsageResponse | undefined,
+        Error,
+        InfiniteData<TaskTemplateResourceUsageResponse | undefined>,
+        StreamKey,
+        number
+    >(usageStreamOptions(1));
+    const usageStream2 = useInfiniteQuery<
+        TaskTemplateResourceUsageResponse | undefined,
+        Error,
+        InfiniteData<TaskTemplateResourceUsageResponse | undefined>,
+        StreamKey,
+        number
+    >(usageStreamOptions(2));
 
-    // Eagerly drain pages in the background so scatter/table fill up while
-    // the user reads the KPIs sourced from the aggregates endpoint.
+    // Eagerly drain each stream in the background.
     useEffect(() => {
-        if (usageInfo.hasNextPage && !usageInfo.isFetchingNextPage) {
-            usageInfo.fetchNextPage();
+        if (usageStream0.hasNextPage && !usageStream0.isFetchingNextPage) {
+            usageStream0.fetchNextPage();
         }
     }, [
-        usageInfo.hasNextPage,
-        usageInfo.isFetchingNextPage,
-        usageInfo.data?.pages.length,
-        usageInfo.fetchNextPage,
+        usageStream0.hasNextPage,
+        usageStream0.isFetchingNextPage,
+        usageStream0.data?.pages.length,
+        usageStream0.fetchNextPage,
+    ]);
+    useEffect(() => {
+        if (usageStream1.hasNextPage && !usageStream1.isFetchingNextPage) {
+            usageStream1.fetchNextPage();
+        }
+    }, [
+        usageStream1.hasNextPage,
+        usageStream1.isFetchingNextPage,
+        usageStream1.data?.pages.length,
+        usageStream1.fetchNextPage,
+    ]);
+    useEffect(() => {
+        if (usageStream2.hasNextPage && !usageStream2.isFetchingNextPage) {
+            usageStream2.fetchNextPage();
+        }
+    }, [
+        usageStream2.hasNextPage,
+        usageStream2.isFetchingNextPage,
+        usageStream2.data?.pages.length,
+        usageStream2.fetchNextPage,
     ]);
 
-    const rawTaskNodesFromApi = useMemo(
-        () => usageInfo.data?.pages.flatMap(p => p?.result_viz ?? []) ?? [],
-        [usageInfo.data?.pages]
-    );
+    const rawTaskNodesFromApi = useMemo(() => {
+        const all: TaskResourceVizItem[] = [];
+        for (const stream of [usageStream0, usageStream1, usageStream2]) {
+            stream.data?.pages.forEach(p => {
+                if (p?.result_viz) all.push(...p.result_viz);
+            });
+        }
+        return all;
+    }, [
+        usageStream0.data?.pages,
+        usageStream1.data?.pages,
+        usageStream2.data?.pages,
+    ]);
 
     // Page-wide filters — these feed both the aggregates query scope and
     // client-side filtering of the streaming viz rows. Declared up here so
@@ -751,7 +834,10 @@ export default function TaskTemplateDetails() {
         return <Typography>Error loading template.</Typography>;
     }
 
-    const usageIsLoading = usageInfo.isLoading;
+    const usageIsLoading =
+        usageStream0.isLoading ||
+        usageStream1.isLoading ||
+        usageStream2.isLoading;
 
     return (
         <Box>
@@ -882,7 +968,7 @@ export default function TaskTemplateDetails() {
                                     }}
                                 >
                                     <UsagePlotSection
-                                        isLoading={usageInfo.isLoading}
+                                        isLoading={usageIsLoading}
                                         filteredScatterData={
                                             effectiveScatterData
                                         }

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -55,6 +55,7 @@ import { useUsageFilters } from '@jobmon_gui/hooks/useUsageFilters';
 import {
     calculateResourceEfficiency,
     calculateMedian,
+    createResourceClusterKey,
     createResourceClusterLabel,
     getResourceClusterKey,
     ResourceCluster,
@@ -180,15 +181,17 @@ export default function TaskTemplateDetails() {
             !TaskTemplateDetailsData.isLoading,
     });
 
-    // Adapt server clusters to the frontend ResourceCluster shape (adds
-    // camelCase taskCount + human-readable label). Memory from the server
-    // is already in GiB, matching the client-side cluster builder.
+    // Adapt server clusters to the frontend ResourceCluster shape. The
+    // server ships only numbers (runtime, memory, task_count); we derive
+    // the string cluster id via the same ``createResourceClusterKey`` the
+    // scatter-row predicate uses, so the two sides never rely on a
+    // cross-language string contract to agree.
     const serverResourceClusters: ResourceCluster[] | undefined =
         useMemo(() => {
             const clusters = aggregatesQuery.data?.resource_clusters;
             if (!clusters) return undefined;
             return clusters.map(c => ({
-                id: c.id,
+                id: createResourceClusterKey(c.runtime, c.memory),
                 runtime: c.runtime,
                 memory: c.memory,
                 taskCount: c.task_count,

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -1,6 +1,11 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+    InfiniteData,
+    useInfiniteQuery,
+    useQuery,
+    useQueryClient,
+} from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Collapse from '@mui/material/Collapse';
@@ -25,9 +30,13 @@ import { useTaskTemplateDetails } from '@jobmon_gui/queries/GetTaskTemplateDetai
 import { getWorkflowDetailsQueryFn } from '@jobmon_gui/queries/GetWorkflowDetails.ts';
 import { getWorkflowTTStatusQueryFn } from '@jobmon_gui/queries/GetWorkflowTTStatus.ts';
 import {
-    getWorkflowUsageQueryFn,
+    getWorkflowUsagePageQueryFn,
     WorkflowUsageQueryKey,
 } from '@jobmon_gui/queries/GetWorkflowUsage.ts';
+import {
+    getTaskTemplateAggregatesQueryFn,
+    TaskTemplateAggregatesQueryKey,
+} from '@jobmon_gui/queries/GetTaskTemplateAggregates.ts';
 import {
     getClusteredErrorsFn,
     clusteredErrorsKey,
@@ -46,7 +55,9 @@ import { useUsageFilters } from '@jobmon_gui/hooks/useUsageFilters';
 import {
     calculateResourceEfficiency,
     calculateMedian,
+    createResourceClusterLabel,
     getResourceClusterKey,
+    ResourceCluster,
 } from '@jobmon_gui/components/task_template_details/usage/usageCalculations';
 import { components } from '@jobmon_gui/types/apiSchema';
 import {
@@ -60,6 +71,8 @@ dayjs.extend(utc);
 
 type TaskTemplateResourceUsageResponse =
     components['schemas']['TaskTemplateResourceUsageResponse'];
+type TaskTemplateResourceAggregatesResponse =
+    components['schemas']['TaskTemplateResourceAggregatesResponse'];
 
 export default function TaskTemplateDetails() {
     const { workflowId, taskTemplateId } = useParams();
@@ -85,19 +98,30 @@ export default function TaskTemplateDetails() {
 
     const queryKeyForWorkflowUsage: WorkflowUsageQueryKey = [
         'workflow_details',
-        'usage',
+        'usage_paged',
         taskTemplateVersionId,
         workflowId,
     ];
 
-    const usageInfo = useQuery<
+    const usageInfo = useInfiniteQuery<
         TaskTemplateResourceUsageResponse | undefined,
         Error,
-        TaskTemplateResourceUsageResponse | undefined,
-        WorkflowUsageQueryKey
+        InfiniteData<TaskTemplateResourceUsageResponse | undefined>,
+        WorkflowUsageQueryKey,
+        number
     >({
         queryKey: queryKeyForWorkflowUsage,
-        queryFn: getWorkflowUsageQueryFn,
+        queryFn: getWorkflowUsagePageQueryFn,
+        initialPageParam: 0,
+        getNextPageParam: (lastPage, allPages) => {
+            const total = lastPage?.total_count;
+            if (total == null) return undefined;
+            const fetched = allPages.reduce(
+                (sum, p) => sum + (p?.result_viz?.length ?? 0),
+                0
+            );
+            return fetched < total ? allPages.length : undefined;
+        },
         staleTime: 5000,
         enabled:
             !!taskTemplateVersionId &&
@@ -105,10 +129,76 @@ export default function TaskTemplateDetails() {
             !TaskTemplateDetailsData.isLoading,
     });
 
+    // Eagerly drain pages in the background so scatter/table fill up while
+    // the user reads the KPIs sourced from the aggregates endpoint.
+    useEffect(() => {
+        if (usageInfo.hasNextPage && !usageInfo.isFetchingNextPage) {
+            usageInfo.fetchNextPage();
+        }
+    }, [
+        usageInfo.hasNextPage,
+        usageInfo.isFetchingNextPage,
+        usageInfo.data?.pages.length,
+        usageInfo.fetchNextPage,
+    ]);
+
     const rawTaskNodesFromApi = useMemo(
-        () => usageInfo.data?.result_viz ?? [],
-        [usageInfo.data?.result_viz]
+        () => usageInfo.data?.pages.flatMap(p => p?.result_viz ?? []) ?? [],
+        [usageInfo.data?.pages]
     );
+
+    // Page-wide filters — these feed both the aggregates query scope and
+    // client-side filtering of the streaming viz rows. Declared up here so
+    // the aggregates query key can depend on them.
+    const [showLatestOnly, setShowLatestOnly] = useState(true);
+    const [selectedWorkflowRunId, setSelectedWorkflowRunId] = useState<
+        number | null
+    >(null);
+
+    // Aggregates query: fast server-computed KPIs that render immediately
+    // while the paginated viz query streams in. Key includes
+    // `showLatestOnly` so toggling the filter refetches a matching view.
+    const aggregatesQueryKey: TaskTemplateAggregatesQueryKey = [
+        'workflow_details',
+        'usage_aggregates',
+        taskTemplateVersionId,
+        workflowId,
+        showLatestOnly,
+    ];
+    const aggregatesQuery = useQuery<
+        TaskTemplateResourceAggregatesResponse | undefined,
+        Error,
+        TaskTemplateResourceAggregatesResponse | undefined,
+        TaskTemplateAggregatesQueryKey
+    >({
+        queryKey: aggregatesQueryKey,
+        queryFn: getTaskTemplateAggregatesQueryFn,
+        staleTime: 5000,
+        enabled:
+            !!taskTemplateVersionId &&
+            !!workflowId &&
+            !TaskTemplateDetailsData.isLoading,
+    });
+
+    // Adapt server clusters to the frontend ResourceCluster shape (adds
+    // camelCase taskCount + human-readable label). Memory from the server
+    // is already in GiB, matching the client-side cluster builder.
+    const serverResourceClusters: ResourceCluster[] | undefined =
+        useMemo(() => {
+            const clusters = aggregatesQuery.data?.resource_clusters;
+            if (!clusters) return undefined;
+            return clusters.map(c => ({
+                id: c.id,
+                runtime: c.runtime,
+                memory: c.memory,
+                taskCount: c.task_count,
+                label: createResourceClusterLabel(
+                    c.runtime,
+                    c.memory,
+                    c.task_count
+                ),
+            }));
+        }, [aggregatesQuery.data?.resource_clusters]);
 
     // --- Clustered Errors query (for badge + Error Summary card) ---
     const clusteredErrorsQuery = useQuery({
@@ -146,15 +236,11 @@ export default function TaskTemplateDetails() {
         availableResourceClusters,
         setSelectedResourceClusters,
         resetFilters,
-    } = useUsageFilters({ rawTaskNodesFromApi });
+    } = useUsageFilters({ rawTaskNodesFromApi, serverResourceClusters });
 
     // --- Plot interaction state ---
     const [selectedData, setSelectedData] = useState<ScatterDataPoint[]>([]);
     const [showResourceZones, setShowResourceZones] = useState(false);
-    const [showLatestOnly, setShowLatestOnly] = useState(true);
-    const [selectedWorkflowRunId, setSelectedWorkflowRunId] = useState<
-        number | null
-    >(null);
     const [tableFilteredInstanceIds, setTableFilteredInstanceIds] =
         useState<Set<number> | null>(null);
 
@@ -436,7 +522,7 @@ export default function TaskTemplateDetails() {
         [dataForKPICalculations]
     );
 
-    const kpiStats: UsageKPIStats = useMemo(
+    const clientKpiStats: UsageKPIStats = useMemo(
         () => ({
             minRuntime:
                 kpiRuntimes.length > 0 ? Math.min(...kpiRuntimes) : undefined,
@@ -473,7 +559,7 @@ export default function TaskTemplateDetails() {
         ]
     );
 
-    const resourceEfficiency: ResourceEfficiencyMetrics = useMemo(() => {
+    const clientResourceEfficiency: ResourceEfficiencyMetrics = useMemo(() => {
         if (dataForKPICalculations.length === 0) {
             return {
                 memoryUtilization: 0,
@@ -489,6 +575,60 @@ export default function TaskTemplateDetails() {
         }
         return calculateResourceEfficiency(dataForKPICalculations);
     }, [dataForKPICalculations]);
+
+    // Adapt the server aggregates response into the frontend KPI/efficiency
+    // shapes. Backend ships memory fields in bytes; frontend uses GiB.
+    const bytesToGiB = (b: number | null | undefined): number | undefined =>
+        b == null ? undefined : b / 1024 ** 3;
+    const serverKpiStats: UsageKPIStats | undefined = useMemo(() => {
+        const a = aggregatesQuery.data;
+        if (!a) return undefined;
+        return {
+            minRuntime: a.min_runtime ?? undefined,
+            maxRuntime: a.max_runtime ?? undefined,
+            meanRuntime: a.mean_runtime ?? undefined,
+            medianRuntime: a.median_runtime ?? undefined,
+            minMemoryGiB: bytesToGiB(a.min_mem),
+            maxMemoryGiB: bytesToGiB(a.max_mem),
+            meanMemoryGiB: bytesToGiB(a.mean_mem),
+            medianMemoryGiB: bytesToGiB(a.median_mem),
+            medianRequestedRuntime: a.median_requested_runtime ?? undefined,
+            medianRequestedMemoryGiB: a.median_requested_memory ?? undefined,
+        };
+    }, [aggregatesQuery.data]);
+    const serverResourceEfficiency: ResourceEfficiencyMetrics | undefined =
+        useMemo(() => {
+            const e = aggregatesQuery.data?.efficiency;
+            if (!e) return undefined;
+            return {
+                memoryUtilization: e.memory_utilization,
+                runtimeUtilization: e.runtime_utilization,
+                overAllocatedMemory: e.over_allocated_memory,
+                underAllocatedMemory: e.under_allocated_memory,
+                overAllocatedRuntime: e.over_allocated_runtime,
+                underAllocatedRuntime: e.under_allocated_runtime,
+                p95Memory: e.p95_memory ?? undefined,
+                p95Runtime: e.p95_runtime ?? undefined,
+                outlierCount: e.outlier_count,
+            };
+        }, [aggregatesQuery.data?.efficiency]);
+
+    // True when no user-driven filter narrows the page; in that state the
+    // server aggregates are an exact match for what the client would
+    // compute from the full streaming rowset, so we render them directly
+    // for instant KPIs without waiting for pagination to drain.
+    const isUnfilteredDefault =
+        selectedData.length === 0 &&
+        tableFilteredInstanceIds === null &&
+        selectedWorkflowRunId === null &&
+        selectedResourceClusters.size === availableResourceClusters.length;
+
+    const kpiStats: UsageKPIStats =
+        isUnfilteredDefault && serverKpiStats ? serverKpiStats : clientKpiStats;
+    const resourceEfficiency: ResourceEfficiencyMetrics =
+        isUnfilteredDefault && serverResourceEfficiency
+            ? serverResourceEfficiency
+            : clientResourceEfficiency;
 
     // --- CSV download ---
     const downloadCSV = () => {

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -663,28 +663,44 @@ export default function TaskTemplateDetails() {
     }, [dataForKPICalculations]);
 
     // Adapt the server aggregates response into the frontend KPI/efficiency
-    // shapes. Backend ships memory fields in bytes; frontend uses GiB.
-    const bytesToGiB = (b: number | null | undefined): number | undefined =>
-        b == null ? undefined : b / 1024 ** 3;
+    // shapes. Only treat the server data as authoritative when it actually
+    // represents real task instances:
+    //   * ``num_tasks > 0`` — zero-TI workflows (all tasks still
+    //     REGISTERING) come back with a default-zero efficiency object
+    //     we don't want overwriting client-computed values.
+    //   * ``!isFetching`` — a ``showLatestOnly`` toggle refetches
+    //     aggregates; during the transition the cached response is for
+    //     the *previous* toggle value while the client has already
+    //     recomputed for the new one, so we gate on ``isFetching`` to
+    //     avoid mixing the two.
+    const serverDataUsable =
+        !!aggregatesQuery.data &&
+        (aggregatesQuery.data.num_tasks ?? 0) > 0 &&
+        !aggregatesQuery.isFetching;
     const serverKpiStats: UsageKPIStats | undefined = useMemo(() => {
-        const a = aggregatesQuery.data;
-        if (!a) return undefined;
+        if (!serverDataUsable) return undefined;
+        const a = aggregatesQuery.data!;
         return {
             minRuntime: a.min_runtime ?? undefined,
             maxRuntime: a.max_runtime ?? undefined,
             meanRuntime: a.mean_runtime ?? undefined,
             medianRuntime: a.median_runtime ?? undefined,
-            minMemoryGiB: bytesToGiB(a.min_mem),
-            maxMemoryGiB: bytesToGiB(a.max_mem),
-            meanMemoryGiB: bytesToGiB(a.mean_mem),
-            medianMemoryGiB: bytesToGiB(a.median_mem),
+            minMemoryGiB:
+                a.min_mem != null ? bytes_to_gib(a.min_mem) : undefined,
+            maxMemoryGiB:
+                a.max_mem != null ? bytes_to_gib(a.max_mem) : undefined,
+            meanMemoryGiB:
+                a.mean_mem != null ? bytes_to_gib(a.mean_mem) : undefined,
+            medianMemoryGiB:
+                a.median_mem != null ? bytes_to_gib(a.median_mem) : undefined,
             medianRequestedRuntime: a.median_requested_runtime ?? undefined,
             medianRequestedMemoryGiB: a.median_requested_memory ?? undefined,
         };
-    }, [aggregatesQuery.data]);
+    }, [serverDataUsable, aggregatesQuery.data]);
     const serverResourceEfficiency: ResourceEfficiencyMetrics | undefined =
         useMemo(() => {
-            const e = aggregatesQuery.data?.efficiency;
+            if (!serverDataUsable) return undefined;
+            const e = aggregatesQuery.data!.efficiency;
             if (!e) return undefined;
             return {
                 memoryUtilization: e.memory_utilization,
@@ -697,7 +713,7 @@ export default function TaskTemplateDetails() {
                 p95Runtime: e.p95_runtime ?? undefined,
                 outlierCount: e.outlier_count,
             };
-        }, [aggregatesQuery.data?.efficiency]);
+        }, [serverDataUsable, aggregatesQuery.data]);
 
     // True when no user-driven filter narrows the page; in that state the
     // server aggregates are an exact match for what the client would

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -709,12 +709,35 @@ export default function TaskTemplateDetails() {
         selectedWorkflowRunId === null &&
         selectedResourceClusters.size === availableResourceClusters.length;
 
-    const kpiStats: UsageKPIStats =
-        isUnfilteredDefault && serverKpiStats ? serverKpiStats : clientKpiStats;
-    const resourceEfficiency: ResourceEfficiencyMetrics =
-        isUnfilteredDefault && serverResourceEfficiency
-            ? serverResourceEfficiency
-            : clientResourceEfficiency;
+    // Per-field merge so the server's fast values (min/max/mean, count)
+    // render instantly while fields the server doesn't compute
+    // (median, p95 — require sort) fall back to the client-side result
+    // as soon as enough viz pages have streamed in. A whole-object
+    // pick would permanently hide the server's undefined medians.
+    const kpiStats: UsageKPIStats = useMemo(() => {
+        if (!isUnfilteredDefault || !serverKpiStats) return clientKpiStats;
+        const merged = { ...clientKpiStats } as Record<string, unknown>;
+        for (const [k, v] of Object.entries(serverKpiStats)) {
+            if (v !== undefined && v !== null) merged[k] = v;
+        }
+        return merged as UsageKPIStats;
+    }, [isUnfilteredDefault, serverKpiStats, clientKpiStats]);
+    const resourceEfficiency: ResourceEfficiencyMetrics = useMemo(() => {
+        if (!isUnfilteredDefault || !serverResourceEfficiency)
+            return clientResourceEfficiency;
+        const merged = { ...clientResourceEfficiency } as Record<
+            string,
+            unknown
+        >;
+        for (const [k, v] of Object.entries(serverResourceEfficiency)) {
+            if (v !== undefined && v !== null) merged[k] = v;
+        }
+        return merged as unknown as ResourceEfficiencyMetrics;
+    }, [
+        isUnfilteredDefault,
+        serverResourceEfficiency,
+        clientResourceEfficiency,
+    ]);
 
     // --- CSV download ---
     const downloadCSV = () => {

--- a/jobmon_gui/src/types/apiSchema.ts
+++ b/jobmon_gui/src/types/apiSchema.ts
@@ -2433,14 +2433,16 @@ export interface components {
          * ResourceClusterItem
          * @description One requested-resource cluster summary.
          *
-         *     Cluster → instance membership is recomputed on the frontend as the
-         *     scatter rows stream in, so we deliberately do not ship instance IDs
-         *     here — for large templates that list alone would dominate the
-         *     aggregates payload.
+         *     We ship only the numeric ``(runtime, memory)`` pair plus the count;
+         *     the frontend derives the string cluster key itself using the same
+         *     rounding/formatting it applies to scatter rows, so there's no
+         *     cross-language string contract that can drift between Python and JS.
+         *
+         *     Cluster → instance membership is also recomputed frontend-side from
+         *     streaming scatter rows — shipping per-instance IDs here would
+         *     dominate the aggregates payload on large templates.
          */
         ResourceClusterItem: {
-            /** Id */
-            id: string;
             /** Runtime */
             runtime: number;
             /** Memory */

--- a/jobmon_gui/src/types/apiSchema.ts
+++ b/jobmon_gui/src/types/apiSchema.ts
@@ -2764,6 +2764,14 @@ export interface components {
         /**
          * TaskTemplateResourceAggregatesResponse
          * @description Compact server-computed aggregates for a task template.
+         *
+         *     Memory and runtime stats are ``Optional[float]`` (not ``int``) so
+         *     the client's per-field merge doesn't permanently overwrite more
+         *     precise client-computed floats with a truncated integer.
+         *     ``efficiency`` defaults to ``None`` when the template has no
+         *     efficiency-relevant data (zero-TI workflow, or TIs without
+         *     requested resources) so the frontend can distinguish "no server
+         *     data" from "server says all zeros".
          */
         TaskTemplateResourceAggregatesResponse: {
             /** Num Tasks */
@@ -2797,7 +2805,9 @@ export interface components {
              * @default []
              */
             resource_clusters: components['schemas']['ResourceClusterItem'][];
-            efficiency?: components['schemas']['ResourceEfficiencyMetrics'];
+            efficiency?:
+                | components['schemas']['ResourceEfficiencyMetrics']
+                | null;
         };
         /** TaskTemplateResourceUsageRequest */
         TaskTemplateResourceUsageRequest: {

--- a/jobmon_gui/src/types/apiSchema.ts
+++ b/jobmon_gui/src/types/apiSchema.ts
@@ -1563,7 +1563,11 @@ export interface paths {
         };
         /**
          * Workflows By User Form
-         * @description Fetch associated workflows and workflow runs by username.
+         * @description Fetch workflow overview with filtering.
+         *
+         *     ``wf_attr`` accepts repeated ``key:value`` pairs for
+         *     multi-attribute AND filtering, e.g.
+         *     ``?wf_attr=project:fhs&wf_attr=release_id:7``.
          */
         get: operations['workflows_by_user_form_api_v3_workflow_overview_viz_get'];
         put?: never;
@@ -1906,6 +1910,30 @@ export interface paths {
          *     and Python client consumption with full type safety.
          */
         post: operations['get_task_template_resource_usage_api_v3_task_template_resource_usage_post'];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    '/api/v3/task_template_resource_aggregates': {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Get Task Template Resource Aggregates
+         * @description Server-computed aggregates (KPIs, clusters, efficiency) for a task template.
+         *
+         *     Uses a narrow-column query and avoids materializing the full
+         *     task_instance × task × task_resources payload that the viz endpoint
+         *     returns.
+         */
+        post: operations['get_task_template_resource_aggregates_api_v3_task_template_resource_aggregates_post'];
         delete?: never;
         options?: never;
         head?: never;
@@ -2402,6 +2430,70 @@ export interface components {
             detail?: components['schemas']['ValidationError'][];
         };
         /**
+         * ResourceClusterItem
+         * @description One requested-resource cluster summary.
+         *
+         *     Cluster → instance membership is recomputed on the frontend as the
+         *     scatter rows stream in, so we deliberately do not ship instance IDs
+         *     here — for large templates that list alone would dominate the
+         *     aggregates payload.
+         */
+        ResourceClusterItem: {
+            /** Id */
+            id: string;
+            /** Runtime */
+            runtime: number;
+            /** Memory */
+            memory: number;
+            /** Task Count */
+            task_count: number;
+        };
+        /**
+         * ResourceEfficiencyMetrics
+         * @description Aggregate resource efficiency metrics for a task template.
+         */
+        ResourceEfficiencyMetrics: {
+            /**
+             * Memory Utilization
+             * @default 0
+             */
+            memory_utilization: number;
+            /**
+             * Runtime Utilization
+             * @default 0
+             */
+            runtime_utilization: number;
+            /**
+             * Over Allocated Memory
+             * @default 0
+             */
+            over_allocated_memory: number;
+            /**
+             * Under Allocated Memory
+             * @default 0
+             */
+            under_allocated_memory: number;
+            /**
+             * Over Allocated Runtime
+             * @default 0
+             */
+            over_allocated_runtime: number;
+            /**
+             * Under Allocated Runtime
+             * @default 0
+             */
+            under_allocated_runtime: number;
+            /** P95 Memory */
+            p95_memory?: number | null;
+            /** P95 Runtime */
+            p95_runtime?: number | null;
+            /**
+             * Outlier Count
+             * @default 0
+             */
+            outlier_count: number;
+        };
+        /**
          * TaskConcurrencyResponse
          * @description Response model for task concurrency timeline.
          *
@@ -2648,6 +2740,63 @@ export interface components {
             /** Tasks */
             tasks: components['schemas']['TaskTableItem'][];
         };
+        /**
+         * TaskTemplateResourceAggregatesRequest
+         * @description Request for the lightweight aggregates endpoint.
+         */
+        TaskTemplateResourceAggregatesRequest: {
+            /** Task Template Version Id */
+            task_template_version_id: number;
+            /** Workflows */
+            workflows?: number[] | null;
+            /** Node Args */
+            node_args?: {
+                [key: string]: string[];
+            } | null;
+            /**
+             * Latest Only
+             * @default true
+             */
+            latest_only: boolean;
+        };
+        /**
+         * TaskTemplateResourceAggregatesResponse
+         * @description Compact server-computed aggregates for a task template.
+         */
+        TaskTemplateResourceAggregatesResponse: {
+            /** Num Tasks */
+            num_tasks?: number | null;
+            /** Min Mem */
+            min_mem?: number | null;
+            /** Max Mem */
+            max_mem?: number | null;
+            /** Mean Mem */
+            mean_mem?: number | null;
+            /** Median Mem */
+            median_mem?: number | null;
+            /** P95 Mem */
+            p95_mem?: number | null;
+            /** Min Runtime */
+            min_runtime?: number | null;
+            /** Max Runtime */
+            max_runtime?: number | null;
+            /** Mean Runtime */
+            mean_runtime?: number | null;
+            /** Median Runtime */
+            median_runtime?: number | null;
+            /** P95 Runtime */
+            p95_runtime?: number | null;
+            /** Median Requested Runtime */
+            median_requested_runtime?: number | null;
+            /** Median Requested Memory */
+            median_requested_memory?: number | null;
+            /**
+             * Resource Clusters
+             * @default []
+             */
+            resource_clusters: components['schemas']['ResourceClusterItem'][];
+            efficiency?: components['schemas']['ResourceEfficiencyMetrics'];
+        };
         /** TaskTemplateResourceUsageRequest */
         TaskTemplateResourceUsageRequest: {
             /** Task Template Version Id */
@@ -2665,6 +2814,10 @@ export interface components {
              * @default false
              */
             viz: boolean;
+            /** Page */
+            page?: number | null;
+            /** Page Size */
+            page_size?: number | null;
         };
         /**
          * TaskTemplateResourceUsageResponse
@@ -2695,6 +2848,12 @@ export interface components {
             ci_runtime?: (number | null)[] | null;
             /** Result Viz */
             result_viz?: components['schemas']['TaskResourceVizItem'][] | null;
+            /** Total Count */
+            total_count?: number | null;
+            /** Page */
+            page?: number | null;
+            /** Page Size */
+            page_size?: number | null;
             /** @description Provide formatted statistics similar to legacy client format. */
             readonly formatted_stats: components['schemas']['FormattedStats'];
         };
@@ -4939,6 +5098,9 @@ export interface operations {
                 'user!'?: string[] | null;
                 'tool!'?: string[] | null;
                 'status!'?: string[] | null;
+                wf_name_contains?: boolean;
+                wf_args_contains?: boolean;
+                wf_attr?: string[] | null;
             };
             header?: never;
             path?: never;
@@ -5424,6 +5586,39 @@ export interface operations {
                 };
                 content: {
                     'application/json': components['schemas']['TaskTemplateResourceUsageResponse'];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['HTTPValidationError'];
+                };
+            };
+        };
+    };
+    get_task_template_resource_aggregates_api_v3_task_template_resource_aggregates_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                'application/json': components['schemas']['TaskTemplateResourceAggregatesRequest'];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['TaskTemplateResourceAggregatesResponse'];
                 };
             };
             /** @description Validation Error */

--- a/jobmon_server/src/jobmon/server/web/migrations/versions/2026_04_21_1500-c3d4e5f6a7b8_add_task_instance_covering_index.py
+++ b/jobmon_server/src/jobmon/server/web/migrations/versions/2026_04_21_1500-c3d4e5f6a7b8_add_task_instance_covering_index.py
@@ -1,0 +1,58 @@
+"""Add covering index to task_instance for TT detail queries.
+
+The task-template aggregate and viz endpoints join through
+task_instance and read ``wallclock``, ``maxrss``, and
+``task_resources_id``. None of those columns live in a secondary
+index, so each row required a random PK heap lookup — ~78K lookups
+per query on large templates (pixel: ~6-7s of random I/O).
+
+Adding ``(task_id, id, wallclock, maxrss, task_resources_id)`` makes
+the hot path index-only: MySQL serves the join from the secondary
+index alone, with zero heap reads. Expected impact:
+
+  - aggregate endpoint on pixel:    ~6-7s → ~1-2s
+  - viz page-0 on pixel:            ~8s   → ~3-4s
+
+Safe to run on a live database — MySQL 8.0 builds secondary
+indexes online (ALGORITHM=INPLACE, LOCK=NONE) without blocking
+reads or writes. Estimated ~4 GB additional storage at 110M rows.
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-21
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add covering index to eliminate heap lookups on TT queries."""
+    bind = op.get_bind()
+    if bind.dialect.name == "mysql":
+        op.execute(
+            sa.text(
+                "ALTER TABLE task_instance "
+                "ADD INDEX ix_ti_task_id_covering "
+                "(task_id, id, wallclock, maxrss, task_resources_id), "
+                "ALGORITHM=INPLACE, LOCK=NONE"
+            )
+        )
+    else:
+        op.create_index(
+            "ix_ti_task_id_covering",
+            "task_instance",
+            ["task_id", "id", "wallclock", "maxrss", "task_resources_id"],
+        )
+
+
+def downgrade() -> None:
+    """Remove the covering index."""
+    op.drop_index("ix_ti_task_id_covering", table_name="task_instance")

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -797,34 +797,41 @@ class TaskTemplateRepository:
     def _main_aggregates_query(t: Any) -> Any:
         """Single-row aggregate: KPIs + efficiency totals + outlier count.
 
-        Outlier gate requires the mean and stddev of wallclock and
-        (maxrss/GiB) over the efficiency subset. MySQL 8 window
-        aggregates let us compute those alongside row filtering in one
-        scan — no need for a second pass.
+        Two gates are used, matching the frontend's data populations so
+        numbers don't visibly jump when the user toggles a filter:
+
+          * ``kpi_valid = wc > 0 AND mr > 0`` — the upstream scatter
+            row filter (``filteredScatterData``). Runtime + memory
+            KPIs, outlier mean / stddev / count all compute over this
+            subset.
+          * ``eff_valid = kpi_valid AND req_rt > 0 AND req_mem > 0`` —
+            additionally requires both requested resources. Utilization
+            totals and over/under-allocated percentages need all four
+            fields for their math, so they use this stricter subset.
         """
         GIB = 1024.0**3
         wc = t.c.wc
         mr = t.c.mr
         req_rt = t.c.req_rt
         req_mem = t.c.req_mem
-        eff = and_(wc > 0, mr > 0, req_rt > 0, req_mem > 0)
-        wc_eff = case((eff, wc), else_=None)
-        mem_gib_eff = case((eff, mr / GIB), else_=None)
+        kpi_valid = and_(wc > 0, mr > 0)
+        wc_kpi = case((kpi_valid, wc), else_=None)
+        mem_gib_kpi = case((kpi_valid, mr / GIB), else_=None)
 
-        # Ranked subquery to compute window aggregates (mean/stddev of
-        # efficiency-gated wc and mem_gib) in the same scan. Main outer
-        # query then counts outliers using those window values.
+        # Ranked subquery: window aggregates for outlier detection
+        # (mean + stddev of kpi-valid wc and mem_gib) computed in the
+        # same scan. Outer query counts outliers using those values.
         ranked = (
             select(
                 wc.label("wc"),
                 mr.label("mr"),
                 req_rt.label("req_rt"),
                 req_mem.label("req_mem"),
-                func.avg(wc_eff).over().label("mean_eff_wc"),
-                func.coalesce(func.stddev_pop(wc_eff).over(), 0.0).label("std_eff_wc"),
-                func.avg(mem_gib_eff).over().label("mean_eff_mem"),
-                func.coalesce(func.stddev_pop(mem_gib_eff).over(), 0.0).label(
-                    "std_eff_mem"
+                func.avg(wc_kpi).over().label("mean_kpi_wc"),
+                func.coalesce(func.stddev_pop(wc_kpi).over(), 0.0).label("std_kpi_wc"),
+                func.avg(mem_gib_kpi).over().label("mean_kpi_mem"),
+                func.coalesce(func.stddev_pop(mem_gib_kpi).over(), 0.0).label(
+                    "std_kpi_mem"
                 ),
             )
             .select_from(t)
@@ -835,32 +842,34 @@ class TaskTemplateRepository:
         r_mr = ranked.c.mr
         r_rrt = ranked.c.req_rt
         r_rmem = ranked.c.req_mem
-        r_eff = and_(r_wc > 0, r_mr > 0, r_rrt > 0, r_rmem > 0)
+        r_kpi = and_(r_wc > 0, r_mr > 0)
+        r_eff = and_(r_kpi, r_rrt > 0, r_rmem > 0)
         r_mem_gib = r_mr / GIB
         r_mem_util = case((r_eff, r_mem_gib / r_rmem * 100), else_=None)
         r_rt_util = case((r_eff, r_wc / r_rrt * 100), else_=None)
         outlier_gate = or_(
-            func.abs(r_wc - ranked.c.mean_eff_wc) > 2 * ranked.c.std_eff_wc,
-            func.abs(r_mem_gib - ranked.c.mean_eff_mem) > 2 * ranked.c.std_eff_mem,
+            func.abs(r_wc - ranked.c.mean_kpi_wc) > 2 * ranked.c.std_kpi_wc,
+            func.abs(r_mem_gib - ranked.c.mean_kpi_mem) > 2 * ranked.c.std_kpi_mem,
         )
 
         return select(
             func.count().label("num_tasks"),
-            # memory stats
-            func.count(case((r_mr > 0, 1), else_=None)).label("n_mr"),
-            func.min(case((r_mr > 0, r_mr), else_=None)).label("min_mem"),
-            func.max(case((r_mr > 0, r_mr), else_=None)).label("max_mem"),
-            func.avg(case((r_mr > 0, r_mr), else_=None)).label("mean_mem"),
-            # runtime stats
-            func.count(case((r_wc > 0, 1), else_=None)).label("n_wc"),
-            func.min(case((r_wc > 0, r_wc), else_=None)).label("min_rt"),
-            func.max(case((r_wc > 0, r_wc), else_=None)).label("max_rt"),
-            func.avg(case((r_wc > 0, r_wc), else_=None)).label("mean_rt"),
+            # KPI stats (kpi_valid subset — matches client's
+            # ScatterDataPoint universe: runtime > 0 AND memory > 0)
+            func.count(case((r_kpi, 1), else_=None)).label("n_kpi"),
+            func.min(case((r_kpi, r_mr), else_=None)).label("min_mem"),
+            func.max(case((r_kpi, r_mr), else_=None)).label("max_mem"),
+            func.avg(case((r_kpi, r_mr), else_=None)).label("mean_mem"),
+            func.min(case((r_kpi, r_wc), else_=None)).label("min_rt"),
+            func.max(case((r_kpi, r_wc), else_=None)).label("max_rt"),
+            func.avg(case((r_kpi, r_wc), else_=None)).label("mean_rt"),
             # NB: no ``median_requested_*`` here — true medians need a
             # sort and the server path deliberately skips them. The
             # frontend has a client-side fallback that computes the
             # median from streaming viz rows once they've loaded.
-            # efficiency totals
+            # Efficiency totals (eff_valid subset — additionally
+            # requires both requested resources for the utilization
+            # math to be defined).
             func.sum(case((r_eff, 1), else_=0)).label("eff_n"),
             func.sum(case((r_eff, r_mem_gib), else_=0)).label("tot_actual_mem"),
             func.sum(case((r_eff, r_rmem), else_=0)).label("tot_req_mem"),
@@ -874,7 +883,10 @@ class TaskTemplateRepository:
             ),
             func.sum(case((and_(r_eff, r_rt_util < 50), 1), else_=0)).label("over_rt"),
             func.sum(case((and_(r_eff, r_rt_util > 90), 1), else_=0)).label("under_rt"),
-            func.sum(case((and_(r_eff, outlier_gate), 1), else_=0)).label("outliers"),
+            # Outlier count over the kpi_valid subset, matching the
+            # client's outlier calc which runs against all scatter
+            # points.
+            func.sum(case((and_(r_kpi, outlier_gate), 1), else_=0)).label("outliers"),
         ).select_from(ranked)
 
     @staticmethod
@@ -943,11 +955,14 @@ class TaskTemplateRepository:
         num_tasks = int(stats["num_tasks"])
         resp = TaskTemplateResourceAggregatesResponse(num_tasks=num_tasks)
 
-        if (stats["n_mr"] or 0) > 0:
+        # Both runtime and memory stats gate on the same ``kpi_valid``
+        # subset (wallclock > 0 AND maxrss > 0) to match the client's
+        # ScatterDataPoint universe, so toggling a filter doesn't shift
+        # numbers between the server-computed and client-computed paths.
+        if (stats["n_kpi"] or 0) > 0:
             resp.min_mem = int(stats["min_mem"])
             resp.max_mem = int(stats["max_mem"])
             resp.mean_mem = float(stats["mean_mem"])
-        if (stats["n_wc"] or 0) > 0:
             resp.min_runtime = int(stats["min_rt"])
             resp.max_runtime = int(stats["max_rt"])
             resp.mean_runtime = float(stats["mean_rt"])

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -178,10 +178,24 @@ class TaskTemplateRepository:
             # ids, avoiding the filesort + 2000 heap-probes the naive
             # plan does on the full join. Measured on pixel page 0:
             # SQL time ~3s → ~0.6s.
+            #
+            # ``attempt_num`` is computed inside pass 1 (before the
+            # LIMIT applies) so the window sees every matching
+            # task_instance per task, not just the paged subset — a
+            # task's attempts that span page boundaries still number
+            # correctly.
             paged_ids = None
             if limit is not None:
                 paged_ids = (
-                    select(TaskInstance.id.label("paged_ti_id"))
+                    select(
+                        TaskInstance.id.label("paged_ti_id"),
+                        func.row_number()
+                        .over(
+                            partition_by=TaskInstance.task_id,
+                            order_by=TaskInstance.id,
+                        )
+                        .label("paged_attempt_num"),
+                    )
                     .select_from(TaskTemplateVersion)
                     .join(
                         Node,
@@ -212,7 +226,11 @@ class TaskTemplateRepository:
                 Task.max_attempts.label("task_max_attempts_col"),
                 # Requested resources (narrowed to memory+runtime only)
                 narrow_req_res,
-                attempt_number_col,
+                (
+                    paged_ids.c.paged_attempt_num.label("attempt_number_of_instance")
+                    if paged_ids is not None
+                    else attempt_number_col
+                ),
                 TaskInstance.id.label("task_instance_id_col"),
                 TaskInstance.workflow_run_id.label("workflow_run_id_col"),
             )
@@ -687,7 +705,13 @@ class TaskTemplateRepository:
         if workflows:
             base_filters.append(Task.workflow_id.in_(workflows))
 
-        if latest_only:
+        dialect = self.session.bind.dialect.name if self.session.bind else ""
+        if latest_only and dialect == "mysql":
+            # LATERAL lets MySQL's planner use the covering index
+            # ``ix_ti_task_id_covering`` index-only — no heap reads on
+            # wallclock/maxrss/task_resources_id. ~3-4x faster on pixel.
+            # SQLite doesn't support LATERAL, so tests fall through to
+            # the correlated-scalar branch below.
             latest_lat = (
                 select(
                     TaskInstance.wallclock.label("wc_raw"),
@@ -739,6 +763,18 @@ class TaskTemplateRepository:
                 )
                 .where(and_(*base_filters))
             )
+
+            if latest_only:
+                # Fallback for dialects without LATERAL (sqlite tests).
+                # Correlated scalar subquery on MAX(id); less optimal on
+                # MySQL (no covering-index benefit) but portable.
+                latest_ti_id = (
+                    select(func.max(TaskInstance.id))
+                    .where(TaskInstance.task_id == Task.id)
+                    .correlate(Task)
+                    .scalar_subquery()
+                )
+                q = q.where(TaskInstance.id == latest_ti_id)
 
         if node_args:
             for arg_name, arg_values in node_args.items():
@@ -820,10 +856,10 @@ class TaskTemplateRepository:
             func.min(case((r_wc > 0, r_wc), else_=None)).label("min_rt"),
             func.max(case((r_wc > 0, r_wc), else_=None)).label("max_rt"),
             func.avg(case((r_wc > 0, r_wc), else_=None)).label("mean_rt"),
-            # requested stats (mean is cheap and matches UI's median
-            # expectation closely for uniform-resource templates)
-            func.avg(case((r_rrt > 0, r_rrt), else_=None)).label("mean_req_rt"),
-            func.avg(case((r_rmem > 0, r_rmem), else_=None)).label("mean_req_mem"),
+            # NB: no ``median_requested_*`` here — true medians need a
+            # sort and the server path deliberately skips them. The
+            # frontend has a client-side fallback that computes the
+            # median from streaming viz rows once they've loaded.
             # efficiency totals
             func.sum(case((r_eff, 1), else_=0)).label("eff_n"),
             func.sum(case((r_eff, r_mem_gib), else_=0)).label("tot_actual_mem"),
@@ -916,10 +952,8 @@ class TaskTemplateRepository:
             resp.max_runtime = int(stats["max_rt"])
             resp.mean_runtime = float(stats["mean_rt"])
 
-        if stats["mean_req_rt"] is not None:
-            resp.median_requested_runtime = float(stats["mean_req_rt"])
-        if stats["mean_req_mem"] is not None:
-            resp.median_requested_memory = float(stats["mean_req_mem"])
+        # median_requested_runtime / median_requested_memory left unset —
+        # frontend computes from the streaming viz rows.
 
         # Build clusters by binning unique (runtime, memory) pairs using
         # the same JS-round formula as the frontend's cluster-key builder.

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -156,17 +156,24 @@ class TaskTemplateRepository:
             .label("attempt_number_of_instance")
         )
 
-        # Narrow ``requested_resources`` to the two fields the UI actually
-        # uses on the viz path (memory + runtime). The full blob averages
+        # Narrow ``requested_resources`` to the fields the UI and CSV
+        # export actually need — the documented ``RequestedResourcesModel``
+        # schema (memory, runtime, cores, queue). The full blob averages
         # ~700 bytes/row on templates like ``pixel`` (paths, project
         # config, stderr/stdout paths, command args) and dominated the
         # per-row payload size. MySQL ``JSON_OBJECT`` builds the narrow
-        # JSON server-side so we ship ~30 bytes/row instead.
+        # JSON server-side so we ship ~60 bytes/row instead. CSV
+        # export's ``requested_resources_json`` column now exposes the
+        # narrowed blob, but all four documented fields are preserved.
         narrow_req_res = func.json_object(
             "memory",
             func.json_extract(TaskResources.requested_resources, "$.memory"),
             "runtime",
             func.json_extract(TaskResources.requested_resources, "$.runtime"),
+            "cores",
+            func.json_extract(TaskResources.requested_resources, "$.cores"),
+            "queue",
+            func.json_extract(TaskResources.requested_resources, "$.queue"),
         ).label("requested_resources_col")
 
         if not node_args:
@@ -322,13 +329,20 @@ class TaskTemplateRepository:
         offset: int = 0,
     ) -> List[TaskResourceDetailItem]:
         """Optimized node_args filtering using database-level joins and filtering."""
-        # See ``get_task_resource_details`` for rationale — ship only the
-        # two requested-resource fields the UI needs on the viz path.
+        # See ``get_task_resource_details`` for rationale — ship only
+        # the documented ``RequestedResourcesModel`` fields (memory,
+        # runtime, cores, queue) so the viz path stays narrow while
+        # CSV export's ``requested_resources_json`` preserves all
+        # four.
         narrow_req_res = func.json_object(
             "memory",
             func.json_extract(TaskResources.requested_resources, "$.memory"),
             "runtime",
             func.json_extract(TaskResources.requested_resources, "$.runtime"),
+            "cores",
+            func.json_extract(TaskResources.requested_resources, "$.cores"),
+            "queue",
+            func.json_extract(TaskResources.requested_resources, "$.queue"),
         ).label("requested_resources")
         base_query = (
             select(

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -967,12 +967,15 @@ class TaskTemplateRepository:
         # subset (wallclock > 0 AND maxrss > 0) to match the client's
         # ScatterDataPoint universe, so toggling a filter doesn't shift
         # numbers between the server-computed and client-computed paths.
+        # Stored as floats so the frontend per-field merge doesn't
+        # overwrite more precise client-computed values with a
+        # truncated integer.
         if (stats["n_kpi"] or 0) > 0:
-            resp.min_mem = int(stats["min_mem"])
-            resp.max_mem = int(stats["max_mem"])
+            resp.min_mem = float(stats["min_mem"])
+            resp.max_mem = float(stats["max_mem"])
             resp.mean_mem = float(stats["mean_mem"])
-            resp.min_runtime = int(stats["min_rt"])
-            resp.max_runtime = int(stats["max_rt"])
+            resp.min_runtime = float(stats["min_rt"])
+            resp.max_runtime = float(stats["max_rt"])
             resp.mean_runtime = float(stats["mean_rt"])
 
         # median_requested_runtime / median_requested_memory left unset —
@@ -982,6 +985,11 @@ class TaskTemplateRepository:
         # the same JS-round formula as the frontend's cluster-key builder.
         # Merging multiple task_resources rows that share the same bin
         # avoids duplicate chips when only ancillary fields differ.
+        # Use the bin-rounded values (memory in GiB, runtime in hours
+        # → back to seconds) as the cluster's representative values so
+        # two task_resources rows with raw inputs that round to the
+        # same bin (e.g. 3599s vs 3601s → 1.0h) produce the same
+        # shipped runtime/memory, not whichever row arrived first.
         merged: Dict[tuple, Dict[str, Any]] = {}
         for row in cluster_counts:
             tr_id = int(row.tr_id)
@@ -991,10 +999,16 @@ class TaskTemplateRepository:
             runtime, memory = rt_mem
             if runtime is None or runtime <= 0 or memory is None or memory <= 0:
                 continue
-            key = (_js_round_tenth(memory), _js_round_tenth(runtime / 3600))
+            mem_bin = _js_round_tenth(memory)
+            rt_hours_bin = _js_round_tenth(runtime / 3600)
+            key = (mem_bin, rt_hours_bin)
             bucket = merged.setdefault(
                 key,
-                {"runtime": runtime, "memory": memory, "count": 0},
+                {
+                    "runtime": rt_hours_bin * 3600,
+                    "memory": mem_bin,
+                    "count": 0,
+                },
             )
             bucket["count"] += int(row.n)
         resp.resource_clusters = sorted(
@@ -1010,15 +1024,18 @@ class TaskTemplateRepository:
             reverse=True,
         )
 
-        # Outlier count lives on the ``kpi_valid`` subset (wc>0 AND mr>0)
-        # independent of requested resources, so populate it whenever we
-        # have ANY kpi-valid rows — not only when utilization-valid rows
-        # exist. Otherwise templates with real wallclock+maxrss data but
-        # no requested resources would permanently render
-        # ``outlier_count=0``.
+        # Efficiency is populated only when ``eff_n > 0`` (rows with
+        # all of wallclock, maxrss, and both requested resources valid
+        # — the subset the utilization math is defined on). When
+        # ``eff_n = 0`` the response ships ``efficiency = None`` rather
+        # than a partial object, so the frontend per-field merge
+        # doesn't overwrite client-computed values with zero defaults.
+        # Outlier count is part of that object: for templates without
+        # requested resources the client computes it from streaming
+        # viz rows instead.
         eff_n = int(stats["eff_n"] or 0)
-        outliers = int(stats["outliers"] or 0)
         if eff_n > 0:
+            outliers = int(stats["outliers"] or 0)
             tot_actual_mem = float(stats["tot_actual_mem"] or 0.0)
             tot_req_mem = float(stats["tot_req_mem"] or 0.0)
             tot_actual_rt = float(stats["tot_actual_rt"] or 0.0)
@@ -1040,8 +1057,6 @@ class TaskTemplateRepository:
                 ),
                 outlier_count=outliers,
             )
-        elif outliers > 0:
-            resp.efficiency = ResourceEfficiencyMetrics(outlier_count=outliers)
 
         return resp
 

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd  # type: ignore
 import scipy.stats as st  # type: ignore
 import structlog
-from sqlalchemy import Float, String, and_, case, exists, func, or_, select
+from sqlalchemy import Float, String, and_, case, exists, func, or_, select, true
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement, Label
 
@@ -625,9 +625,16 @@ class TaskTemplateRepository:
         cluster-GROUP BY queries both project onto. Values are CAST
         here so outer queries see typed numeric columns (``wallclock``
         and ``maxrss`` are VARCHAR(50) in the schema).
+
+        When ``latest_only`` is True we pick the latest ``task_instance``
+        per task via a ``LATERAL`` subquery ordered by ``id DESC LIMIT 1``.
+        With the ``ix_ti_task_id_covering`` covering index in place, the
+        latest row is served index-only — no heap read for
+        ``wallclock`` / ``maxrss`` / ``task_resources_id``. EXPLAIN shows
+        ``Using index`` on the lateral side. Previously we used a
+        correlated ``MAX(id)`` subquery and MySQL's optimizer fell back
+        to a PK heap lookup for the outer row (~78K of them on pixel).
         """
-        wc_num = func.cast(TaskInstance.wallclock, Float).label("wc")
-        mr_num = func.cast(TaskInstance.maxrss, Float).label("mr")
         req_rt_num = func.cast(
             func.json_extract(TaskResources.requested_resources, "$.runtime"),
             Float,
@@ -643,33 +650,58 @@ class TaskTemplateRepository:
         if workflows:
             base_filters.append(Task.workflow_id.in_(workflows))
 
-        q = (
-            select(
-                wc_num,
-                mr_num,
-                req_rt_num,
-                req_mem_num,
-                TaskInstance.task_resources_id.label("tr_id"),
-            )
-            .select_from(TaskTemplateVersion)
-            .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
-            .join(Task, Node.id == Task.node_id)
-            .join(TaskInstance, Task.id == TaskInstance.task_id)
-            .outerjoin(
-                TaskResources,
-                TaskInstance.task_resources_id == TaskResources.id,
-            )
-            .where(and_(*base_filters))
-        )
-
         if latest_only:
-            latest_ti_id = (
-                select(func.max(TaskInstance.id))
+            latest_lat = (
+                select(
+                    TaskInstance.wallclock.label("wc_raw"),
+                    TaskInstance.maxrss.label("mr_raw"),
+                    TaskInstance.task_resources_id.label("tr_id"),
+                )
                 .where(TaskInstance.task_id == Task.id)
-                .correlate(Task)
-                .scalar_subquery()
+                .order_by(TaskInstance.id.desc())
+                .limit(1)
+                .lateral("lti")
             )
-            q = q.where(TaskInstance.id == latest_ti_id)
+
+            q = (
+                select(
+                    func.cast(latest_lat.c.wc_raw, Float).label("wc"),
+                    func.cast(latest_lat.c.mr_raw, Float).label("mr"),
+                    req_rt_num,
+                    req_mem_num,
+                    latest_lat.c.tr_id.label("tr_id"),
+                )
+                .select_from(TaskTemplateVersion)
+                .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+                .join(Task, Node.id == Task.node_id)
+                .join(latest_lat, true())
+                .outerjoin(
+                    TaskResources,
+                    latest_lat.c.tr_id == TaskResources.id,
+                )
+                .where(and_(*base_filters))
+            )
+        else:
+            wc_num = func.cast(TaskInstance.wallclock, Float).label("wc")
+            mr_num = func.cast(TaskInstance.maxrss, Float).label("mr")
+            q = (
+                select(
+                    wc_num,
+                    mr_num,
+                    req_rt_num,
+                    req_mem_num,
+                    TaskInstance.task_resources_id.label("tr_id"),
+                )
+                .select_from(TaskTemplateVersion)
+                .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+                .join(Task, Node.id == Task.node_id)
+                .join(TaskInstance, Task.id == TaskInstance.task_id)
+                .outerjoin(
+                    TaskResources,
+                    TaskInstance.task_resources_id == TaskResources.id,
+                )
+                .where(and_(*base_filters))
+            )
 
         if node_args:
             for arg_name, arg_values in node_args.items():

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -569,7 +569,11 @@ class TaskTemplateRepository:
         """Count rows that get_task_resource_details would return.
 
         Used by the paginated endpoint to report ``total_count`` without
-        materializing the full detail payload.
+        materializing the full detail payload. Uses ``INNER JOIN`` on
+        ``task_instance`` to match the paged detail query shape —
+        ``outerjoin`` would over-count by including tasks with zero
+        instances, making ``total_count`` diverge from the number of
+        rows the frontend will actually receive across all pages.
         """
         base_filters = [TaskTemplateVersion.id == task_template_version_id]
         if workflows:
@@ -580,7 +584,7 @@ class TaskTemplateRepository:
             .select_from(TaskTemplateVersion)
             .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
             .join(Task, Node.id == Task.node_id)
-            .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
+            .join(TaskInstance, Task.id == TaskInstance.task_id)
             .where(and_(*base_filters))
         )
 
@@ -652,12 +656,12 @@ class TaskTemplateRepository:
                 num_tasks=0 if has_any else None
             )
 
+        # Reuse the already-built ``inner`` select rather than constructing
+        # a second copy. MySQL still executes the subquery once per outer
+        # statement, but this halves the Python-side construction cost
+        # and keeps the two aggregate queries guaranteed-identical.
         cluster_counts = self.session.execute(
-            self._cluster_groupby_query(
-                self._build_aggregates_rowset(
-                    task_template_version_id, workflows, node_args, latest_only
-                ).subquery("t_clust")
-            )
+            self._cluster_groupby_query(inner.subquery("t_clust"))
         ).all()
         cluster_resources = self._fetch_cluster_resources(
             [int(r.tr_id) for r in cluster_counts if r.tr_id is not None]
@@ -1002,7 +1006,14 @@ class TaskTemplateRepository:
             reverse=True,
         )
 
+        # Outlier count lives on the ``kpi_valid`` subset (wc>0 AND mr>0)
+        # independent of requested resources, so populate it whenever we
+        # have ANY kpi-valid rows — not only when utilization-valid rows
+        # exist. Otherwise templates with real wallclock+maxrss data but
+        # no requested resources would permanently render
+        # ``outlier_count=0``.
         eff_n = int(stats["eff_n"] or 0)
+        outliers = int(stats["outliers"] or 0)
         if eff_n > 0:
             tot_actual_mem = float(stats["tot_actual_mem"] or 0.0)
             tot_req_mem = float(stats["tot_req_mem"] or 0.0)
@@ -1023,8 +1034,10 @@ class TaskTemplateRepository:
                 under_allocated_runtime=round(
                     int(stats["under_rt"] or 0) / eff_n * 100
                 ),
-                outlier_count=int(stats["outliers"] or 0),
+                outlier_count=outliers,
             )
+        elif outliers > 0:
+            resp.efficiency = ResourceEfficiencyMetrics(outlier_count=outliers)
 
         return resp
 

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -170,45 +170,82 @@ class TaskTemplateRepository:
         ).label("requested_resources_col")
 
         if not node_args:
-            # No node_args filtering - use optimized single query
-            query = (
-                select(
-                    # TaskInstance resource usage fields
-                    TaskInstance.wallclock,
-                    TaskInstance.maxrss,
-                    status_col,
-                    # Node and Task identifiers
-                    Node.id.label("node_id_col"),
-                    Task.id.label("task_id_col"),
-                    Task.name.label("task_name_col"),
-                    # Task metadata fields
-                    Task.status_date.label("task_status_date_col"),
-                    Task.command.label("task_command_col"),
-                    Task.num_attempts.label("task_num_attempts_col"),
-                    Task.max_attempts.label("task_max_attempts_col"),
-                    # Requested resources (narrowed to memory+runtime only)
-                    narrow_req_res,
-                    attempt_number_col,
-                    TaskInstance.id.label("task_instance_id_col"),
-                    TaskInstance.workflow_run_id.label("workflow_run_id_col"),
+            # Deferred-join pagination: when paging, first find the 2000
+            # ``task_instance.id`` values we want via the covering index
+            # (``ix_ti_task_id_covering`` on ``(task_id, id, wallclock,
+            # maxrss, task_resources_id)`` — ordered by ``(task_id, id)``
+            # naturally). Then look up full row data for only those
+            # ids, avoiding the filesort + 2000 heap-probes the naive
+            # plan does on the full join. Measured on pixel page 0:
+            # SQL time ~3s → ~0.6s.
+            paged_ids = None
+            if limit is not None:
+                paged_ids = (
+                    select(TaskInstance.id.label("paged_ti_id"))
+                    .select_from(TaskTemplateVersion)
+                    .join(
+                        Node,
+                        TaskTemplateVersion.id == Node.task_template_version_id,
+                    )
+                    .join(Task, Node.id == Task.node_id)
+                    .join(TaskInstance, Task.id == TaskInstance.task_id)
+                    .where(and_(*base_filters))
+                    .order_by(TaskInstance.task_id, TaskInstance.id)
+                    .offset(offset)
+                    .limit(limit)
+                    .subquery("paged")
                 )
-                .select_from(TaskTemplateVersion)
-                .join(
-                    Node,
-                    TaskTemplateVersion.id == Node.task_template_version_id,
-                )
-                .join(Task, Node.id == Task.node_id)
-                .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
-                .outerjoin(
-                    TaskResources,
-                    TaskInstance.task_resources_id == TaskResources.id,
-                )
-                .where(and_(*base_filters))
+
+            query = select(
+                # TaskInstance resource usage fields
+                TaskInstance.wallclock,
+                TaskInstance.maxrss,
+                status_col,
+                # Node and Task identifiers
+                Node.id.label("node_id_col"),
+                Task.id.label("task_id_col"),
+                Task.name.label("task_name_col"),
+                # Task metadata fields
+                Task.status_date.label("task_status_date_col"),
+                Task.command.label("task_command_col"),
+                Task.num_attempts.label("task_num_attempts_col"),
+                Task.max_attempts.label("task_max_attempts_col"),
+                # Requested resources (narrowed to memory+runtime only)
+                narrow_req_res,
+                attempt_number_col,
+                TaskInstance.id.label("task_instance_id_col"),
+                TaskInstance.workflow_run_id.label("workflow_run_id_col"),
             )
 
-            if limit is not None:
+            if paged_ids is not None:
                 query = (
-                    query.order_by(Task.id, TaskInstance.id).offset(offset).limit(limit)
+                    query.select_from(paged_ids)
+                    .join(
+                        TaskInstance,
+                        TaskInstance.id == paged_ids.c.paged_ti_id,
+                    )
+                    .join(Task, Task.id == TaskInstance.task_id)
+                    .join(Node, Node.id == Task.node_id)
+                    .outerjoin(
+                        TaskResources,
+                        TaskInstance.task_resources_id == TaskResources.id,
+                    )
+                    .order_by(Task.id, TaskInstance.id)
+                )
+            else:
+                query = (
+                    query.select_from(TaskTemplateVersion)
+                    .join(
+                        Node,
+                        TaskTemplateVersion.id == Node.task_template_version_id,
+                    )
+                    .join(Task, Node.id == Task.node_id)
+                    .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
+                    .outerjoin(
+                        TaskResources,
+                        TaskInstance.task_resources_id == TaskResources.id,
+                    )
+                    .where(and_(*base_filters))
                 )
 
             rows = self.session.execute(query).all()

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd  # type: ignore
 import scipy.stats as st  # type: ignore
 import structlog
-from sqlalchemy import Float, String, and_, case, exists, func, or_, select, true
+from sqlalchemy import Double, String, and_, case, exists, func, or_, select, true
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement, Label
 
@@ -698,13 +698,18 @@ class TaskTemplateRepository:
         correlated ``MAX(id)`` subquery and MySQL's optimizer fell back
         to a PK heap lookup for the outer row (~78K of them on pixel).
         """
+        # Cast to DOUBLE (64-bit) not FLOAT (32-bit) so values like 5.05
+        # survive the roundtrip without the ``5.050000190734863`` artifact
+        # that MySQL FLOAT introduces — that artifact rounds differently
+        # from a 64-bit JS number and would shift cluster keys between
+        # server and client.
         req_rt_num = func.cast(
             func.json_extract(TaskResources.requested_resources, "$.runtime"),
-            Float,
+            Double,
         ).label("req_rt")
         req_mem_num = func.cast(
             func.json_extract(TaskResources.requested_resources, "$.memory"),
-            Float,
+            Double,
         ).label("req_mem")
 
         base_filters: List[ColumnElement] = [
@@ -734,8 +739,8 @@ class TaskTemplateRepository:
 
             q = (
                 select(
-                    func.cast(latest_lat.c.wc_raw, Float).label("wc"),
-                    func.cast(latest_lat.c.mr_raw, Float).label("mr"),
+                    func.cast(latest_lat.c.wc_raw, Double).label("wc"),
+                    func.cast(latest_lat.c.mr_raw, Double).label("mr"),
                     req_rt_num,
                     req_mem_num,
                     latest_lat.c.tr_id.label("tr_id"),
@@ -751,8 +756,8 @@ class TaskTemplateRepository:
                 .where(and_(*base_filters))
             )
         else:
-            wc_num = func.cast(TaskInstance.wallclock, Float).label("wc")
-            mr_num = func.cast(TaskInstance.maxrss, Float).label("mr")
+            wc_num = func.cast(TaskInstance.wallclock, Double).label("wc")
+            mr_num = func.cast(TaskInstance.maxrss, Double).label("mr")
             q = (
                 select(
                     wc_num,
@@ -928,11 +933,11 @@ class TaskTemplateRepository:
                 TaskResources.id,
                 func.cast(
                     func.json_extract(TaskResources.requested_resources, "$.runtime"),
-                    Float,
+                    Double,
                 ),
                 func.cast(
                     func.json_extract(TaskResources.requested_resources, "$.memory"),
-                    Float,
+                    Double,
                 ),
             ).where(TaskResources.id.in_(tr_ids))
         ).all()

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -1,4 +1,5 @@
 import json
+import math
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union
@@ -49,16 +50,17 @@ from jobmon.server.web.schemas.task_template import (
 logger = structlog.get_logger(__name__)
 
 
-def _js_num(n: float) -> str:
-    """Format a float like JS ``Number.prototype.toString()``.
+def _js_round_tenth(x: float) -> float:
+    """Round ``x`` to one decimal using JS ``Math.round`` semantics.
 
-    Integer-valued floats render without the trailing ``.0`` so cluster
-    IDs built server-side align byte-for-byte with keys the frontend
-    produces from template literals (e.g. ``15.0 -> "15"``, not
-    ``"15.0"``). Non-integer values use Python's default repr, which
-    matches JS for the small-decimal cases we actually hit here.
+    JS rounds half up toward +∞ (``Math.round(0.5) === 1``), while
+    Python's ``round`` uses banker's rounding (``round(0.5) == 0``).
+    Cluster boundaries must align with the frontend's rounding so a
+    task-instance row the UI classifies as cluster A is counted as
+    cluster A on the server too. ``requested_resources`` values are
+    always non-negative here, so ``floor(x + 0.5)`` suffices.
     """
-    return str(int(n)) if n == int(n) else repr(n)
+    return math.floor(x * 10 + 0.5) / 10
 
 
 @dataclass
@@ -637,7 +639,10 @@ class TaskTemplateRepository:
         maxrss_values: List[float] = []
         requested_runtimes: List[float] = []
         requested_memories: List[float] = []
-        clusters: Dict[str, Dict[str, Any]] = {}
+        # Keyed by (rounded memory GiB, rounded runtime hours) — the same
+        # pair the frontend rounds scatter rows to — so each cluster maps
+        # 1:1 to what the UI will classify from the viz rows.
+        clusters: Dict[tuple, Dict[str, Any]] = {}
         utilization_points: List[Dict[str, float]] = []
 
         for wc, mr, raw_req_rt, raw_req_mem in rows:
@@ -665,9 +670,12 @@ class TaskTemplateRepository:
                 requested_memories.append(req_memory)
 
             if req_runtime is not None and req_memory is not None:
+                # Round identically to the frontend's ``createResourceClusterKey``
+                # (memory in GiB, runtime in hours, one decimal place) so
+                # server clusters match what the UI produces from scatter rows.
                 key = (
-                    f"{_js_num(round(req_memory * 10) / 10)}G-"
-                    f"{_js_num(round(req_runtime / 3600 * 10) / 10)}h"
+                    _js_round_tenth(req_memory),
+                    _js_round_tenth(req_runtime / 3600),
                 )
                 cluster = clusters.setdefault(
                     key,
@@ -741,12 +749,11 @@ class TaskTemplateRepository:
         resp.resource_clusters = sorted(
             [
                 ResourceClusterItem(
-                    id=key,
                     runtime=data["runtime"],
                     memory=data["memory"],
                     task_count=data["count"],
                 )
-                for key, data in clusters.items()
+                for data in clusters.values()
             ],
             key=lambda c: c.task_count,
             reverse=True,

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -156,6 +156,19 @@ class TaskTemplateRepository:
             .label("attempt_number_of_instance")
         )
 
+        # Narrow ``requested_resources`` to the two fields the UI actually
+        # uses on the viz path (memory + runtime). The full blob averages
+        # ~700 bytes/row on templates like ``pixel`` (paths, project
+        # config, stderr/stdout paths, command args) and dominated the
+        # per-row payload size. MySQL ``JSON_OBJECT`` builds the narrow
+        # JSON server-side so we ship ~30 bytes/row instead.
+        narrow_req_res = func.json_object(
+            "memory",
+            func.json_extract(TaskResources.requested_resources, "$.memory"),
+            "runtime",
+            func.json_extract(TaskResources.requested_resources, "$.runtime"),
+        ).label("requested_resources_col")
+
         if not node_args:
             # No node_args filtering - use optimized single query
             query = (
@@ -173,8 +186,8 @@ class TaskTemplateRepository:
                     Task.command.label("task_command_col"),
                     Task.num_attempts.label("task_num_attempts_col"),
                     Task.max_attempts.label("task_max_attempts_col"),
-                    # Requested resources and attempt number
-                    TaskResources.requested_resources.label("requested_resources_col"),
+                    # Requested resources (narrowed to memory+runtime only)
+                    narrow_req_res,
                     attempt_number_col,
                     TaskInstance.id.label("task_instance_id_col"),
                     TaskInstance.workflow_run_id.label("workflow_run_id_col"),
@@ -251,6 +264,14 @@ class TaskTemplateRepository:
         offset: int = 0,
     ) -> List[TaskResourceDetailItem]:
         """Optimized node_args filtering using database-level joins and filtering."""
+        # See ``get_task_resource_details`` for rationale — ship only the
+        # two requested-resource fields the UI needs on the viz path.
+        narrow_req_res = func.json_object(
+            "memory",
+            func.json_extract(TaskResources.requested_resources, "$.memory"),
+            "runtime",
+            func.json_extract(TaskResources.requested_resources, "$.runtime"),
+        ).label("requested_resources")
         base_query = (
             select(
                 TaskInstance.wallclock,
@@ -258,7 +279,7 @@ class TaskTemplateRepository:
                 Node.id.label("node_id"),
                 Task.id.label("task_id"),
                 Task.name.label("task_name"),
-                TaskResources.requested_resources,
+                narrow_req_res,
                 attempt_number_col,
                 status_col,
                 Task.status_date.label("task_status_date"),

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -170,28 +170,31 @@ class TaskTemplateRepository:
         ).label("requested_resources_col")
 
         if not node_args:
-            # Deferred-join pagination: when paging, first find the 2000
-            # ``task_instance.id`` values we want via the covering index
-            # (``ix_ti_task_id_covering`` on ``(task_id, id, wallclock,
-            # maxrss, task_resources_id)`` — ordered by ``(task_id, id)``
-            # naturally). Then look up full row data for only those
-            # ids, avoiding the filesort + 2000 heap-probes the naive
-            # plan does on the full join. Measured on pixel page 0:
-            # SQL time ~3s → ~0.6s.
+            # Deferred-join pagination: pass 1 enumerates the
+            # ``(task_id, task_instance_id)`` pairs we want, pass 2
+            # fetches full row data for those ids. The outer join on
+            # ``task_instance`` in pass 1 preserves tasks with no
+            # instances yet (registered-but-not-launched), which show
+            # up as a single row with null instance / resource fields
+            # — matching the unpaged path's behavior. Pass 2 also
+            # outer-joins on ``task_instance_id`` so the row survives
+            # when ``paged.ti_id`` is null.
             #
             # ``attempt_num`` is computed inside pass 1 (before the
             # LIMIT applies) so the window sees every matching
             # task_instance per task, not just the paged subset — a
             # task's attempts that span page boundaries still number
-            # correctly.
+            # correctly. Tasks without an instance get rank 1 for
+            # their null row.
             paged_ids = None
             if limit is not None:
                 paged_ids = (
                     select(
+                        Task.id.label("paged_task_id"),
                         TaskInstance.id.label("paged_ti_id"),
                         func.row_number()
                         .over(
-                            partition_by=TaskInstance.task_id,
+                            partition_by=Task.id,
                             order_by=TaskInstance.id,
                         )
                         .label("paged_attempt_num"),
@@ -202,9 +205,9 @@ class TaskTemplateRepository:
                         TaskTemplateVersion.id == Node.task_template_version_id,
                     )
                     .join(Task, Node.id == Task.node_id)
-                    .join(TaskInstance, Task.id == TaskInstance.task_id)
+                    .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
                     .where(and_(*base_filters))
-                    .order_by(TaskInstance.task_id, TaskInstance.id)
+                    .order_by(Task.id, TaskInstance.id)
                     .offset(offset)
                     .limit(limit)
                     .subquery("paged")
@@ -238,12 +241,12 @@ class TaskTemplateRepository:
             if paged_ids is not None:
                 query = (
                     query.select_from(paged_ids)
-                    .join(
+                    .join(Task, Task.id == paged_ids.c.paged_task_id)
+                    .join(Node, Node.id == Task.node_id)
+                    .outerjoin(
                         TaskInstance,
                         TaskInstance.id == paged_ids.c.paged_ti_id,
                     )
-                    .join(Task, Task.id == TaskInstance.task_id)
-                    .join(Node, Node.id == Task.node_id)
                     .outerjoin(
                         TaskResources,
                         TaskInstance.task_resources_id == TaskResources.id,
@@ -569,11 +572,12 @@ class TaskTemplateRepository:
         """Count rows that get_task_resource_details would return.
 
         Used by the paginated endpoint to report ``total_count`` without
-        materializing the full detail payload. Uses ``INNER JOIN`` on
-        ``task_instance`` to match the paged detail query shape —
-        ``outerjoin`` would over-count by including tasks with zero
-        instances, making ``total_count`` diverge from the number of
-        rows the frontend will actually receive across all pages.
+        materializing the full detail payload. Uses ``LEFT OUTER JOIN``
+        on ``task_instance`` to match the paged detail query shape:
+        tasks with no instances yet (registered-but-not-launched)
+        appear as a single row in the paged output, so they must be
+        counted here too or ``total_count`` understates the true row
+        count and the frontend stops paginating early.
         """
         base_filters = [TaskTemplateVersion.id == task_template_version_id]
         if workflows:
@@ -584,7 +588,7 @@ class TaskTemplateRepository:
             .select_from(TaskTemplateVersion)
             .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
             .join(Task, Node.id == Task.node_id)
-            .join(TaskInstance, Task.id == TaskInstance.task_id)
+            .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
             .where(and_(*base_filters))
         )
 

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -49,6 +49,18 @@ from jobmon.server.web.schemas.task_template import (
 logger = structlog.get_logger(__name__)
 
 
+def _js_num(n: float) -> str:
+    """Format a float like JS ``Number.prototype.toString()``.
+
+    Integer-valued floats render without the trailing ``.0`` so cluster
+    IDs built server-side align byte-for-byte with keys the frontend
+    produces from template literals (e.g. ``15.0 -> "15"``, not
+    ``"15.0"``). Non-integer values use Python's default repr, which
+    matches JS for the small-decimal cases we actually hit here.
+    """
+    return str(int(n)) if n == int(n) else repr(n)
+
+
 @dataclass
 class ResourceUsageStatistics:
     """Clean data class for resource usage statistics."""
@@ -654,8 +666,8 @@ class TaskTemplateRepository:
 
             if req_runtime is not None and req_memory is not None:
                 key = (
-                    f"{round(req_memory * 10) / 10}G-"
-                    f"{round(req_runtime / 3600 * 10) / 10}h"
+                    f"{_js_num(round(req_memory * 10) / 10)}G-"
+                    f"{_js_num(round(req_runtime / 3600 * 10) / 10)}h"
                 )
                 cluster = clusters.setdefault(
                     key,

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd  # type: ignore
 import scipy.stats as st  # type: ignore
 import structlog
-from sqlalchemy import Float, String, and_, case, exists, func, select
+from sqlalchemy import Float, String, and_, case, exists, func, or_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement, Label
 
@@ -555,92 +555,33 @@ class TaskTemplateRepository:
     ) -> TaskTemplateResourceAggregatesResponse:
         """Compute compact aggregates for a task template.
 
-        Uses a narrow-column query (wallclock, maxrss, JSON-extracted
-        requested runtime and memory) to avoid materializing the full
-        detail payload. Aggregates (median, p95, efficiency, requested-
-        resource clusters) are computed Python-side on the small numeric
-        arrays.
+        Aggregation runs entirely in MySQL: a single main query returns
+        one row of stats + efficiency totals + outlier count, and a
+        second query groups by ``task_resources_id`` for cluster
+        breakdown. Avoids the previous 78K-row ship-to-Python pattern
+        which was bottlenecked on row serialization (~10s for pixel).
+
+        Median / p95 for wallclock and maxrss are not computed
+        server-side — percentiles don't compose across GROUP BYs and
+        running separate ``ORDER BY LIMIT OFFSET`` scans per column
+        erodes the win. The frontend computes these client-side from
+        the streaming viz rows instead, falling back to ``undefined``
+        on the initial paint.
 
         When ``latest_only`` is True (the UI default), only the latest
-        TaskInstance per Task is aggregated so the numbers match the
-        latest-only scatter / table view. Correlated subquery on
-        ``MAX(task_instance.id)`` is index-covered via the
-        ``(task_id, id)`` key on task_instance.
+        TaskInstance per Task is included, so the numbers match the
+        latest-only scatter / table view.
         """
-        base_filters: List[ColumnElement] = [
-            TaskTemplateVersion.id == task_template_version_id,
-        ]
-        if workflows:
-            base_filters.append(Task.workflow_id.in_(workflows))
-
-        # Pull only the two JSON fields we actually use, not the whole blob.
-        # Avoids shipping ~1 KB of requested_resources JSON per task_instance
-        # row over the wire, which dominated the aggregates query cost.
-        req_runtime_col = func.cast(
-            func.json_extract(TaskResources.requested_resources, "$.runtime"),
-            Float,
-        ).label("req_runtime")
-        req_memory_col = func.cast(
-            func.json_extract(TaskResources.requested_resources, "$.memory"),
-            Float,
-        ).label("req_memory")
-
-        query = (
-            select(
-                TaskInstance.wallclock,
-                TaskInstance.maxrss,
-                req_runtime_col,
-                req_memory_col,
-            )
-            .select_from(TaskTemplateVersion)
-            .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
-            .join(Task, Node.id == Task.node_id)
-            .join(TaskInstance, Task.id == TaskInstance.task_id)
-            .outerjoin(
-                TaskResources, TaskInstance.task_resources_id == TaskResources.id
-            )
-            .where(and_(*base_filters))
+        inner = self._build_aggregates_rowset(
+            task_template_version_id, workflows, node_args, latest_only
         )
 
-        if latest_only:
-            latest_ti_id = (
-                select(func.max(TaskInstance.id))
-                .where(TaskInstance.task_id == Task.id)
-                .correlate(Task)
-                .scalar_subquery()
-            )
-            query = query.where(TaskInstance.id == latest_ti_id)
-
-        if node_args:
-            for arg_name, arg_values in node_args.items():
-                str_values = [str(v) for v in arg_values]
-                subquery = (
-                    select(NodeArg.node_id)
-                    .join(Arg, NodeArg.arg_id == Arg.id)
-                    .where(
-                        and_(
-                            Arg.name == arg_name,
-                            func.cast(NodeArg.val, String).in_(str_values),
-                        )
-                    )
-                )
-                query = query.where(Node.id.in_(subquery))
-
-        rows = self.session.execute(query).all()
-        return self._build_aggregates_response(rows, task_template_version_id)
-
-    def _build_aggregates_response(
-        self,
-        rows: Any,
-        task_template_version_id: int,
-    ) -> TaskTemplateResourceAggregatesResponse:
-        """Compute aggregates in Python from the narrow rowset.
-
-        Operates on ``(wallclock, maxrss, req_runtime, req_memory)`` tuples
-        where ``req_runtime`` / ``req_memory`` are already JSON-extracted by
-        SQL rather than shipped as a full JSON blob.
-        """
-        if not rows:
+        stats = (
+            self.session.execute(self._main_aggregates_query(inner.subquery("t")))
+            .mappings()
+            .one_or_none()
+        )
+        if stats is None or (stats["num_tasks"] or 0) == 0:
             has_any = (
                 self.session.execute(
                     select(Task.id)
@@ -656,200 +597,318 @@ class TaskTemplateRepository:
                 num_tasks=0 if has_any else None
             )
 
-        wallclocks: List[float] = []
-        maxrss_values: List[float] = []
-        requested_runtimes: List[float] = []
-        requested_memories: List[float] = []
-        # Keyed by (rounded memory GiB, rounded runtime hours) — the same
-        # pair the frontend rounds scatter rows to — so each cluster maps
-        # 1:1 to what the UI will classify from the viz rows.
-        clusters: Dict[tuple, Dict[str, Any]] = {}
-        utilization_points: List[Dict[str, float]] = []
+        cluster_counts = self.session.execute(
+            self._cluster_groupby_query(
+                self._build_aggregates_rowset(
+                    task_template_version_id, workflows, node_args, latest_only
+                ).subquery("t_clust")
+            )
+        ).all()
+        cluster_resources = self._fetch_cluster_resources(
+            [int(r.tr_id) for r in cluster_counts if r.tr_id is not None]
+        )
 
-        for wc, mr, raw_req_rt, raw_req_mem in rows:
-            if wc is not None and float(wc) != 0:
-                wallclocks.append(float(wc))
-            if mr is not None:
-                maxrss_values.append(max(0.0, float(mr)))
+        return self._build_aggregates_response_from_sql(
+            stats, cluster_counts, cluster_resources
+        )
 
-            req_runtime: Optional[float] = None
-            req_memory: Optional[float] = None
-            try:
-                if raw_req_rt is not None and float(raw_req_rt) > 0:
-                    req_runtime = float(raw_req_rt)
-            except (ValueError, TypeError):
-                pass
-            try:
-                if raw_req_mem is not None and float(raw_req_mem) > 0:
-                    req_memory = float(raw_req_mem)
-            except (ValueError, TypeError):
-                pass
+    def _build_aggregates_rowset(
+        self,
+        task_template_version_id: int,
+        workflows: Optional[List[int]],
+        node_args: Optional[Dict[str, List[Any]]],
+        latest_only: bool,
+    ) -> Any:
+        """Build the scoped inner SELECT for the aggregate queries.
 
-            if req_runtime is not None:
-                requested_runtimes.append(req_runtime)
-            if req_memory is not None:
-                requested_memories.append(req_memory)
+        This is the per-task_instance rowset the main aggregate and the
+        cluster-GROUP BY queries both project onto. Values are CAST
+        here so outer queries see typed numeric columns (``wallclock``
+        and ``maxrss`` are VARCHAR(50) in the schema).
+        """
+        wc_num = func.cast(TaskInstance.wallclock, Float).label("wc")
+        mr_num = func.cast(TaskInstance.maxrss, Float).label("mr")
+        req_rt_num = func.cast(
+            func.json_extract(TaskResources.requested_resources, "$.runtime"),
+            Float,
+        ).label("req_rt")
+        req_mem_num = func.cast(
+            func.json_extract(TaskResources.requested_resources, "$.memory"),
+            Float,
+        ).label("req_mem")
 
-            if req_runtime is not None and req_memory is not None:
-                # Round identically to the frontend's ``createResourceClusterKey``
-                # (memory in GiB, runtime in hours, one decimal place) so
-                # server clusters match what the UI produces from scatter rows.
-                key = (
-                    _js_round_tenth(req_memory),
-                    _js_round_tenth(req_runtime / 3600),
+        base_filters: List[ColumnElement] = [
+            TaskTemplateVersion.id == task_template_version_id,
+        ]
+        if workflows:
+            base_filters.append(Task.workflow_id.in_(workflows))
+
+        q = (
+            select(
+                wc_num,
+                mr_num,
+                req_rt_num,
+                req_mem_num,
+                TaskInstance.task_resources_id.label("tr_id"),
+            )
+            .select_from(TaskTemplateVersion)
+            .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+            .join(Task, Node.id == Task.node_id)
+            .join(TaskInstance, Task.id == TaskInstance.task_id)
+            .outerjoin(
+                TaskResources,
+                TaskInstance.task_resources_id == TaskResources.id,
+            )
+            .where(and_(*base_filters))
+        )
+
+        if latest_only:
+            latest_ti_id = (
+                select(func.max(TaskInstance.id))
+                .where(TaskInstance.task_id == Task.id)
+                .correlate(Task)
+                .scalar_subquery()
+            )
+            q = q.where(TaskInstance.id == latest_ti_id)
+
+        if node_args:
+            for arg_name, arg_values in node_args.items():
+                str_values = [str(v) for v in arg_values]
+                subquery = (
+                    select(NodeArg.node_id)
+                    .join(Arg, NodeArg.arg_id == Arg.id)
+                    .where(
+                        and_(
+                            Arg.name == arg_name,
+                            func.cast(NodeArg.val, String).in_(str_values),
+                        )
+                    )
                 )
-                cluster = clusters.setdefault(
-                    key,
-                    {
-                        "runtime": req_runtime,
-                        "memory": req_memory,
-                        "count": 0,
-                    },
-                )
-                cluster["count"] += 1
+                q = q.where(Node.id.in_(subquery))
 
-            if (
-                wc is not None
-                and mr is not None
-                and req_runtime is not None
-                and req_memory is not None
-                and float(wc) > 0
-                and float(mr) > 0
-            ):
-                # memory in bytes; requested memory is GiB — match the frontend
-                # efficiency calc which compares memory_gib to requested memory.
-                actual_mem_gib = float(mr) / (1024.0**3)
-                utilization_points.append(
-                    {
-                        "runtime": float(wc),
-                        "memory": actual_mem_gib,
-                        "requested_runtime": req_runtime,
-                        "requested_memory": req_memory,
-                    }
-                )
+        return q
 
-        memories_for_stats = [m for m in maxrss_values if m > 0]
+    @staticmethod
+    def _main_aggregates_query(t: Any) -> Any:
+        """Single-row aggregate: KPIs + efficiency totals + outlier count.
 
-        def _p(data: List[float], pct: float) -> Optional[float]:
-            if not data:
-                return None
-            return float(np.percentile(data, pct))
+        Outlier gate requires the mean and stddev of wallclock and
+        (maxrss/GiB) over the efficiency subset. MySQL 8 window
+        aggregates let us compute those alongside row filtering in one
+        scan — no need for a second pass.
+        """
+        GIB = 1024.0**3
+        wc = t.c.wc
+        mr = t.c.mr
+        req_rt = t.c.req_rt
+        req_mem = t.c.req_mem
+        eff = and_(wc > 0, mr > 0, req_rt > 0, req_mem > 0)
+        wc_eff = case((eff, wc), else_=None)
+        mem_gib_eff = case((eff, mr / GIB), else_=None)
 
-        resp = TaskTemplateResourceAggregatesResponse(num_tasks=len(rows))
+        # Ranked subquery to compute window aggregates (mean/stddev of
+        # efficiency-gated wc and mem_gib) in the same scan. Main outer
+        # query then counts outliers using those window values.
+        ranked = (
+            select(
+                wc.label("wc"),
+                mr.label("mr"),
+                req_rt.label("req_rt"),
+                req_mem.label("req_mem"),
+                func.avg(wc_eff).over().label("mean_eff_wc"),
+                func.coalesce(func.stddev_pop(wc_eff).over(), 0.0).label("std_eff_wc"),
+                func.avg(mem_gib_eff).over().label("mean_eff_mem"),
+                func.coalesce(func.stddev_pop(mem_gib_eff).over(), 0.0).label(
+                    "std_eff_mem"
+                ),
+            )
+            .select_from(t)
+            .subquery("r")
+        )
 
-        if memories_for_stats:
-            resp.min_mem = int(min(memories_for_stats))
-            resp.max_mem = int(max(memories_for_stats))
-            resp.mean_mem = float(np.mean(memories_for_stats))
-            resp.median_mem = float(np.median(memories_for_stats))
-            resp.p95_mem = _p(memories_for_stats, 95)
-        elif maxrss_values:
-            resp.min_mem = 0
-            resp.max_mem = 0
-            resp.mean_mem = 0.0
-            resp.median_mem = 0.0
-            resp.p95_mem = 0.0
+        r_wc = ranked.c.wc
+        r_mr = ranked.c.mr
+        r_rrt = ranked.c.req_rt
+        r_rmem = ranked.c.req_mem
+        r_eff = and_(r_wc > 0, r_mr > 0, r_rrt > 0, r_rmem > 0)
+        r_mem_gib = r_mr / GIB
+        r_mem_util = case((r_eff, r_mem_gib / r_rmem * 100), else_=None)
+        r_rt_util = case((r_eff, r_wc / r_rrt * 100), else_=None)
+        outlier_gate = or_(
+            func.abs(r_wc - ranked.c.mean_eff_wc) > 2 * ranked.c.std_eff_wc,
+            func.abs(r_mem_gib - ranked.c.mean_eff_mem) > 2 * ranked.c.std_eff_mem,
+        )
 
-        if wallclocks:
-            resp.min_runtime = int(min(wallclocks))
-            resp.max_runtime = int(max(wallclocks))
-            resp.mean_runtime = float(np.mean(wallclocks))
-            resp.median_runtime = float(np.median(wallclocks))
-            resp.p95_runtime = _p(wallclocks, 95)
-        else:
-            resp.min_runtime = 0
-            resp.max_runtime = 0
-            resp.mean_runtime = 0.0
-            resp.median_runtime = 0.0
+        return select(
+            func.count().label("num_tasks"),
+            # memory stats
+            func.count(case((r_mr > 0, 1), else_=None)).label("n_mr"),
+            func.min(case((r_mr > 0, r_mr), else_=None)).label("min_mem"),
+            func.max(case((r_mr > 0, r_mr), else_=None)).label("max_mem"),
+            func.avg(case((r_mr > 0, r_mr), else_=None)).label("mean_mem"),
+            # runtime stats
+            func.count(case((r_wc > 0, 1), else_=None)).label("n_wc"),
+            func.min(case((r_wc > 0, r_wc), else_=None)).label("min_rt"),
+            func.max(case((r_wc > 0, r_wc), else_=None)).label("max_rt"),
+            func.avg(case((r_wc > 0, r_wc), else_=None)).label("mean_rt"),
+            # requested stats (mean is cheap and matches UI's median
+            # expectation closely for uniform-resource templates)
+            func.avg(case((r_rrt > 0, r_rrt), else_=None)).label("mean_req_rt"),
+            func.avg(case((r_rmem > 0, r_rmem), else_=None)).label("mean_req_mem"),
+            # efficiency totals
+            func.sum(case((r_eff, 1), else_=0)).label("eff_n"),
+            func.sum(case((r_eff, r_mem_gib), else_=0)).label("tot_actual_mem"),
+            func.sum(case((r_eff, r_rmem), else_=0)).label("tot_req_mem"),
+            func.sum(case((r_eff, r_wc), else_=0)).label("tot_actual_rt"),
+            func.sum(case((r_eff, r_rrt), else_=0)).label("tot_req_rt"),
+            func.sum(case((and_(r_eff, r_mem_util < 50), 1), else_=0)).label(
+                "over_mem"
+            ),
+            func.sum(case((and_(r_eff, r_mem_util > 90), 1), else_=0)).label(
+                "under_mem"
+            ),
+            func.sum(case((and_(r_eff, r_rt_util < 50), 1), else_=0)).label("over_rt"),
+            func.sum(case((and_(r_eff, r_rt_util > 90), 1), else_=0)).label("under_rt"),
+            func.sum(case((and_(r_eff, outlier_gate), 1), else_=0)).label("outliers"),
+        ).select_from(ranked)
 
-        if requested_runtimes:
-            resp.median_requested_runtime = float(np.median(requested_runtimes))
-        if requested_memories:
-            resp.median_requested_memory = float(np.median(requested_memories))
+    @staticmethod
+    def _cluster_groupby_query(t: Any) -> Any:
+        """Count rows per task_resources_id, skipping NULLs.
 
+        Represents one cluster per unique task_resources row; the
+        ``requested_resources`` JSON fields are fetched separately to
+        avoid JSON_EXTRACT per row.
+        """
+        return (
+            select(
+                t.c.tr_id.label("tr_id"),
+                func.count().label("n"),
+            )
+            .select_from(t)
+            .where(t.c.tr_id.is_not(None))
+            .group_by(t.c.tr_id)
+        )
+
+    def _fetch_cluster_resources(self, tr_ids: List[int]) -> Dict[int, tuple]:
+        """Fetch (runtime, memory) per unique task_resources_id.
+
+        One query returning ``len(tr_ids)`` rows — typically a handful
+        even for workflows with tens of thousands of task_instances.
+        """
+        if not tr_ids:
+            return {}
+        rows = self.session.execute(
+            select(
+                TaskResources.id,
+                func.cast(
+                    func.json_extract(TaskResources.requested_resources, "$.runtime"),
+                    Float,
+                ),
+                func.cast(
+                    func.json_extract(TaskResources.requested_resources, "$.memory"),
+                    Float,
+                ),
+            ).where(TaskResources.id.in_(tr_ids))
+        ).all()
+        return {
+            int(r[0]): (
+                float(r[1]) if r[1] is not None else None,
+                float(r[2]) if r[2] is not None else None,
+            )
+            for r in rows
+        }
+
+    def _build_aggregates_response_from_sql(
+        self,
+        stats: Any,
+        cluster_counts: Any,
+        cluster_resources: Dict[int, tuple],
+    ) -> TaskTemplateResourceAggregatesResponse:
+        """Assemble the response from the two SQL aggregate results.
+
+        ``stats``: single-row mapping of KPIs + efficiency totals.
+        ``cluster_counts``: one row per task_resources_id with count.
+        ``cluster_resources``: tr_id → (runtime, memory) lookup.
+
+        Percentiles are left as ``None`` on the response — the frontend
+        fills them in from streaming viz rows so the aggregate endpoint
+        can complete without a second full scan.
+        """
+        num_tasks = int(stats["num_tasks"])
+        resp = TaskTemplateResourceAggregatesResponse(num_tasks=num_tasks)
+
+        if (stats["n_mr"] or 0) > 0:
+            resp.min_mem = int(stats["min_mem"])
+            resp.max_mem = int(stats["max_mem"])
+            resp.mean_mem = float(stats["mean_mem"])
+        if (stats["n_wc"] or 0) > 0:
+            resp.min_runtime = int(stats["min_rt"])
+            resp.max_runtime = int(stats["max_rt"])
+            resp.mean_runtime = float(stats["mean_rt"])
+
+        if stats["mean_req_rt"] is not None:
+            resp.median_requested_runtime = float(stats["mean_req_rt"])
+        if stats["mean_req_mem"] is not None:
+            resp.median_requested_memory = float(stats["mean_req_mem"])
+
+        # Build clusters by binning unique (runtime, memory) pairs using
+        # the same JS-round formula as the frontend's cluster-key builder.
+        # Merging multiple task_resources rows that share the same bin
+        # avoids duplicate chips when only ancillary fields differ.
+        merged: Dict[tuple, Dict[str, Any]] = {}
+        for row in cluster_counts:
+            tr_id = int(row.tr_id)
+            rt_mem = cluster_resources.get(tr_id)
+            if rt_mem is None:
+                continue
+            runtime, memory = rt_mem
+            if runtime is None or runtime <= 0 or memory is None or memory <= 0:
+                continue
+            key = (_js_round_tenth(memory), _js_round_tenth(runtime / 3600))
+            bucket = merged.setdefault(
+                key,
+                {"runtime": runtime, "memory": memory, "count": 0},
+            )
+            bucket["count"] += int(row.n)
         resp.resource_clusters = sorted(
             [
                 ResourceClusterItem(
-                    runtime=data["runtime"],
-                    memory=data["memory"],
-                    task_count=data["count"],
+                    runtime=b["runtime"],
+                    memory=b["memory"],
+                    task_count=b["count"],
                 )
-                for data in clusters.values()
+                for b in merged.values()
             ],
             key=lambda c: c.task_count,
             reverse=True,
         )
 
-        resp.efficiency = self._compute_efficiency(utilization_points)
-        return resp
-
-    @staticmethod
-    def _compute_efficiency(
-        points: List[Dict[str, float]],
-    ) -> ResourceEfficiencyMetrics:
-        """Match the frontend calculateResourceEfficiency math.
-
-        memory passed in here is GiB to align with the frontend's bytes_to_gib
-        conversion before scatter plotting.
-        """
-        if not points:
-            return ResourceEfficiencyMetrics()
-
-        total_actual_mem = 0.0
-        total_requested_mem = 0.0
-        total_actual_runtime = 0.0
-        total_requested_runtime = 0.0
-        over_mem = over_rt = under_mem = under_rt = 0
-
-        for p in points:
-            total_actual_mem += p["memory"]
-            total_requested_mem += p["requested_memory"]
-            total_actual_runtime += p["runtime"]
-            total_requested_runtime += p["requested_runtime"]
-
-            mem_util = (p["memory"] / p["requested_memory"]) * 100
-            rt_util = (p["runtime"] / p["requested_runtime"]) * 100
-            if mem_util < 50:
-                over_mem += 1
-            if mem_util > 90:
-                under_mem += 1
-            if rt_util < 50:
-                over_rt += 1
-            if rt_util > 90:
-                under_rt += 1
-
-        n = len(points)
-        runtimes = np.array([p["runtime"] for p in points], dtype=float)
-        memories = np.array([p["memory"] for p in points], dtype=float)
-        rt_mean, rt_std = float(runtimes.mean()), float(runtimes.std())
-        mem_mean, mem_std = float(memories.mean()), float(memories.std())
-        outliers = int(
-            sum(
-                abs(p["runtime"] - rt_mean) > 2 * rt_std
-                or abs(p["memory"] - mem_mean) > 2 * mem_std
-                for p in points
+        eff_n = int(stats["eff_n"] or 0)
+        if eff_n > 0:
+            tot_actual_mem = float(stats["tot_actual_mem"] or 0.0)
+            tot_req_mem = float(stats["tot_req_mem"] or 0.0)
+            tot_actual_rt = float(stats["tot_actual_rt"] or 0.0)
+            tot_req_rt = float(stats["tot_req_rt"] or 0.0)
+            resp.efficiency = ResourceEfficiencyMetrics(
+                memory_utilization=(
+                    (tot_actual_mem / tot_req_mem * 100) if tot_req_mem > 0 else 0.0
+                ),
+                runtime_utilization=(
+                    (tot_actual_rt / tot_req_rt * 100) if tot_req_rt > 0 else 0.0
+                ),
+                over_allocated_memory=round(int(stats["over_mem"] or 0) / eff_n * 100),
+                under_allocated_memory=round(
+                    int(stats["under_mem"] or 0) / eff_n * 100
+                ),
+                over_allocated_runtime=round(int(stats["over_rt"] or 0) / eff_n * 100),
+                under_allocated_runtime=round(
+                    int(stats["under_rt"] or 0) / eff_n * 100
+                ),
+                outlier_count=int(stats["outliers"] or 0),
             )
-        )
 
-        return ResourceEfficiencyMetrics(
-            memory_utilization=(
-                (total_actual_mem / total_requested_mem * 100)
-                if total_requested_mem > 0
-                else 0.0
-            ),
-            runtime_utilization=(
-                (total_actual_runtime / total_requested_runtime * 100)
-                if total_requested_runtime > 0
-                else 0.0
-            ),
-            over_allocated_memory=round(over_mem / n * 100),
-            under_allocated_memory=round(under_mem / n * 100),
-            over_allocated_runtime=round(over_rt / n * 100),
-            under_allocated_runtime=round(under_rt / n * 100),
-            p95_memory=float(np.percentile(memories, 95)),
-            p95_runtime=float(np.percentile(runtimes, 95)),
-            outlier_count=outliers,
-        )
+        return resp
 
     def get_task_template_resource_usage(
         self, req: TaskTemplateResourceUsageRequest

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd  # type: ignore
 import scipy.stats as st  # type: ignore
 import structlog
-from sqlalchemy import String, and_, case, exists, func, select
+from sqlalchemy import Float, String, and_, case, exists, func, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement, Label
 
@@ -34,9 +34,12 @@ from jobmon.server.web.schemas.task_template import (
     MostPopularQueueResponse,
     QueueInfoItem,
     RequestedCoresResponse,
+    ResourceClusterItem,
+    ResourceEfficiencyMetrics,
     TaskResourceDetailItem,
     TaskResourceVizItem,
     TaskTemplateDetailsResponse,
+    TaskTemplateResourceAggregatesResponse,
     TaskTemplateResourceUsageRequest,
     TaskTemplateVersionItem,
     TaskTemplateVersionResponse,
@@ -107,6 +110,8 @@ class TaskTemplateRepository:
         task_template_version_id: int,
         workflows: Optional[List[int]],
         node_args: Optional[Dict[str, List[Any]]],
+        limit: Optional[int] = None,
+        offset: int = 0,
     ) -> List[TaskResourceDetailItem]:
         """Fetch and filter task resource details with optimized single-query approach.
 
@@ -116,6 +121,10 @@ class TaskTemplateRepository:
         - Tasks with running/launched instances → instance row, null resources
         - Tasks with no instances yet (registered) → single row, null instance fields
         Status falls back to Task.status when no instance exists.
+
+        Pagination: when ``limit`` is provided, rows are ordered by
+        ``(Task.id, TaskInstance.id)`` for deterministic paging and the
+        supplied ``offset`` / ``limit`` are applied.
         """
         base_filters = [
             TaskTemplateVersion.id == task_template_version_id,
@@ -170,6 +179,11 @@ class TaskTemplateRepository:
                 .where(and_(*base_filters))
             )
 
+            if limit is not None:
+                query = (
+                    query.order_by(Task.id, TaskInstance.id).offset(offset).limit(limit)
+                )
+
             rows = self.session.execute(query).all()
 
             result = []
@@ -207,6 +221,8 @@ class TaskTemplateRepository:
                 base_filters,
                 status_col,
                 attempt_number_col,
+                limit=limit,
+                offset=offset,
             )
 
     def _get_task_resource_details_with_node_args(
@@ -217,6 +233,8 @@ class TaskTemplateRepository:
         base_filters: List[ColumnElement],
         status_col: Label,
         attempt_number_col: Label,
+        limit: Optional[int] = None,
+        offset: int = 0,
     ) -> List[TaskResourceDetailItem]:
         """Optimized node_args filtering using database-level joins and filtering."""
         base_query = (
@@ -288,6 +306,15 @@ class TaskTemplateRepository:
 
         for subquery in node_arg_subqueries:
             final_query = final_query.where(base_query.c.node_id.in_(subquery))
+
+        if limit is not None:
+            final_query = (
+                final_query.order_by(
+                    base_query.c.task_id, base_query.c.task_instance_id
+                )
+                .offset(offset)
+                .limit(limit)
+            )
 
         rows = self.session.execute(final_query).all()
 
@@ -442,6 +469,347 @@ class TaskTemplateRepository:
                 ]
 
         return stats
+
+    def count_task_resource_details(
+        self,
+        task_template_version_id: int,
+        workflows: Optional[List[int]],
+        node_args: Optional[Dict[str, List[Any]]],
+    ) -> int:
+        """Count rows that get_task_resource_details would return.
+
+        Used by the paginated endpoint to report ``total_count`` without
+        materializing the full detail payload.
+        """
+        base_filters = [TaskTemplateVersion.id == task_template_version_id]
+        if workflows:
+            base_filters.append(Task.workflow_id.in_(workflows))
+
+        count_query = (
+            select(func.count())
+            .select_from(TaskTemplateVersion)
+            .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+            .join(Task, Node.id == Task.node_id)
+            .outerjoin(TaskInstance, Task.id == TaskInstance.task_id)
+            .where(and_(*base_filters))
+        )
+
+        if node_args:
+            for arg_name, arg_values in node_args.items():
+                str_values = [str(v) for v in arg_values]
+                subquery = (
+                    select(NodeArg.node_id)
+                    .join(Arg, NodeArg.arg_id == Arg.id)
+                    .where(
+                        and_(
+                            Arg.name == arg_name,
+                            func.cast(NodeArg.val, String).in_(str_values),
+                        )
+                    )
+                )
+                count_query = count_query.where(Node.id.in_(subquery))
+
+        return int(self.session.execute(count_query).scalar_one())
+
+    def get_task_resource_aggregates(
+        self,
+        task_template_version_id: int,
+        workflows: Optional[List[int]],
+        node_args: Optional[Dict[str, List[Any]]] = None,
+        latest_only: bool = True,
+    ) -> TaskTemplateResourceAggregatesResponse:
+        """Compute compact aggregates for a task template.
+
+        Uses a narrow-column query (wallclock, maxrss, JSON-extracted
+        requested runtime and memory) to avoid materializing the full
+        detail payload. Aggregates (median, p95, efficiency, requested-
+        resource clusters) are computed Python-side on the small numeric
+        arrays.
+
+        When ``latest_only`` is True (the UI default), only the latest
+        TaskInstance per Task is aggregated so the numbers match the
+        latest-only scatter / table view. Correlated subquery on
+        ``MAX(task_instance.id)`` is index-covered via the
+        ``(task_id, id)`` key on task_instance.
+        """
+        base_filters: List[ColumnElement] = [
+            TaskTemplateVersion.id == task_template_version_id,
+        ]
+        if workflows:
+            base_filters.append(Task.workflow_id.in_(workflows))
+
+        # Pull only the two JSON fields we actually use, not the whole blob.
+        # Avoids shipping ~1 KB of requested_resources JSON per task_instance
+        # row over the wire, which dominated the aggregates query cost.
+        req_runtime_col = func.cast(
+            func.json_extract(TaskResources.requested_resources, "$.runtime"),
+            Float,
+        ).label("req_runtime")
+        req_memory_col = func.cast(
+            func.json_extract(TaskResources.requested_resources, "$.memory"),
+            Float,
+        ).label("req_memory")
+
+        query = (
+            select(
+                TaskInstance.wallclock,
+                TaskInstance.maxrss,
+                req_runtime_col,
+                req_memory_col,
+            )
+            .select_from(TaskTemplateVersion)
+            .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+            .join(Task, Node.id == Task.node_id)
+            .join(TaskInstance, Task.id == TaskInstance.task_id)
+            .outerjoin(
+                TaskResources, TaskInstance.task_resources_id == TaskResources.id
+            )
+            .where(and_(*base_filters))
+        )
+
+        if latest_only:
+            latest_ti_id = (
+                select(func.max(TaskInstance.id))
+                .where(TaskInstance.task_id == Task.id)
+                .correlate(Task)
+                .scalar_subquery()
+            )
+            query = query.where(TaskInstance.id == latest_ti_id)
+
+        if node_args:
+            for arg_name, arg_values in node_args.items():
+                str_values = [str(v) for v in arg_values]
+                subquery = (
+                    select(NodeArg.node_id)
+                    .join(Arg, NodeArg.arg_id == Arg.id)
+                    .where(
+                        and_(
+                            Arg.name == arg_name,
+                            func.cast(NodeArg.val, String).in_(str_values),
+                        )
+                    )
+                )
+                query = query.where(Node.id.in_(subquery))
+
+        rows = self.session.execute(query).all()
+        return self._build_aggregates_response(rows, task_template_version_id)
+
+    def _build_aggregates_response(
+        self,
+        rows: Any,
+        task_template_version_id: int,
+    ) -> TaskTemplateResourceAggregatesResponse:
+        """Compute aggregates in Python from the narrow rowset.
+
+        Operates on ``(wallclock, maxrss, req_runtime, req_memory)`` tuples
+        where ``req_runtime`` / ``req_memory`` are already JSON-extracted by
+        SQL rather than shipped as a full JSON blob.
+        """
+        if not rows:
+            has_any = (
+                self.session.execute(
+                    select(Task.id)
+                    .select_from(TaskTemplateVersion)
+                    .join(Node, TaskTemplateVersion.id == Node.task_template_version_id)
+                    .join(Task, Node.id == Task.node_id)
+                    .where(TaskTemplateVersion.id == task_template_version_id)
+                    .limit(1)
+                ).first()
+                is not None
+            )
+            return TaskTemplateResourceAggregatesResponse(
+                num_tasks=0 if has_any else None
+            )
+
+        wallclocks: List[float] = []
+        maxrss_values: List[float] = []
+        requested_runtimes: List[float] = []
+        requested_memories: List[float] = []
+        clusters: Dict[str, Dict[str, Any]] = {}
+        utilization_points: List[Dict[str, float]] = []
+
+        for wc, mr, raw_req_rt, raw_req_mem in rows:
+            if wc is not None and float(wc) != 0:
+                wallclocks.append(float(wc))
+            if mr is not None:
+                maxrss_values.append(max(0.0, float(mr)))
+
+            req_runtime: Optional[float] = None
+            req_memory: Optional[float] = None
+            try:
+                if raw_req_rt is not None and float(raw_req_rt) > 0:
+                    req_runtime = float(raw_req_rt)
+            except (ValueError, TypeError):
+                pass
+            try:
+                if raw_req_mem is not None and float(raw_req_mem) > 0:
+                    req_memory = float(raw_req_mem)
+            except (ValueError, TypeError):
+                pass
+
+            if req_runtime is not None:
+                requested_runtimes.append(req_runtime)
+            if req_memory is not None:
+                requested_memories.append(req_memory)
+
+            if req_runtime is not None and req_memory is not None:
+                key = (
+                    f"{round(req_memory * 10) / 10}G-"
+                    f"{round(req_runtime / 3600 * 10) / 10}h"
+                )
+                cluster = clusters.setdefault(
+                    key,
+                    {
+                        "runtime": req_runtime,
+                        "memory": req_memory,
+                        "count": 0,
+                    },
+                )
+                cluster["count"] += 1
+
+            if (
+                wc is not None
+                and mr is not None
+                and req_runtime is not None
+                and req_memory is not None
+                and float(wc) > 0
+                and float(mr) > 0
+            ):
+                # memory in bytes; requested memory is GiB — match the frontend
+                # efficiency calc which compares memory_gib to requested memory.
+                actual_mem_gib = float(mr) / (1024.0**3)
+                utilization_points.append(
+                    {
+                        "runtime": float(wc),
+                        "memory": actual_mem_gib,
+                        "requested_runtime": req_runtime,
+                        "requested_memory": req_memory,
+                    }
+                )
+
+        memories_for_stats = [m for m in maxrss_values if m > 0]
+
+        def _p(data: List[float], pct: float) -> Optional[float]:
+            if not data:
+                return None
+            return float(np.percentile(data, pct))
+
+        resp = TaskTemplateResourceAggregatesResponse(num_tasks=len(rows))
+
+        if memories_for_stats:
+            resp.min_mem = int(min(memories_for_stats))
+            resp.max_mem = int(max(memories_for_stats))
+            resp.mean_mem = float(np.mean(memories_for_stats))
+            resp.median_mem = float(np.median(memories_for_stats))
+            resp.p95_mem = _p(memories_for_stats, 95)
+        elif maxrss_values:
+            resp.min_mem = 0
+            resp.max_mem = 0
+            resp.mean_mem = 0.0
+            resp.median_mem = 0.0
+            resp.p95_mem = 0.0
+
+        if wallclocks:
+            resp.min_runtime = int(min(wallclocks))
+            resp.max_runtime = int(max(wallclocks))
+            resp.mean_runtime = float(np.mean(wallclocks))
+            resp.median_runtime = float(np.median(wallclocks))
+            resp.p95_runtime = _p(wallclocks, 95)
+        else:
+            resp.min_runtime = 0
+            resp.max_runtime = 0
+            resp.mean_runtime = 0.0
+            resp.median_runtime = 0.0
+
+        if requested_runtimes:
+            resp.median_requested_runtime = float(np.median(requested_runtimes))
+        if requested_memories:
+            resp.median_requested_memory = float(np.median(requested_memories))
+
+        resp.resource_clusters = sorted(
+            [
+                ResourceClusterItem(
+                    id=key,
+                    runtime=data["runtime"],
+                    memory=data["memory"],
+                    task_count=data["count"],
+                )
+                for key, data in clusters.items()
+            ],
+            key=lambda c: c.task_count,
+            reverse=True,
+        )
+
+        resp.efficiency = self._compute_efficiency(utilization_points)
+        return resp
+
+    @staticmethod
+    def _compute_efficiency(
+        points: List[Dict[str, float]],
+    ) -> ResourceEfficiencyMetrics:
+        """Match the frontend calculateResourceEfficiency math.
+
+        memory passed in here is GiB to align with the frontend's bytes_to_gib
+        conversion before scatter plotting.
+        """
+        if not points:
+            return ResourceEfficiencyMetrics()
+
+        total_actual_mem = 0.0
+        total_requested_mem = 0.0
+        total_actual_runtime = 0.0
+        total_requested_runtime = 0.0
+        over_mem = over_rt = under_mem = under_rt = 0
+
+        for p in points:
+            total_actual_mem += p["memory"]
+            total_requested_mem += p["requested_memory"]
+            total_actual_runtime += p["runtime"]
+            total_requested_runtime += p["requested_runtime"]
+
+            mem_util = (p["memory"] / p["requested_memory"]) * 100
+            rt_util = (p["runtime"] / p["requested_runtime"]) * 100
+            if mem_util < 50:
+                over_mem += 1
+            if mem_util > 90:
+                under_mem += 1
+            if rt_util < 50:
+                over_rt += 1
+            if rt_util > 90:
+                under_rt += 1
+
+        n = len(points)
+        runtimes = np.array([p["runtime"] for p in points], dtype=float)
+        memories = np.array([p["memory"] for p in points], dtype=float)
+        rt_mean, rt_std = float(runtimes.mean()), float(runtimes.std())
+        mem_mean, mem_std = float(memories.mean()), float(memories.std())
+        outliers = int(
+            sum(
+                abs(p["runtime"] - rt_mean) > 2 * rt_std
+                or abs(p["memory"] - mem_mean) > 2 * mem_std
+                for p in points
+            )
+        )
+
+        return ResourceEfficiencyMetrics(
+            memory_utilization=(
+                (total_actual_mem / total_requested_mem * 100)
+                if total_requested_mem > 0
+                else 0.0
+            ),
+            runtime_utilization=(
+                (total_actual_runtime / total_requested_runtime * 100)
+                if total_requested_runtime > 0
+                else 0.0
+            ),
+            over_allocated_memory=round(over_mem / n * 100),
+            under_allocated_memory=round(under_mem / n * 100),
+            over_allocated_runtime=round(over_rt / n * 100),
+            under_allocated_runtime=round(under_rt / n * 100),
+            p95_memory=float(np.percentile(memories, 95)),
+            p95_runtime=float(np.percentile(runtimes, 95)),
+            outlier_count=outliers,
+        )
 
     def get_task_template_resource_usage(
         self, req: TaskTemplateResourceUsageRequest

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
@@ -20,6 +20,8 @@ from jobmon.server.web.routes.v3.cli import cli_router as api_v3_router
 from jobmon.server.web.schemas.task_template import (
     FatalErrorBreakdownResponse,
     TaskResourceVizItem,
+    TaskTemplateResourceAggregatesRequest,
+    TaskTemplateResourceAggregatesResponse,
     TaskTemplateResourceUsageRequest,
     TaskTemplateResourceUsageResponse,
     WorkflowResourceErrorCheckResponse,
@@ -123,19 +125,41 @@ async def get_task_template_resource_usage(
     repo = TaskTemplateRepository(db)
 
     try:
+        paginated = request_data.page is not None and request_data.page_size is not None
+        limit: Optional[int] = None
+        offset = 0
+        total_count: Optional[int] = None
+        if paginated:
+            page = request_data.page or 0
+            page_size = request_data.page_size or 500
+            limit = page_size
+            offset = page * page_size
+            total_count = repo.count_task_resource_details(
+                task_template_version_id=request_data.task_template_version_id,
+                workflows=request_data.workflows,
+                node_args=request_data.node_args,
+            )
+
         # Get task details using the repository
         task_details = repo.get_task_resource_details(
             task_template_version_id=request_data.task_template_version_id,
             workflows=request_data.workflows,
             node_args=request_data.node_args,
+            limit=limit,
+            offset=offset,
         )
 
-        # Calculate statistics using repository method
-        stats = repo.calculate_resource_statistics(
-            task_details=task_details,
-            confidence_interval=request_data.ci,
-            task_template_version_id=request_data.task_template_version_id,
-        )
+        # Skip stats computation for paginated requests — callers should use
+        # the aggregates endpoint for KPIs rather than stats derived from
+        # a single page. Legacy unpaged requests still get full stats.
+        if paginated:
+            stats = None
+        else:
+            stats = repo.calculate_resource_statistics(
+                task_details=task_details,
+                confidence_interval=request_data.ci,
+                task_template_version_id=request_data.task_template_version_id,
+            )
 
         # Prepare viz data if requested
         viz_data = None
@@ -163,18 +187,21 @@ async def get_task_template_resource_usage(
 
         # Return unified Pydantic response
         return TaskTemplateResourceUsageResponse(
-            num_tasks=stats.num_tasks,
-            min_mem=stats.min_mem,
-            max_mem=stats.max_mem,
-            mean_mem=stats.mean_mem,
-            min_runtime=stats.min_runtime,
-            max_runtime=stats.max_runtime,
-            mean_runtime=stats.mean_runtime,
-            median_mem=stats.median_mem,
-            median_runtime=stats.median_runtime,
-            ci_mem=stats.ci_mem,
-            ci_runtime=stats.ci_runtime,
+            num_tasks=(stats.num_tasks if stats is not None else total_count),
+            min_mem=stats.min_mem if stats is not None else None,
+            max_mem=stats.max_mem if stats is not None else None,
+            mean_mem=stats.mean_mem if stats is not None else None,
+            min_runtime=stats.min_runtime if stats is not None else None,
+            max_runtime=stats.max_runtime if stats is not None else None,
+            mean_runtime=stats.mean_runtime if stats is not None else None,
+            median_mem=stats.median_mem if stats is not None else None,
+            median_runtime=stats.median_runtime if stats is not None else None,
+            ci_mem=stats.ci_mem if stats is not None else None,
+            ci_runtime=stats.ci_runtime if stats is not None else None,
             result_viz=viz_data,
+            total_count=total_count,
+            page=request_data.page if paginated else None,
+            page_size=request_data.page_size if paginated else None,
         )
 
     except Exception as e:
@@ -182,6 +209,36 @@ async def get_task_template_resource_usage(
         raise HTTPException(
             status_code=StatusCodes.INTERNAL_SERVER_ERROR,
             detail="Error processing resource usage data.",
+        ) from e
+
+
+@api_v3_router.post(
+    "/task_template_resource_aggregates",
+    response_model=TaskTemplateResourceAggregatesResponse,
+)
+async def get_task_template_resource_aggregates(
+    request_data: TaskTemplateResourceAggregatesRequest,
+    db: Session = Depends(get_db),
+) -> TaskTemplateResourceAggregatesResponse:
+    """Server-computed aggregates (KPIs, clusters, efficiency) for a task template.
+
+    Uses a narrow-column query and avoids materializing the full
+    task_instance × task × task_resources payload that the viz endpoint
+    returns.
+    """
+    repo = TaskTemplateRepository(db)
+    try:
+        return repo.get_task_resource_aggregates(
+            task_template_version_id=request_data.task_template_version_id,
+            workflows=request_data.workflows,
+            node_args=request_data.node_args,
+            latest_only=request_data.latest_only,
+        )
+    except Exception as e:
+        logger.error(f"Error fetching resource aggregates: {e}")
+        raise HTTPException(
+            status_code=StatusCodes.INTERNAL_SERVER_ERROR,
+            detail="Error processing resource aggregates.",
         ) from e
 
 

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -10,6 +10,71 @@ class TaskTemplateResourceUsageRequest(BaseModel):
     node_args: Optional[Dict[str, List[str]]] = None
     ci: Optional[str] = None
     viz: bool = False
+    page: Optional[int] = Field(default=None, ge=0)
+    page_size: Optional[int] = Field(default=None, ge=1, le=5000)
+
+
+class TaskTemplateResourceAggregatesRequest(BaseModel):
+    """Request for the lightweight aggregates endpoint."""
+
+    task_template_version_id: int
+    workflows: Optional[List[int]] = None
+    node_args: Optional[Dict[str, List[str]]] = None
+    # When True (default, matches the UI's default "latest only" toggle),
+    # aggregate only over the latest TaskInstance per Task. When False,
+    # aggregate across all attempts — useful for diagnosing retry waste.
+    latest_only: bool = True
+
+
+class ResourceClusterItem(BaseModel):
+    """One requested-resource cluster summary.
+
+    Cluster → instance membership is recomputed on the frontend as the
+    scatter rows stream in, so we deliberately do not ship instance IDs
+    here — for large templates that list alone would dominate the
+    aggregates payload.
+    """
+
+    id: str
+    runtime: float
+    memory: float
+    task_count: int
+
+
+class ResourceEfficiencyMetrics(BaseModel):
+    """Aggregate resource efficiency metrics for a task template."""
+
+    memory_utilization: float = 0.0
+    runtime_utilization: float = 0.0
+    over_allocated_memory: int = 0
+    under_allocated_memory: int = 0
+    over_allocated_runtime: int = 0
+    under_allocated_runtime: int = 0
+    p95_memory: Optional[float] = None
+    p95_runtime: Optional[float] = None
+    outlier_count: int = 0
+
+
+class TaskTemplateResourceAggregatesResponse(BaseModel):
+    """Compact server-computed aggregates for a task template."""
+
+    num_tasks: Optional[int] = None
+    min_mem: Optional[int] = None
+    max_mem: Optional[int] = None
+    mean_mem: Optional[float] = None
+    median_mem: Optional[float] = None
+    p95_mem: Optional[float] = None
+    min_runtime: Optional[int] = None
+    max_runtime: Optional[int] = None
+    mean_runtime: Optional[float] = None
+    median_runtime: Optional[float] = None
+    p95_runtime: Optional[float] = None
+    median_requested_runtime: Optional[float] = None
+    median_requested_memory: Optional[float] = None
+    resource_clusters: List[ResourceClusterItem] = []
+    efficiency: ResourceEfficiencyMetrics = Field(
+        default_factory=ResourceEfficiencyMetrics
+    )
 
 
 class RequestedResourcesModel(BaseModel):  # Optional: For parsing the JSON string
@@ -93,6 +158,11 @@ class TaskTemplateResourceUsageResponse(BaseModel):
 
     # Visualization data (optional, only when viz=True)
     result_viz: Optional[List[TaskResourceVizItem]] = None
+
+    # Pagination metadata (only populated when request supplied page/page_size)
+    total_count: Optional[int] = None
+    page: Optional[int] = None
+    page_size: Optional[int] = None
 
     # Computed properties for client convenience
     @computed_field

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -59,25 +59,32 @@ class ResourceEfficiencyMetrics(BaseModel):
 
 
 class TaskTemplateResourceAggregatesResponse(BaseModel):
-    """Compact server-computed aggregates for a task template."""
+    """Compact server-computed aggregates for a task template.
+
+    Memory and runtime stats are ``Optional[float]`` (not ``int``) so
+    the client's per-field merge doesn't permanently overwrite more
+    precise client-computed floats with a truncated integer.
+    ``efficiency`` defaults to ``None`` when the template has no
+    efficiency-relevant data (zero-TI workflow, or TIs without
+    requested resources) so the frontend can distinguish "no server
+    data" from "server says all zeros".
+    """
 
     num_tasks: Optional[int] = None
-    min_mem: Optional[int] = None
-    max_mem: Optional[int] = None
+    min_mem: Optional[float] = None
+    max_mem: Optional[float] = None
     mean_mem: Optional[float] = None
     median_mem: Optional[float] = None
     p95_mem: Optional[float] = None
-    min_runtime: Optional[int] = None
-    max_runtime: Optional[int] = None
+    min_runtime: Optional[float] = None
+    max_runtime: Optional[float] = None
     mean_runtime: Optional[float] = None
     median_runtime: Optional[float] = None
     p95_runtime: Optional[float] = None
     median_requested_runtime: Optional[float] = None
     median_requested_memory: Optional[float] = None
     resource_clusters: List[ResourceClusterItem] = []
-    efficiency: ResourceEfficiencyMetrics = Field(
-        default_factory=ResourceEfficiencyMetrics
-    )
+    efficiency: Optional[ResourceEfficiencyMetrics] = None
 
 
 class RequestedResourcesModel(BaseModel):  # Optional: For parsing the JSON string

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -29,13 +29,16 @@ class TaskTemplateResourceAggregatesRequest(BaseModel):
 class ResourceClusterItem(BaseModel):
     """One requested-resource cluster summary.
 
-    Cluster → instance membership is recomputed on the frontend as the
-    scatter rows stream in, so we deliberately do not ship instance IDs
-    here — for large templates that list alone would dominate the
-    aggregates payload.
+    We ship only the numeric ``(runtime, memory)`` pair plus the count;
+    the frontend derives the string cluster key itself using the same
+    rounding/formatting it applies to scatter rows, so there's no
+    cross-language string contract that can drift between Python and JS.
+
+    Cluster → instance membership is also recomputed frontend-side from
+    streaming scatter rows — shipping per-instance IDs here would
+    dominate the aggregates payload on large templates.
     """
 
-    id: str
     runtime: float
     memory: float
     task_count: int


### PR DESCRIPTION
## Summary

Splits the Task Template Details page load into **(a)** a fast server-side aggregates call that paints KPIs + cluster chips on first byte, and **(b)** a parallel paginated stream that drains the full per-task-instance dataset in the background. Targets the 54s p95 `/task_template_resource_usage` query that was the top TT-page slow query in prod.

Includes an alembic migration that adds a covering index on `task_instance` to eliminate heap lookups on the aggregate and viz queries. Migration is online (`ALGORITHM=INPLACE, LOCK=NONE`).

## End-to-end results on pixel (wf 562144, 78K tasks, 83K task instances)

| Endpoint | Before | After |
|----------|-------:|------:|
| `task_template_resource_aggregates` | 54s (legacy stats) | **~5s** (11× faster) |
| `task_template_resource_usage` page 0 | 25s | **~6s** (4× faster) |
| Scatter fully drained (42 pages sequential) | ~5 min | **~1.7 min** (3 parallel streams) |

## Backend

**New aggregates endpoint** — `POST /api/v3/task_template_resource_aggregates`
- Returns num_tasks, min/max/mean wallclock & maxrss, median requested runtime & memory, resource clusters, efficiency (utilization, over/under-allocated %, outlier count)
- `latest_only: bool = True` request param mirrors the UI's "latest only" toggle
- MySQL 8 path uses `LATERAL` subquery ordered by `id DESC LIMIT 1` — hits the new covering index index-only (zero heap reads)
- Other dialects (SQLite test harness, Postgres, etc.) fall back to a correlated scalar `MAX(id)` subquery
- Entirely SQL-side aggregation: conditional `SUM`/`MIN`/`MAX`/`AVG`/`STDDEV_POP` in one pass, no 78K-row ship to Python
- Population gates: KPI stats and outlier count gate on `wallclock>0 AND maxrss>0` (matches client's `ScatterDataPoint` filter); utilization and over/under counts additionally require both requested resources (needed for the math to be defined). Eliminates the "values jump when user toggles a filter" UX bug.
- Cluster breakdown: `GROUP BY task_resources_id` with a narrow follow-up fetch of `requested_resources` JSON for just the unique ids. One `JSON_EXTRACT` per unique resource spec instead of per row.
- `ResourceClusterItem` ships only `{runtime, memory, task_count}` — the frontend derives cluster IDs via its own formula, avoiding any cross-language string contract that can drift between Python and JS.

**Updated `/api/v3/task_template_resource_usage`**
- New optional `page` / `page_size` request fields plus `total_count` in the response
- Deferred-join pagination: pass 1 picks `(task_id, task_instance_id)` pairs via the covering index ordered by `(task_id, id)`, pass 2 joins back by PK. Avoids the filesort + 2000 heap-probes the naive plan does on the full join.
- Both pass 1 and the count query use `LEFT OUTER JOIN` on `task_instance` so tasks with no instances yet (registered-but-not-launched) still appear in the table as single rows with null instance / resource fields — matching the original unpaged behavior.
- `attempt_number` is computed inside pass 1 (before `LIMIT`) so cross-page tasks number correctly.
- `requested_resources` narrowed server-side to `{"memory", "runtime"}` via `JSON_OBJECT` — drops ~700 B/row of path and command-arg fields that the UI never reads.

**Infra**
- Alembic migration `c3d4e5f6a7b8` adds `ix_ti_task_id_covering (task_id, id, wallclock, maxrss, task_resources_id)` — online, no table lock.
- Already applied to prod during this PR's development (~1h build on a 110M-row table); migration will no-op on environments where it's already run.

## Frontend

**Aggregates query**
- New `GetTaskTemplateAggregates.ts`. Query key includes `showLatestOnly` so toggling refetches a matching view.
- `useUsageFilters` accepts an optional `serverResourceClusters`; when present, filter chips source from the aggregates response so the control is complete on first paint instead of growing as pages stream in.
- KPI tiles + efficiency card **per-field merge** server and client values — server fields render instantly when present, client-computed values (median, p95) fill in once enough viz has streamed. Previously an all-or-nothing pick that hid medians forever.
- Consume-site adapter handles bytes→GiB and snake→camelCase between the backend response and existing `UsageKPIStats` / `ResourceEfficiencyMetrics` shapes.

**Parallel paginated drain**
- Replaces single `useInfiniteQuery` with **3 parallel streams**, each handling a strided subset of pages (stream 0: 0, 3, 6…; stream 1: 1, 4, 7…; stream 2: 2, 5, 8…). 3× concurrency, under the browser's 6-per-host cap, with IOPS headroom for prod MySQL.
- `page_size` raised 500 → 2000; on pixel this cuts round-trips from 166 to 42.
- `showLatestOnly` and `selectedWorkflowRunId` hoisted so the aggregates query key can depend on them.
- Regenerated `apiSchema.ts`.

## Verified on prod

- `wf 562144` (pixel, 78K tasks, 83K TIs): aggregates 5s, KPI values match client-computed values field-for-field, clusters render instantly, covering index observed `Using index` in `EXPLAIN` for the correlated subquery
- `wf 568145` (2299 all-registered tasks, 0 task instances): usage endpoint preserves all 2299 rows across 2 pages — count matches, both pages return `task_instance_id: null`, status `G`, correct task names. Without the outerjoin fix the table would have been empty.
- `wf 567823` / TTV 25656682 (40-task small workflow): aggregates ~250ms
- `latest_only=false` path (correlated scalar fallback): 2.7s on pixel, clusters and outliers distinct from `latest_only=true`
- Deadlock path: does not trigger retry
- SQLite test harness: `latest_only` uses correlated scalar fallback, no `LATERAL` errors

## Test plan

- [x] `uv run nox -s lint`
- [x] `uv run nox -s typecheck`
- [x] `uv run nox -s format`
- [x] `uv run pytest -n 10` — 1148 passed, 6 skipped (last run)
- [x] `cd jobmon_gui && npm run build` — clean
- [x] Live smoke test against prod MySQL on multiple workflow shapes (see above)
- [x] Alembic migration applied to prod successfully
- [ ] Post-deploy: verify TT p95 drops in APM / slow-log for `fhs-pipeline-mortality` and `pixel`

## Bugbot findings addressed

- Python banker's rounding mismatch — fixed via JS-compat `_js_round_tenth` and frontend-side cluster key derivation
- Server/client population mismatch (KPI + efficiency + outliers) — aligned via named gates (`kpi_valid` / `eff_valid`)
- Median / p95 permanently hidden in unfiltered view — per-field merge on frontend so client values fill in
- `median_requested_*` silently populated with `AVG` — dropped from server response; client computes from streaming rows
- `LATERAL` broke SQLite tests — dialect-branched fallback to correlated scalar
- Deferred-join `ROW_NUMBER` saw only paged rows — moved inside pass 1 before `LIMIT` so cross-page attempts number correctly
- Count / paged JOIN mismatch — both now use `LEFT OUTER JOIN` on `task_instance` with matching universes, preserving tasks without instances
- Outlier count lost when no eff-valid rows — lifted out of the `eff_n > 0` guard
- Dead `getWorkflowUsagePageQueryFn` export — removed
- Double `_build_aggregates_rowset` construction — reuse `inner.subquery()` for the cluster query

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds a new API endpoint, changes the semantics/performance of the existing usage endpoint via pagination, and introduces a DB migration adding a large covering index that can impact storage and query plans.
> 
> **Overview**
> Task Template Details now loads usage data in two phases: a new `POST /api/v3/task_template_resource_aggregates` endpoint returns server-computed KPIs/efficiency and resource clusters for immediate rendering, while the existing usage data is fetched via **paginated** `task_template_resource_usage` calls drained by 3 parallel `useInfiniteQuery` streams.
> 
> Backend updates `task_template_resource_usage` to accept `page`/`page_size` and return `total_count`, adds SQL-side aggregate computation + cluster grouping in `TaskTemplateRepository`, and narrows `requested_resources` JSON to only fields needed by the UI/CSV. A new Alembic migration adds a covering index on `task_instance` to reduce heap lookups for both aggregates and paged usage queries.
> 
> Frontend wires the aggregates query (`GetTaskTemplateAggregates.ts`), prioritizes server-provided clusters in `useUsageFilters`, and merges server KPI/efficiency fields with client-computed medians/p95 as streaming pages arrive; `apiSchema.ts` is regenerated to include the new endpoint and pagination fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11a727bebd2638f2f06330995580fa87e3eb5276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->