### PR TITLE
Add Requested Resources view: workflow panel + TT table column + attempts detail

### DIFF
--- a/jobmon_gui/src/components/common/RequestedResourceClusterCard.tsx
+++ b/jobmon_gui/src/components/common/RequestedResourceClusterCard.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Chip from '@mui/material/Chip';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+
+import {
+    formatRequestedResourcesFull,
+    formatRequestedResourcesSummary,
+} from '@jobmon_gui/utils/requestedResources';
+import RequestedResourcesGrid from '@jobmon_gui/components/common/RequestedResourcesGrid';
+import { components } from '@jobmon_gui/types/apiSchema';
+
+export type RequestedResourceCluster =
+    components['schemas']['RequestedResourceClusterItem'];
+
+export default function RequestedResourceClusterCard({
+    cluster,
+    defaultOpen = false,
+}: {
+    cluster: RequestedResourceCluster;
+    defaultOpen?: boolean;
+}) {
+    const [open, setOpen] = useState(defaultOpen);
+    const blob = cluster.requested_resources ?? {};
+    const summary = formatRequestedResourcesSummary(blob);
+    const fullRows = open ? formatRequestedResourcesFull(blob) : [];
+
+    return (
+        <Box
+            sx={{
+                border: '1px solid #e0e0e0',
+                borderRadius: 1,
+                p: 1,
+                mb: 1,
+            }}
+        >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Chip
+                    label={`${cluster.num_tasks} task${
+                        cluster.num_tasks === 1 ? '' : 's'
+                    }`}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                />
+                <Typography
+                    variant="body2"
+                    sx={{
+                        fontFamily: 'monospace',
+                        flex: 1,
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {summary || '(empty)'}
+                </Typography>
+                <Tooltip title={open ? 'Hide full blob' : 'Show full blob'}>
+                    <IconButton size="small" onClick={() => setOpen(v => !v)}>
+                        {open ? (
+                            <ExpandLessIcon fontSize="small" />
+                        ) : (
+                            <ExpandMoreIcon fontSize="small" />
+                        )}
+                    </IconButton>
+                </Tooltip>
+            </Box>
+            {open && (
+                <RequestedResourcesGrid
+                    rows={fullRows}
+                    sx={{ mt: 1 }}
+                />
+            )}
+        </Box>
+    );
+}

--- a/jobmon_gui/src/components/common/RequestedResourcesGrid.tsx
+++ b/jobmon_gui/src/components/common/RequestedResourcesGrid.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import { SxProps, Theme } from '@mui/material/styles';
+
+import { formatResourceLabel } from '@jobmon_gui/utils/requestedResources';
+
+interface Props {
+    rows: { key: string; value: string }[];
+    labelSx?: SxProps<Theme>;
+    valueSx?: SxProps<Theme>;
+    sx?: SxProps<Theme>;
+    emptyText?: string;
+}
+
+/** Two-column (label: value) grid used by the workflow Resources card
+ *  and the Task Template Details task-table tooltip. Labels come from
+ *  ``formatResourceLabel`` so casing and overrides stay consistent. */
+export default function RequestedResourcesGrid({
+    rows,
+    labelSx,
+    valueSx,
+    sx,
+    emptyText = 'No resource fields set.',
+}: Props) {
+    if (rows.length === 0) {
+        return (
+            <Box sx={{ fontSize: '0.8rem', color: 'text.secondary', ...sx }}>
+                {emptyText}
+            </Box>
+        );
+    }
+    return (
+        <Box
+            sx={{
+                display: 'grid',
+                gridTemplateColumns: 'max-content 1fr',
+                gap: '2px 8px',
+                fontFamily: 'monospace',
+                fontSize: '0.8rem',
+                ...sx,
+            }}
+        >
+            {rows.map(({ key, value }) => (
+                <React.Fragment key={key}>
+                    <Box
+                        sx={{
+                            color: 'text.secondary',
+                            textAlign: 'right',
+                            whiteSpace: 'nowrap',
+                            ...labelSx,
+                        }}
+                    >
+                        {formatResourceLabel(key)}:
+                    </Box>
+                    <Box sx={{ wordBreak: 'break-all', ...valueSx }}>
+                        {value}
+                    </Box>
+                </React.Fragment>
+            ))}
+        </Box>
+    );
+}

--- a/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
+++ b/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
@@ -29,6 +29,8 @@ import {
     formatResourceLabel,
     parseRequestedResources,
 } from '@jobmon_gui/utils/requestedResources';
+import { JobmonModal } from '@jobmon_gui/components/JobmonModal';
+import { getBarColor } from './ResourceComparisonBar';
 
 // Keys shown elsewhere in the attempt panel (resource bars, Queue /
 // Cores rows, captured-log section) — skip them in the generic
@@ -42,8 +44,6 @@ const HIDDEN_REQ_RES_KEYS = new Set([
     'stdout',
     'stderr',
 ]);
-import { JobmonModal } from '@jobmon_gui/components/JobmonModal';
-import { getBarColor } from './ResourceComparisonBar';
 
 type AuditRecord = components['schemas']['TaskStatusAuditRecord'];
 

--- a/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
+++ b/jobmon_gui/src/components/task_details/TaskStatusTimeline.tsx
@@ -6,7 +6,6 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Tooltip from '@mui/material/Tooltip';
 import Collapse from '@mui/material/Collapse';
 import Button from '@mui/material/Button';
-import Grid from '@mui/material/Grid';
 import LinearProgress from '@mui/material/LinearProgress';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -25,9 +24,26 @@ import { components } from '@jobmon_gui/types/apiSchema';
 import { TaskInstance } from '@jobmon_gui/types/TaskInstance';
 import { formatBytes, bytes_to_gib } from '@jobmon_gui/utils/formatters';
 import { parseResourceJson } from '@jobmon_gui/utils/csvExport';
+import {
+    formatRequestedResourcesFull,
+    formatResourceLabel,
+    parseRequestedResources,
+} from '@jobmon_gui/utils/requestedResources';
+
+// Keys shown elsewhere in the attempt panel (resource bars, Queue /
+// Cores rows, captured-log section) — skip them in the generic
+// "other fields" rendering so values don't show up twice.
+const HIDDEN_REQ_RES_KEYS = new Set([
+    'memory',
+    'runtime',
+    'queue',
+    'cores',
+    'num_cores',
+    'stdout',
+    'stderr',
+]);
 import { JobmonModal } from '@jobmon_gui/components/JobmonModal';
 import { getBarColor } from './ResourceComparisonBar';
-import { ScrollableCodeBlock } from '@jobmon_gui/components/ScrollableTextArea';
 
 type AuditRecord = components['schemas']['TaskStatusAuditRecord'];
 
@@ -201,6 +217,207 @@ function mapAttemptsToInstances(
 
 // --- Sub-components ---
 
+function AttemptColumn({
+    heading,
+    rows,
+}: {
+    heading: string;
+    rows: { label: string; value: string }[];
+}) {
+    return (
+        <Box>
+            <Typography
+                variant="caption"
+                fontWeight={700}
+                sx={{
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                    display: 'block',
+                    mb: 0.5,
+                }}
+            >
+                {heading}
+            </Typography>
+            <Box
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'max-content 1fr',
+                    gap: '2px 12px',
+                }}
+            >
+                {rows.map(row => (
+                    <React.Fragment key={row.label}>
+                        <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            fontWeight={600}
+                        >
+                            {row.label}
+                        </Typography>
+                        <Typography
+                            variant="caption"
+                            sx={{
+                                fontFamily: 'Roboto Mono Variable',
+                                wordBreak: 'break-all',
+                            }}
+                        >
+                            {row.value}
+                        </Typography>
+                    </React.Fragment>
+                ))}
+            </Box>
+        </Box>
+    );
+}
+
+function LogModalSection({
+    label,
+    value,
+    kind,
+    emphasize = false,
+}: {
+    label: string;
+    value: string | null | undefined;
+    kind: 'path' | 'content';
+    emphasize?: boolean;
+}) {
+    const hasContent =
+        value != null && value !== '' && value !== '/dev/null';
+    return (
+        <Box sx={{ mb: 1.5 }}>
+            <Typography
+                variant="caption"
+                sx={{
+                    display: 'block',
+                    fontWeight: 700,
+                    textTransform: 'uppercase',
+                    letterSpacing: 0.5,
+                    color: emphasize ? 'error.main' : 'text.secondary',
+                    mb: 0.25,
+                }}
+            >
+                {label}
+            </Typography>
+            {!hasContent ? (
+                <Typography variant="body2" color="text.secondary">
+                    No output captured.
+                </Typography>
+            ) : kind === 'path' ? (
+                <Box
+                    sx={{
+                        fontFamily: 'Roboto Mono Variable',
+                        fontSize: '0.8rem',
+                        bgcolor: '#f5f5f5',
+                        border: '1px solid',
+                        borderColor: 'grey.300',
+                        borderRadius: 1,
+                        px: 1,
+                        py: 0.5,
+                        whiteSpace: 'pre',
+                        overflowX: 'auto',
+                        userSelect: 'all',
+                    }}
+                >
+                    {value}
+                </Box>
+            ) : (
+                <Box
+                    component="pre"
+                    sx={{
+                        fontFamily: 'Roboto Mono Variable',
+                        fontSize: '0.75rem',
+                        bgcolor: '#f5f5f5',
+                        border: '1px solid',
+                        borderColor: 'grey.300',
+                        borderRadius: 1,
+                        px: 1.5,
+                        py: 1,
+                        m: 0,
+                        maxHeight: '50vh',
+                        overflow: 'auto',
+                        whiteSpace: 'pre',
+                    }}
+                >
+                    {value}
+                </Box>
+            )}
+        </Box>
+    );
+}
+
+function CapturedStdoutModal({
+    instance,
+    open,
+    onClose,
+}: {
+    instance: TaskInstance | null;
+    open: boolean;
+    onClose: () => void;
+}) {
+    return (
+        <JobmonModal
+            title="Captured Stdout"
+            open={open && !!instance}
+            onClose={onClose}
+            width="min(900px, 85vw)"
+            minHeight="auto"
+        >
+            <LogModalSection
+                label="File path"
+                value={instance?.ti_stdout}
+                kind="path"
+            />
+            <LogModalSection
+                label="Log content"
+                value={instance?.ti_stdout_log}
+                kind="content"
+            />
+        </JobmonModal>
+    );
+}
+
+function CapturedStderrModal({
+    instance,
+    open,
+    onClose,
+}: {
+    instance: TaskInstance | null;
+    open: boolean;
+    onClose: () => void;
+}) {
+    const hasErrorSummary =
+        instance?.ti_error_log_description != null &&
+        instance.ti_error_log_description !== '';
+    return (
+        <JobmonModal
+            title="Captured Stderr"
+            open={open && !!instance}
+            onClose={onClose}
+            width="min(900px, 85vw)"
+            minHeight="auto"
+        >
+            {hasErrorSummary && (
+                <LogModalSection
+                    label="Error summary"
+                    value={instance?.ti_error_log_description}
+                    kind="content"
+                    emphasize
+                />
+            )}
+            <LogModalSection
+                label="File path"
+                value={instance?.ti_stderr}
+                kind="path"
+            />
+            <LogModalSection
+                label="Log content"
+                value={instance?.ti_stderr_log}
+                kind="content"
+            />
+        </JobmonModal>
+    );
+}
+
 function AttemptDetailPanel({
     instance,
     onViewStdout,
@@ -211,6 +428,13 @@ function AttemptDetailPanel({
     onViewStderr: () => void;
 }) {
     const resources = parseResourceJson(instance.ti_resources);
+    // ``parseResourceJson`` projects to {memory, runtime} only. Use the
+    // full-blob parser here so the section shows cores, project,
+    // stdout/stderr, and any user-defined fields.
+    const fullResources = parseRequestedResources(instance.ti_resources);
+    const requestedResourceRows = formatRequestedResourcesFull(
+        fullResources
+    ).filter(r => !HIDDEN_REQ_RES_KEYS.has(r.key));
 
     const requestedMemoryGiB = resources?.memory ?? null;
     const utilizedMemoryGiB = bytes_to_gib(
@@ -231,39 +455,46 @@ function AttemptDetailPanel({
               })
             : null;
 
-    const stderrPreview = instance.ti_stderr_log
-        ? instance.ti_stderr_log.trim().split('\n').slice(-10).join('\n')
-        : null;
+    const tail10 = (s: string | null | undefined) =>
+        s ? s.trim().split('\n').slice(-10).join('\n') : null;
+    const stderrPreview = tail10(instance.ti_stderr_log);
+    const stdoutPreview = tail10(instance.ti_stdout_log);
 
-    // Metadata chips
-    const metaRows: { label: string; value: string }[] = [];
+    const executionRows: { label: string; value: string }[] = [];
     if (instance.ti_workflow_run_id) {
-        metaRows.push({
+        executionRows.push({
             label: 'WF Run',
             value: String(instance.ti_workflow_run_id),
         });
     }
     if (instance.ti_distributor_id) {
-        metaRows.push({
+        executionRows.push({
             label: 'Job ID',
             value: String(instance.ti_distributor_id),
         });
     }
     if (instance.ti_nodename) {
-        metaRows.push({
-            label: 'Node',
-            value: instance.ti_nodename,
-        });
+        executionRows.push({ label: 'Node', value: instance.ti_nodename });
     }
-    metaRows.push({
+    if (instance.ti_cpu) {
+        executionRows.push({ label: 'CPU Usage', value: instance.ti_cpu });
+    }
+    if (instance.ti_io) {
+        executionRows.push({ label: 'I/O', value: instance.ti_io });
+    }
+
+    const requestedRows: { label: string; value: string }[] = [];
+    requestedRows.push({
         label: 'Queue',
         value: instance.ti_queue_name || 'N/A',
     });
-    if (instance.ti_cpu) {
-        metaRows.push({ label: 'CPU', value: instance.ti_cpu });
+    const requestedCores =
+        fullResources.cores ?? fullResources.num_cores ?? null;
+    if (requestedCores !== null && requestedCores !== undefined) {
+        requestedRows.push({ label: 'Cores', value: String(requestedCores) });
     }
-    if (instance.ti_io) {
-        metaRows.push({ label: 'I/O', value: instance.ti_io });
+    for (const { key, value } of requestedResourceRows) {
+        requestedRows.push({ label: formatResourceLabel(key), value });
     }
     // Resource utilization (rendered as inline bars, not text rows)
     const memoryPercent =
@@ -355,40 +586,21 @@ function AttemptDetailPanel({
                 </Box>
             )}
 
-            {/* Metadata key-value grid */}
             <Box
                 sx={{
                     display: 'grid',
-                    gridTemplateColumns:
-                        'max-content 1fr',
-                    gap: '2px 12px',
-                    alignContent: 'start',
-                    mb: 1,
+                    gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' },
+                    columnGap: 3,
+                    rowGap: 1.5,
+                    mb: 1.5,
                 }}
             >
-                {metaRows.map(row => (
-                    <React.Fragment key={row.label}>
-                        <Typography
-                            variant="caption"
-                            color="text.secondary"
-                            fontWeight={600}
-                        >
-                            {row.label}
-                        </Typography>
-                        <Typography
-                            variant="caption"
-                            sx={{
-                                fontFamily:
-                                    'Roboto Mono Variable',
-                            }}
-                        >
-                            {row.value}
-                        </Typography>
-                    </React.Fragment>
-                ))}
+                <AttemptColumn heading="Execution" rows={executionRows} />
+                <AttemptColumn heading="Requested" rows={requestedRows} />
             </Box>
 
-            {/* Resource inline bars */}
+            {/* Resource inline bars — span full panel width so they
+                don't feel orphaned under the Execution column. */}
             <Box
                 sx={{
                     display: 'grid',
@@ -397,7 +609,6 @@ function AttemptDetailPanel({
                     gap: '6px 10px',
                     alignItems: 'center',
                     mb: 1.5,
-                    maxWidth: 500,
                 }}
             >
                 {[
@@ -450,122 +661,88 @@ function AttemptDetailPanel({
                 }}
             />
 
-            {/* Stderr */}
-            <Box sx={{ mb: 1.5 }}>
-                <Box
-                    sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 1,
-                        mb: 0.5,
-                    }}
-                >
-                    <Typography
-                        variant="caption"
-                        fontWeight={700}
-                        sx={{
-                            textTransform: 'uppercase',
-                            letterSpacing: 0.5,
-                        }}
-                    >
-                        Stderr
-                    </Typography>
-                    <Button
-                        size="small"
-                        variant="outlined"
-                        onClick={onViewStderr}
-                        sx={{
-                            py: 0,
-                            px: 0.75,
-                            fontSize: '0.7rem',
-                            minHeight: 0,
-                            lineHeight: 1.5,
-                        }}
-                    >
-                        View Full Log
-                    </Button>
-                </Box>
-                {stderrPreview ? (
+            {[
+                {
+                    key: 'stderr',
+                    label: 'Captured Stderr',
+                    preview: stderrPreview,
+                    onView: onViewStderr,
+                    emptyText: isResourceError
+                        ? 'Killed by cluster (no stderr captured)'
+                        : 'No output',
+                },
+                {
+                    key: 'stdout',
+                    label: 'Captured Stdout',
+                    preview: stdoutPreview,
+                    onView: onViewStdout,
+                    emptyText: 'No output',
+                },
+            ].map(section => (
+                <Box key={section.key} sx={{ mb: 1.5 }}>
                     <Box
                         sx={{
-                            fontFamily: 'Roboto Mono Variable',
-                            fontSize: '0.7rem',
-                            backgroundColor: '#f5f5f5',
-                            border: '1px solid',
-                            borderColor: 'grey.300',
-                            px: 1.5,
-                            py: 1,
-                            borderRadius: 1,
-                            maxHeight: 150,
-                            overflow: 'auto',
-                            whiteSpace: 'pre-wrap',
-                            wordBreak: 'break-word',
-                            lineHeight: 1.6,
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            mb: 0.5,
                         }}
                     >
-                        {stderrPreview}
+                        <Typography
+                            variant="caption"
+                            fontWeight={700}
+                            sx={{
+                                textTransform: 'uppercase',
+                                letterSpacing: 0.5,
+                            }}
+                        >
+                            {section.label}
+                        </Typography>
+                        <Button
+                            size="small"
+                            variant="outlined"
+                            onClick={section.onView}
+                            sx={{
+                                py: 0,
+                                px: 0.75,
+                                fontSize: '0.7rem',
+                                minHeight: 0,
+                                lineHeight: 1.5,
+                            }}
+                        >
+                            View Full Log
+                        </Button>
                     </Box>
-                ) : (
-                    <Typography
-                        variant="caption"
-                        color="text.secondary"
-                    >
-                        {isResourceError
-                            ? 'Killed by cluster (no stderr captured)'
-                            : 'No output'}
-                    </Typography>
-                )}
-            </Box>
-
-            {/* Stdout */}
-            <Box
-                sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                }}
-            >
-                <Typography
-                    variant="caption"
-                    fontWeight={700}
-                    sx={{
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.5,
-                        flexShrink: 0,
-                    }}
-                >
-                    Stdout
-                </Typography>
-                <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    sx={{
-                        fontFamily: 'Roboto Mono Variable',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        flex: 1,
-                        minWidth: 0,
-                    }}
-                >
-                    {instance.ti_stdout || '/dev/null'}
-                </Typography>
-                <Button
-                    size="small"
-                    variant="outlined"
-                    onClick={onViewStdout}
-                    sx={{
-                        py: 0,
-                        px: 0.75,
-                        fontSize: '0.7rem',
-                        minHeight: 0,
-                        lineHeight: 1.5,
-                        flexShrink: 0,
-                    }}
-                >
-                    View Full Log
-                </Button>
-            </Box>
+                    {section.preview ? (
+                        <Box
+                            sx={{
+                                fontFamily: 'Roboto Mono Variable',
+                                fontSize: '0.7rem',
+                                backgroundColor: '#f5f5f5',
+                                border: '1px solid',
+                                borderColor: 'grey.300',
+                                px: 1.5,
+                                py: 1,
+                                borderRadius: 1,
+                                maxHeight: 150,
+                                overflow: 'auto',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-word',
+                                lineHeight: 1.6,
+                            }}
+                        >
+                            {section.preview}
+                        </Box>
+                    ) : (
+                        <Typography
+                            variant="caption"
+                            color="text.secondary"
+                        >
+                            {section.emptyText}
+                        </Typography>
+                    )}
+                </Box>
+            ))}
         </Box>
     );
 }
@@ -899,73 +1076,16 @@ function FallbackInstanceList({
                 })}
             </Box>
 
-            {/* Stdout modal */}
-            <JobmonModal
-                title="Standard Out"
-                open={modalState.type === 'stdout' && !!modalInstance}
+            <CapturedStdoutModal
+                instance={modalInstance}
+                open={modalState.type === 'stdout'}
                 onClose={() => setModalState({ type: null, instance: null })}
-                width="80%"
-            >
-                <Grid container spacing={2}>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">Standard Out Path:</Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            {modalInstance?.ti_stdout}
-                        </ScrollableCodeBlock>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">Standard Out Log:</Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            <pre>{modalInstance?.ti_stdout_log}</pre>
-                        </ScrollableCodeBlock>
-                    </Grid>
-                </Grid>
-            </JobmonModal>
-
-            {/* Stderr modal */}
-            <JobmonModal
-                title="Standard Error"
-                open={modalState.type === 'stderr' && !!modalInstance}
+            />
+            <CapturedStderrModal
+                instance={modalInstance}
+                open={modalState.type === 'stderr'}
                 onClose={() => setModalState({ type: null, instance: null })}
-                width="80%"
-            >
-                <Grid container spacing={2}>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Error Path:
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            {modalInstance?.ti_stderr}
-                        </ScrollableCodeBlock>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Error Log:
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            <pre>{modalInstance?.ti_stderr_log}</pre>
-                        </ScrollableCodeBlock>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Error Description:
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            {modalInstance?.ti_error_log_description}
-                        </ScrollableCodeBlock>
-                    </Grid>
-                </Grid>
-            </JobmonModal>
+            />
         </Box>
     );
 }
@@ -1170,73 +1290,16 @@ export default function TaskStatusTimeline({
                 ))}
             </Box>
 
-            {/* Stdout modal */}
-            <JobmonModal
-                title="Standard Out"
-                open={modalState.type === 'stdout' && !!modalInstance}
+            <CapturedStdoutModal
+                instance={modalInstance}
+                open={modalState.type === 'stdout'}
                 onClose={() => setModalState({ type: null, instance: null })}
-                width="80%"
-            >
-                <Grid container spacing={2}>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">Standard Out Path:</Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            {modalInstance?.ti_stdout}
-                        </ScrollableCodeBlock>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">Standard Out Log:</Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            <pre>{modalInstance?.ti_stdout_log}</pre>
-                        </ScrollableCodeBlock>
-                    </Grid>
-                </Grid>
-            </JobmonModal>
-
-            {/* Stderr modal */}
-            <JobmonModal
-                title="Standard Error"
-                open={modalState.type === 'stderr' && !!modalInstance}
+            />
+            <CapturedStderrModal
+                instance={modalInstance}
+                open={modalState.type === 'stderr'}
                 onClose={() => setModalState({ type: null, instance: null })}
-                width="80%"
-            >
-                <Grid container spacing={2}>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Error Path:
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            {modalInstance?.ti_stderr}
-                        </ScrollableCodeBlock>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Error Log:
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            <pre>{modalInstance?.ti_stderr_log}</pre>
-                        </ScrollableCodeBlock>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <Typography variant="h6">
-                            Standard Error Description:
-                        </Typography>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ScrollableCodeBlock>
-                            {modalInstance?.ti_error_log_description}
-                        </ScrollableCodeBlock>
-                    </Grid>
-                </Grid>
-            </JobmonModal>
+            />
         </Box>
     );
 }

--- a/jobmon_gui/src/components/task_template_details/TaskTable.tsx
+++ b/jobmon_gui/src/components/task_template_details/TaskTable.tsx
@@ -345,14 +345,13 @@ export default function TaskTable({
                               row.original.task_resources_id
                           )
                         : undefined;
-                const summary = formatRequestedResourcesSummary(narrowBlob);
+                // narrowBlob only carries memory/runtime/cores/queue,
+                // so legacy num_cores and user-defined keys are missing
+                // until the batch fetch lands.
+                const blob = fullBlob ?? narrowBlob;
+                const summary = formatRequestedResourcesSummary(blob);
                 if (!summary) return 'N/A';
-                // Prefer the full server blob for the expanded tooltip;
-                // fall back to the narrowed viz-row blob until the batch
-                // fetch lands.
-                const rows = formatRequestedResourcesFull(
-                    fullBlob ?? narrowBlob
-                );
+                const rows = formatRequestedResourcesFull(blob);
                 return (
                     <Tooltip
                         arrow

--- a/jobmon_gui/src/components/task_template_details/TaskTable.tsx
+++ b/jobmon_gui/src/components/task_template_details/TaskTable.tsx
@@ -39,6 +39,12 @@ import {
     getStatusColor,
 } from '@jobmon_gui/constants/taskStatus';
 import humanizeDuration from 'humanize-duration';
+import Tooltip from '@mui/material/Tooltip';
+import {
+    formatRequestedResourcesFull,
+    formatRequestedResourcesSummary,
+} from '@jobmon_gui/utils/requestedResources';
+import RequestedResourcesGrid from '@jobmon_gui/components/common/RequestedResourcesGrid';
 
 /** Priority order for status sorting — error statuses first. */
 const STATUS_SORT_PRIORITY: Record<string, number> = {
@@ -67,6 +73,7 @@ export default function TaskTable({
     selectedWorkflowRunId,
     availableWorkflowRunIds,
     onSelectedWorkflowRunIdChange,
+    fullResourcesById,
 }: TaskTableProps) {
     dayjs.extend(utc);
     const queryClient = useQueryClient();
@@ -324,6 +331,56 @@ export default function TaskTable({
                 return val.toFixed(2);
             },
         }),
+        columnHelper.accessor('requested_resources', {
+            header: 'Requested',
+            size: 220,
+            grow: 1,
+            enableSorting: false,
+            enableColumnFilter: false,
+            Cell: ({ row }) => {
+                const narrowBlob = row.original.requested_resources;
+                const fullBlob =
+                    row.original.task_resources_id != null
+                        ? fullResourcesById?.get(
+                              row.original.task_resources_id
+                          )
+                        : undefined;
+                const summary = formatRequestedResourcesSummary(narrowBlob);
+                if (!summary) return 'N/A';
+                // Prefer the full server blob for the expanded tooltip;
+                // fall back to the narrowed viz-row blob until the batch
+                // fetch lands.
+                const rows = formatRequestedResourcesFull(
+                    fullBlob ?? narrowBlob
+                );
+                return (
+                    <Tooltip
+                        arrow
+                        slotProps={{
+                            tooltip: { sx: { maxWidth: 600 } },
+                        }}
+                        title={
+                            <RequestedResourcesGrid
+                                rows={rows}
+                                sx={{ fontSize: '0.75rem' }}
+                                labelSx={{ opacity: 0.8 }}
+                            />
+                        }
+                    >
+                        <Box
+                            sx={{
+                                fontFamily: 'monospace',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                            }}
+                        >
+                            {summary}
+                        </Box>
+                    </Tooltip>
+                );
+            },
+        }),
     ];
 
     const table = useMaterialReactTable({
@@ -505,6 +562,9 @@ export default function TaskTable({
         const csvData = data.map(r => ({
             ...r,
             task_status_date: formatDayjsDate(r.task_status_date),
+            requested_resources: formatRequestedResourcesSummary(
+                r.requested_resources
+            ),
         }));
         const csv = generateCsv(csvConfig)(csvData);
         download(csvConfig)(csv);

--- a/jobmon_gui/src/components/workflow_details/WorkflowResourcesPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/WorkflowResourcesPanel.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import Chip from '@mui/material/Chip';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { useQuery } from '@tanstack/react-query';
+
+import {
+    getWorkflowRequestedResourcesQueryFn,
+    WorkflowRequestedResourcesQueryKey,
+    WorkflowRequestedResourcesResponse,
+} from '@jobmon_gui/queries/GetWorkflowRequestedResources';
+import RequestedResourceClusterCard from '@jobmon_gui/components/common/RequestedResourceClusterCard';
+
+interface WorkflowResourcesPanelProps {
+    workflowId: string | number;
+    onBack: () => void;
+}
+
+type Cluster = WorkflowRequestedResourcesResponse['clusters'][number];
+type TemplateGroup = { id: number; name: string; clusters: Cluster[] };
+
+function Header({ onBack }: { onBack: () => void }) {
+    return (
+        <>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                <Tooltip title="Back">
+                    <IconButton size="small" onClick={onBack} sx={{ mr: 1 }}>
+                        <ArrowBackIcon fontSize="small" />
+                    </IconButton>
+                </Tooltip>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    Requested Resources
+                </Typography>
+            </Box>
+            <Divider sx={{ mb: 2 }} />
+        </>
+    );
+}
+
+export default function WorkflowResourcesPanel({
+    workflowId,
+    onBack,
+}: WorkflowResourcesPanelProps) {
+    const { data, isLoading, isError } = useQuery({
+        queryKey: [
+            'workflow_requested_resources',
+            workflowId,
+        ] as WorkflowRequestedResourcesQueryKey,
+        queryFn: getWorkflowRequestedResourcesQueryFn,
+        staleTime: 60_000,
+    });
+
+    const templateGroups = useMemo<TemplateGroup[]>(() => {
+        const byId = new Map<number, TemplateGroup>();
+        for (const c of data?.clusters ?? []) {
+            let group = byId.get(c.task_template_id);
+            if (!group) {
+                group = {
+                    id: c.task_template_id,
+                    name: c.task_template_name,
+                    clusters: [],
+                };
+                byId.set(c.task_template_id, group);
+            }
+            group.clusters.push(c);
+        }
+        return Array.from(byId.values());
+    }, [data]);
+
+    return (
+        <Box sx={{ p: 2, height: '100%', overflow: 'auto' }}>
+            <Header onBack={onBack} />
+            {isLoading ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                    <CircularProgress size={28} />
+                </Box>
+            ) : isError ? (
+                <Typography color="error">
+                    Error loading requested resources.
+                </Typography>
+            ) : templateGroups.length === 0 ? (
+                <Typography color="text.secondary" variant="body2">
+                    No bound tasks yet — the workflow must be bound
+                    (<code>workflow.bind()</code>) before requested
+                    resources are visible.
+                </Typography>
+            ) : (
+                templateGroups.map(group => (
+                    <Box key={group.id} sx={{ mb: 2 }}>
+                        <Typography
+                            variant="subtitle2"
+                            sx={{
+                                fontWeight: 600,
+                                mb: 0.5,
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 1,
+                            }}
+                        >
+                            {group.name}
+                            <Chip
+                                size="small"
+                                variant="outlined"
+                                label={`${group.clusters.length} cluster${
+                                    group.clusters.length === 1 ? '' : 's'
+                                }`}
+                            />
+                        </Typography>
+                        {group.clusters.map(c => (
+                            <RequestedResourceClusterCard
+                                key={c.task_resources_id}
+                                cluster={c}
+                                defaultOpen
+                            />
+                        ))}
+                    </Box>
+                ))
+            )}
+        </Box>
+    );
+}

--- a/jobmon_gui/src/components/workflow_details/WorkflowResourcesPanel.tsx
+++ b/jobmon_gui/src/components/workflow_details/WorkflowResourcesPanel.tsx
@@ -113,7 +113,7 @@ export default function WorkflowResourcesPanel({
                         </Typography>
                         {group.clusters.map(c => (
                             <RequestedResourceClusterCard
-                                key={c.task_resources_id}
+                                key={`${c.task_template_version_id}-${c.task_resources_id}`}
                                 cluster={c}
                                 defaultOpen
                             />

--- a/jobmon_gui/src/components/workflow_details/WorkflowSummaryBar.tsx
+++ b/jobmon_gui/src/components/workflow_details/WorkflowSummaryBar.tsx
@@ -5,6 +5,7 @@ import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import BuildIcon from '@mui/icons-material/Build';
+import TuneIcon from '@mui/icons-material/Tune';
 import humanizeDuration from 'humanize-duration';
 import { formatJobmonDate } from '@jobmon_gui/utils/DayTime.ts';
 import { WorkflowDetails } from '@jobmon_gui/types/WorkflowDetails.ts';
@@ -20,12 +21,14 @@ interface WorkflowSummaryBarProps {
     workflowDetails?: WorkflowDetails;
     ttData?: TTStatusResponse;
     onManageClick?: () => void;
+    onResourcesClick?: () => void;
 }
 
 export default function WorkflowSummaryBar({
     workflowDetails,
     ttData,
     onManageClick,
+    onResourcesClick,
 }: WorkflowSummaryBarProps) {
     const [showMore, setShowMore] = useState(false);
 
@@ -132,6 +135,16 @@ export default function WorkflowSummaryBar({
                         {showMore ? 'Less' : 'More \u25B8'}
                     </Typography>
                     <Box sx={{ flex: 1 }} />
+                    {onResourcesClick && (
+                        <Tooltip title="Requested Resources">
+                            <IconButton
+                                size="small"
+                                onClick={onResourcesClick}
+                            >
+                                <TuneIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                    )}
                     {onManageClick && (
                         <Tooltip title="Manage Workflow">
                             <IconButton

--- a/jobmon_gui/src/configs/ApiUrls.ts
+++ b/jobmon_gui/src/configs/ApiUrls.ts
@@ -53,3 +53,8 @@ export const fatal_error_breakdown_url =
 export const get_task_template_id_url = (
     task_template_version_id: number | string
 ) => api_base_url + `/task_template/id/${task_template_version_id}`;
+
+export const workflow_requested_resources_url = (wf_id: number | string) =>
+    api_base_url + `/workflow/${wf_id}/requested_resources`;
+
+export const task_resources_batch_url = api_base_url + '/task_resources/batch';

--- a/jobmon_gui/src/queries/GetWorkflowRequestedResources.ts
+++ b/jobmon_gui/src/queries/GetWorkflowRequestedResources.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { QueryFunctionContext } from '@tanstack/react-query';
+
+import {
+    task_resources_batch_url,
+    workflow_requested_resources_url,
+} from '@jobmon_gui/configs/ApiUrls.ts';
+import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
+import { components } from '@jobmon_gui/types/apiSchema';
+
+export type WorkflowRequestedResourcesResponse =
+    components['schemas']['WorkflowRequestedResourcesResponse'];
+
+export type WorkflowRequestedResourcesQueryKey = readonly [
+    'workflow_requested_resources',
+    string | number,
+];
+
+export const getWorkflowRequestedResourcesQueryFn = async (
+    context: QueryFunctionContext<WorkflowRequestedResourcesQueryKey>
+): Promise<WorkflowRequestedResourcesResponse | undefined> => {
+    const { queryKey } = context;
+    if (!queryKey || queryKey.length !== 2 || queryKey[1] === undefined) {
+        return undefined;
+    }
+    const workflowId = queryKey[1];
+    const response = await axios.get<WorkflowRequestedResourcesResponse>(
+        workflow_requested_resources_url(workflowId),
+        jobmonAxiosConfig
+    );
+    return response.data;
+};
+
+export type TaskResourcesBatchResponse =
+    components['schemas']['TaskResourcesBatchResponse'];
+
+export const getTaskResourcesBatchQueryFn = async (
+    ids: number[]
+): Promise<TaskResourcesBatchResponse> => {
+    if (ids.length === 0) return { resources: [] };
+    const response = await axios.post<TaskResourcesBatchResponse>(
+        task_resources_batch_url,
+        { task_resources_ids: ids },
+        jobmonAxiosConfig
+    );
+    return response.data;
+};

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -290,8 +290,17 @@ export default function TaskTemplateDetails() {
         !usageStream0.hasNextPage &&
         !usageStream1.hasNextPage &&
         !usageStream2.hasNextPage;
+    // Include the id set in the key so the cache keys on inputs — the
+    // ``streamsDone`` gate prevents this from churning mid-stream
+    // because ``uniqueTaskResourcesIds`` only gets queried once
+    // pagination finishes.
     const resourcesBatchQuery = useQuery<TaskResourcesBatchResponse, Error>({
-        queryKey: ['task_resources_batch', workflowId, taskTemplateVersionId],
+        queryKey: [
+            'task_resources_batch',
+            workflowId,
+            taskTemplateVersionId,
+            uniqueTaskResourcesIds,
+        ],
         queryFn: () => getTaskResourcesBatchQueryFn(uniqueTaskResourcesIds),
         enabled: streamsDone && uniqueTaskResourcesIds.length > 0,
         staleTime: 60_000,

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -32,6 +32,10 @@ import { useTaskTemplateDetails } from '@jobmon_gui/queries/GetTaskTemplateDetai
 import { getWorkflowDetailsQueryFn } from '@jobmon_gui/queries/GetWorkflowDetails.ts';
 import { getWorkflowTTStatusQueryFn } from '@jobmon_gui/queries/GetWorkflowTTStatus.ts';
 import { USAGE_PAGE_SIZE } from '@jobmon_gui/queries/GetWorkflowUsage.ts';
+import {
+    getTaskResourcesBatchQueryFn,
+    TaskResourcesBatchResponse,
+} from '@jobmon_gui/queries/GetWorkflowRequestedResources.ts';
 import { usage_url } from '@jobmon_gui/configs/ApiUrls.ts';
 import { jobmonAxiosConfig } from '@jobmon_gui/configs/Axios.ts';
 import {
@@ -52,6 +56,7 @@ import {
     downloadUsageCSV,
     parseResourceJson,
 } from '@jobmon_gui/utils/csvExport';
+import { parseRequestedResources } from '@jobmon_gui/utils/requestedResources';
 import { useUsageFilters } from '@jobmon_gui/hooks/useUsageFilters';
 import {
     calculateResourceEfficiency,
@@ -264,6 +269,44 @@ export default function TaskTemplateDetails() {
             !TaskTemplateDetailsData.isLoading,
     });
 
+    // Full ``requested_resources`` blobs keyed by
+    // ``TaskInstance.task_resources_id`` for the Task Table's Requested
+    // column tooltip. Collected from the viz rows we already have —
+    // typically a handful of unique ids even on large templates — and
+    // hydrated in one batch request.
+    const uniqueTaskResourcesIds = useMemo(() => {
+        const ids = new Set<number>();
+        for (const row of rawTaskNodesFromApi) {
+            if (row.task_resources_id != null) {
+                ids.add(row.task_resources_id);
+            }
+        }
+        return Array.from(ids).sort((a, b) => a - b);
+    }, [rawTaskNodesFromApi]);
+    // Defer the batch fetch until all three streams have drained, so
+    // we issue one request with the full id set instead of N growing
+    // requests (one per page as new ids trickle in).
+    const streamsDone =
+        !usageStream0.hasNextPage &&
+        !usageStream1.hasNextPage &&
+        !usageStream2.hasNextPage;
+    const resourcesBatchQuery = useQuery<TaskResourcesBatchResponse, Error>({
+        queryKey: ['task_resources_batch', workflowId, taskTemplateVersionId],
+        queryFn: () => getTaskResourcesBatchQueryFn(uniqueTaskResourcesIds),
+        enabled: streamsDone && uniqueTaskResourcesIds.length > 0,
+        staleTime: 60_000,
+    });
+    const fullResourcesById = useMemo(() => {
+        const map = new Map<number, Record<string, unknown>>();
+        for (const item of resourcesBatchQuery.data?.resources ?? []) {
+            map.set(
+                item.task_resources_id,
+                (item.requested_resources as Record<string, unknown>) ?? {}
+            );
+        }
+        return map;
+    }, [resourcesBatchQuery.data]);
+
     // Adapt server clusters to the frontend ResourceCluster shape. The
     // server ships only numbers (runtime, memory, task_count); we derive
     // the string cluster id via the same ``createResourceClusterKey`` the
@@ -373,6 +416,10 @@ export default function TaskTemplateDetails() {
                 memory_gib:
                     typeof item.m === 'number' ? bytes_to_gib(item.m) : null,
                 workflow_run_id: item.workflow_run_id ?? null,
+                requested_resources: parseRequestedResources(
+                    item.requested_resources
+                ),
+                task_resources_id: item.task_resources_id ?? null,
             }));
     }, [rawTaskNodesFromApi, passesResourceClusterFilter]);
 
@@ -1051,6 +1098,7 @@ export default function TaskTemplateDetails() {
                         TaskTemplateDetailsData.data.task_template_name
                     }
                     workflowId={workflowId}
+                    fullResourcesById={fullResourcesById}
                     onFilteredInstanceIdsChange={
                         handleTableFilteredInstanceIdsChange
                     }

--- a/jobmon_gui/src/screens/TaskTemplateDetails.tsx
+++ b/jobmon_gui/src/screens/TaskTemplateDetails.tsx
@@ -285,10 +285,16 @@ export default function TaskTemplateDetails() {
     }, [rawTaskNodesFromApi]);
     // Defer the batch fetch until all three streams have drained, so
     // we issue one request with the full id set instead of N growing
-    // requests (one per page as new ids trickle in).
+    // requests (one per page as new ids trickle in). ``hasNextPage``
+    // is ``false`` in TanStack Query's pre-fetch initial state, so we
+    // also gate on ``isFetchedAfterMount`` to make sure the stream has
+    // actually returned at least one page.
     const streamsDone =
+        usageStream0.isFetchedAfterMount &&
         !usageStream0.hasNextPage &&
+        usageStream1.isFetchedAfterMount &&
         !usageStream1.hasNextPage &&
+        usageStream2.isFetchedAfterMount &&
         !usageStream2.hasNextPage;
     // Include the id set in the key so the cache keys on inputs — the
     // ``streamsDone`` gate prevents this from churning mid-stream

--- a/jobmon_gui/src/screens/WorkflowDetails.tsx
+++ b/jobmon_gui/src/screens/WorkflowDetails.tsx
@@ -44,6 +44,7 @@ import TemplateDetailPanel from '@jobmon_gui/components/workflow_details/Templat
 import WorkflowSummaryBar from '@jobmon_gui/components/workflow_details/WorkflowSummaryBar.tsx';
 import TemplateListPanel from '@jobmon_gui/components/workflow_details/TemplateListPanel.tsx';
 import WorkflowManagePanel from '@jobmon_gui/components/workflow_details/WorkflowManagePanel.tsx';
+import WorkflowResourcesPanel from '@jobmon_gui/components/workflow_details/WorkflowResourcesPanel.tsx';
 import ResizableSplitPane from '@jobmon_gui/components/common/ResizableSplitPane.tsx';
 
 const TaskConcurrencyTab = lazy(
@@ -74,7 +75,7 @@ import { getWorkflowFiltersForNavigation } from '@jobmon_gui/utils/workflowFilte
 import { TTStatus } from '@jobmon_gui/types/TaskTemplateStatus';
 import { compare } from 'compare-versions';
 
-type LeftPanelView = 'list' | 'template' | 'manage';
+type LeftPanelView = 'list' | 'template' | 'manage' | 'resources';
 
 function WorkflowDetails() {
     const { workflowId } = useParams();
@@ -201,6 +202,14 @@ function WorkflowDetails() {
         setLeftPanelView('list');
     };
 
+    const handleResourcesClick = () => {
+        setLeftPanelView('resources');
+    };
+
+    const handleResourcesBack = () => {
+        setLeftPanelView('list');
+    };
+
     const resetStoresAndNavigate = (
         ttId: string | number,
         ttvId: string | number
@@ -272,6 +281,11 @@ function WorkflowDetails() {
             workflowDetails={wfDetails.data}
             onBack={handleManageBack}
             onClose={handleManageClose}
+        />
+    ) : leftPanelView === 'resources' ? (
+        <WorkflowResourcesPanel
+            workflowId={workflowId!}
+            onBack={handleResourcesBack}
         />
     ) : (
         <TemplateListPanel
@@ -418,6 +432,7 @@ function WorkflowDetails() {
                 workflowDetails={wfDetails.data}
                 ttData={wfTTStatus.data}
                 onManageClick={handleManageClick}
+                onResourcesClick={handleResourcesClick}
             />
 
             {/* Middle + Bottom with vertical resize */}

--- a/jobmon_gui/src/types/TaskTable.ts
+++ b/jobmon_gui/src/types/TaskTable.ts
@@ -13,6 +13,8 @@ export type TaskInstanceRow = {
     runtime_seconds: number | null;
     memory_gib: number | null;
     workflow_run_id: number | null;
+    requested_resources: Record<string, unknown>;
+    task_resources_id: number | null;
 };
 
 export type TaskTableProps = {
@@ -26,4 +28,5 @@ export type TaskTableProps = {
     selectedWorkflowRunId: number | null;
     availableWorkflowRunIds: number[];
     onSelectedWorkflowRunIdChange: (id: number | null) => void;
+    fullResourcesById?: Map<number, Record<string, unknown>>;
 };

--- a/jobmon_gui/src/types/apiSchema.ts
+++ b/jobmon_gui/src/types/apiSchema.ts
@@ -790,6 +790,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    '/api/v3/task_resources/batch': {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Get Task Resources Batch
+         * @description Return ``requested_resources`` + ``queue_name`` for many ids in one query.
+         *
+         *     Used by the Task Template Details task table to build a
+         *     ``task_resources_id → full blob`` map keyed on
+         *     ``TaskInstance.task_resources_id``. The single-id ``POST
+         *     /task_resources/{id}`` endpoint works fine for one-off lookups but
+         *     issues N round-trips when the frontend needs N entries.
+         */
+        post: operations['get_task_resources_batch_api_v3_task_resources_batch_post'];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     '/api/v3/tool': {
         parameters: {
             query?: never;
@@ -1439,6 +1465,31 @@ export interface paths {
          * @description Get the tasks for a given workflow.
          */
         get: operations['get_workflow_tasks_api_v3_workflow__workflow_id__workflow_tasks_get'];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    '/api/v3/workflow/{workflow_id}/requested_resources': {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Workflow Requested Resources
+         * @description Return the requested-resource clusters for a workflow.
+         *
+         *     One entry per unique ``(task_template, task_resources_id)``, with
+         *     ``num_tasks``, ``queue_name``, and the raw ``requested_resources``
+         *     JSON blob. Available as soon as the workflow is bound — no
+         *     TaskInstance required.
+         */
+        get: operations['get_workflow_requested_resources_api_v3_workflow__workflow_id__requested_resources_get'];
         put?: never;
         post?: never;
         delete?: never;
@@ -2430,6 +2481,35 @@ export interface components {
             detail?: components['schemas']['ValidationError'][];
         };
         /**
+         * RequestedResourceClusterItem
+         * @description One (task_template, task_resources_id) cluster of requested resources.
+         *
+         *     Sourced from ``task_resources`` rows joined through ``task`` — so the
+         *     cluster is visible as soon as the workflow has been bound, even before
+         *     any TaskInstances have launched. ``requested_resources`` is the raw
+         *     JSON blob the user configured; fields are intentionally unrestricted
+         *     (``Dict[str, Any]``) because ``RequestedResourcesModel`` is only a
+         *     hint — users can stuff arbitrary keys into compute_resources.
+         */
+        RequestedResourceClusterItem: {
+            /** Task Template Id */
+            task_template_id: number;
+            /** Task Template Name */
+            task_template_name: string;
+            /** Task Template Version Id */
+            task_template_version_id: number;
+            /** Task Resources Id */
+            task_resources_id: number;
+            /** Queue Name */
+            queue_name?: string | null;
+            /** Num Tasks */
+            num_tasks: number;
+            /** Requested Resources */
+            requested_resources: {
+                [key: string]: unknown;
+            };
+        };
+        /**
          * ResourceClusterItem
          * @description One requested-resource cluster summary.
          *
@@ -2655,6 +2735,8 @@ export interface components {
             task_name?: string | null;
             /** Requested Resources */
             requested_resources?: string | null;
+            /** Task Resources Id */
+            task_resources_id?: number | null;
             /** Attempt Number Of Instance */
             attempt_number_of_instance?: number | null;
             /** Status */
@@ -2669,6 +2751,34 @@ export interface components {
             task_max_attempts?: number | null;
             /** Workflow Run Id */
             workflow_run_id?: number | null;
+        };
+        /**
+         * TaskResourcesBatchItem
+         * @description One entry in the batch response.
+         */
+        TaskResourcesBatchItem: {
+            /** Task Resources Id */
+            task_resources_id: number;
+            /** Requested Resources */
+            requested_resources?: unknown;
+            /** Queue Name */
+            queue_name?: string | null;
+        };
+        /**
+         * TaskResourcesBatchRequest
+         * @description Request body for ``/task_resources/batch``.
+         */
+        TaskResourcesBatchRequest: {
+            /** Task Resources Ids */
+            task_resources_ids: number[];
+        };
+        /**
+         * TaskResourcesBatchResponse
+         * @description Response for ``/task_resources/batch``.
+         */
+        TaskResourcesBatchResponse: {
+            /** Resources */
+            resources: components['schemas']['TaskResourcesBatchItem'][];
         };
         /**
          * TaskStatusAuditRecord
@@ -3014,6 +3124,14 @@ export interface components {
         WorkflowOverviewResponse: {
             /** Workflows */
             workflows: components['schemas']['WorkflowOverviewItem'][];
+        };
+        /**
+         * WorkflowRequestedResourcesResponse
+         * @description Response for ``GET /workflow/{wfid}/requested_resources``.
+         */
+        WorkflowRequestedResourcesResponse: {
+            /** Clusters */
+            clusters: components['schemas']['RequestedResourceClusterItem'][];
         };
         /**
          * WorkflowResourceErrorCheckResponse
@@ -4089,6 +4207,39 @@ export interface operations {
             };
         };
     };
+    get_task_resources_batch_api_v3_task_resources_batch_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                'application/json': components['schemas']['TaskResourcesBatchRequest'];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['TaskResourcesBatchResponse'];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['HTTPValidationError'];
+                };
+            };
+        };
+    };
     add_tool_api_v3_tool_post: {
         parameters: {
             query?: never;
@@ -4922,6 +5073,37 @@ export interface operations {
                 };
                 content: {
                     'application/json': components['schemas']['WorkflowTasksResponse'];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['HTTPValidationError'];
+                };
+            };
+        };
+    };
+    get_workflow_requested_resources_api_v3_workflow__workflow_id__requested_resources_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    'application/json': components['schemas']['WorkflowRequestedResourcesResponse'];
                 };
             };
             /** @description Validation Error */

--- a/jobmon_gui/src/utils/requestedResources.ts
+++ b/jobmon_gui/src/utils/requestedResources.ts
@@ -94,8 +94,12 @@ export const formatRequestedResourcesSummary = (
 ): string => {
     if (!blob || typeof blob !== 'object') return '';
     const parts: string[] = [];
+    // ``cores`` takes precedence over the legacy ``num_cores`` alias —
+    // showing both would render "4 cores · 4 cores".
+    const hasCores = blob.cores !== undefined && blob.cores !== null;
     for (const k of ['memory', 'runtime', 'cores', 'num_cores', 'queue']) {
         if (blob[k] === undefined || blob[k] === null) continue;
+        if (k === 'num_cores' && hasCores) continue;
         if (k === 'queue') {
             parts.push(String(blob[k]));
         } else {
@@ -112,7 +116,9 @@ export const formatRequestedResourcesFull = (
     if (!blob || typeof blob !== 'object') return [];
     const seen = new Set<string>();
     const rows: { key: string; value: string }[] = [];
+    const hasCores = blob.cores !== undefined && blob.cores !== null;
     for (const k of KNOWN_KEYS) {
+        if (k === 'num_cores' && hasCores) continue;
         if (k in blob && blob[k] !== null && blob[k] !== undefined) {
             rows.push({ key: k, value: formatValue(k, blob[k]) });
             seen.add(k);

--- a/jobmon_gui/src/utils/requestedResources.ts
+++ b/jobmon_gui/src/utils/requestedResources.ts
@@ -1,0 +1,129 @@
+import humanizeDuration from 'humanize-duration';
+
+export type RequestedResources = Record<string, unknown>;
+
+/** Parse a ``requested_resources`` value into a full dict. Unlike
+ *  ``parseResourceJson`` (which projects to {memory, runtime}), this
+ *  preserves every key the user put in compute_resources. */
+export const parseRequestedResources = (
+    json: string | Record<string, unknown> | null | undefined
+): RequestedResources => {
+    if (json == null) return {};
+    if (typeof json === 'object') return json as RequestedResources;
+    try {
+        const parsed = JSON.parse(json);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+        return {};
+    }
+};
+
+const KNOWN_KEYS = ['memory', 'runtime', 'cores', 'num_cores', 'queue'];
+
+// ``standard_output`` / ``standard_error`` are Slurm's ``--output`` /
+// ``--error`` redirects, whereas Jobmon's ``stdout`` / ``stderr`` are
+// the directories where Jobmon captures worker logs. Prefix the Slurm
+// ones so the ownership is obvious if both ever show up together.
+const LABEL_OVERRIDES: Record<string, string> = {
+    stdout: 'Stdout Dir',
+    stderr: 'Stderr Dir',
+    standard_output: 'Slurm Standard Output',
+    standard_error: 'Slurm Standard Error',
+    working_dir: 'Working Dir',
+    num_cores: 'Cores',
+    cpu: 'CPU',
+    io: 'I/O',
+};
+
+export const formatResourceLabel = (key: string): string => {
+    if (key in LABEL_OVERRIDES) return LABEL_OVERRIDES[key];
+    const spaced = key.replace(/_/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2');
+    return spaced
+        .split(' ')
+        .filter(Boolean)
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+        .join(' ');
+};
+
+const formatNumeric = (v: unknown): number | null => {
+    const n = typeof v === 'number' ? v : Number(v);
+    return Number.isFinite(n) ? n : null;
+};
+
+const formatRuntime = (v: unknown): string => {
+    const n = formatNumeric(v);
+    if (n === null) return String(v);
+    return humanizeDuration(n * 1000, { largest: 2, round: true });
+};
+
+const formatMemory = (v: unknown): string => {
+    // requested_resources.memory is in GiB by jobmon convention.
+    const n = formatNumeric(v);
+    if (n === null) return String(v);
+    return `${n >= 10 ? n.toFixed(0) : n.toFixed(1)} GiB`;
+};
+
+const formatCores = (v: unknown): string => {
+    const n = formatNumeric(v);
+    if (n === null) return String(v);
+    return `${n} core${n === 1 ? '' : 's'}`;
+};
+
+const formatValue = (key: string, value: unknown): string => {
+    if (value === null || value === undefined) return '';
+    if (key === 'memory') return formatMemory(value);
+    if (key === 'runtime') return formatRuntime(value);
+    if (key === 'cores' || key === 'num_cores') return formatCores(value);
+    if (
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+    ) {
+        return String(value);
+    }
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+};
+
+/** Short single-line summary (table cell default). */
+export const formatRequestedResourcesSummary = (
+    blob: RequestedResources | null | undefined
+): string => {
+    if (!blob || typeof blob !== 'object') return '';
+    const parts: string[] = [];
+    for (const k of ['memory', 'runtime', 'cores', 'num_cores', 'queue']) {
+        if (blob[k] === undefined || blob[k] === null) continue;
+        if (k === 'queue') {
+            parts.push(String(blob[k]));
+        } else {
+            parts.push(formatValue(k, blob[k]));
+        }
+    }
+    return parts.join(' · ');
+};
+
+/** Ordered (key, value) pairs for full-blob expansion. Known keys first. */
+export const formatRequestedResourcesFull = (
+    blob: RequestedResources | null | undefined
+): { key: string; value: string }[] => {
+    if (!blob || typeof blob !== 'object') return [];
+    const seen = new Set<string>();
+    const rows: { key: string; value: string }[] = [];
+    for (const k of KNOWN_KEYS) {
+        if (k in blob && blob[k] !== null && blob[k] !== undefined) {
+            rows.push({ key: k, value: formatValue(k, blob[k]) });
+            seen.add(k);
+        }
+    }
+    const rest = Object.keys(blob)
+        .filter(k => !seen.has(k))
+        .sort();
+    for (const k of rest) {
+        if (blob[k] === null || blob[k] === undefined) continue;
+        rows.push({ key: k, value: formatValue(k, blob[k]) });
+    }
+    return rows;
+};

--- a/jobmon_gui/src/utils/requestedResources.ts
+++ b/jobmon_gui/src/utils/requestedResources.ts
@@ -118,7 +118,10 @@ export const formatRequestedResourcesFull = (
     const rows: { key: string; value: string }[] = [];
     const hasCores = blob.cores !== undefined && blob.cores !== null;
     for (const k of KNOWN_KEYS) {
-        if (k === 'num_cores' && hasCores) continue;
+        if (k === 'num_cores' && hasCores) {
+            seen.add(k);
+            continue;
+        }
         if (k in blob && blob[k] !== null && blob[k] !== undefined) {
             rows.push({ key: k, value: formatValue(k, blob[k]) });
             seen.add(k);

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -41,7 +41,6 @@ from jobmon.server.web.schemas.task_template import (
     TaskResourceVizItem,
     TaskTemplateDetailsResponse,
     TaskTemplateResourceAggregatesResponse,
-    TaskTemplateResourceUsageRequest,
     TaskTemplateVersionItem,
     TaskTemplateVersionResponse,
     WorkflowTaskTemplateStatusItem,
@@ -1084,41 +1083,6 @@ class TaskTemplateRepository:
             )
 
         return resp
-
-    def get_task_template_resource_usage(
-        self, req: TaskTemplateResourceUsageRequest
-    ) -> Optional[List[TaskResourceVizItem]]:
-        task_details_list: List[TaskResourceDetailItem] = (
-            self.get_task_resource_details(
-                task_template_version_id=req.task_template_version_id,
-                workflows=req.workflows,
-                node_args=req.node_args,
-            )
-        )
-
-        viz_data: Optional[List[TaskResourceVizItem]] = None
-        if req.viz:
-            viz_data = []
-            for detail_item in task_details_list:
-                viz_data.append(
-                    TaskResourceVizItem(
-                        r=detail_item.r,
-                        m=detail_item.m,
-                        node_id=detail_item.node_id,
-                        task_id=detail_item.task_id,
-                        task_instance_id=detail_item.task_instance_id,
-                        task_name=detail_item.task_name,
-                        requested_resources=detail_item.requested_resources,
-                        attempt_number_of_instance=detail_item.attempt_number_of_instance,
-                        status=detail_item.status,
-                        task_status_date=detail_item.task_status_date,
-                        task_command=detail_item.task_command,
-                        task_num_attempts=detail_item.task_num_attempts,
-                        task_max_attempts=detail_item.task_max_attempts,
-                    )
-                )
-
-        return viz_data
 
     def _find_ttvid(self, workflow_id: int, task_template_id: int) -> Optional[int]:
         """Find task template version ID for a workflow + task template.

--- a/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/task_template_repository.py
@@ -105,6 +105,7 @@ class TaskTemplateRepository:
                 task_instance_id=row_data.get("task_instance_id"),
                 task_name=row_data.get("task_name"),
                 requested_resources=row_data["requested_resources"],
+                task_resources_id=row_data.get("task_resources_id"),
                 attempt_number_of_instance=row_data.get("attempt_number_of_instance"),
                 status=row_data.get("status_orig"),
                 task_status_date=row_data.get("task_status_date"),
@@ -243,6 +244,7 @@ class TaskTemplateRepository:
                 ),
                 TaskInstance.id.label("task_instance_id_col"),
                 TaskInstance.workflow_run_id.label("workflow_run_id_col"),
+                TaskInstance.task_resources_id.label("task_resources_id_col"),
             )
 
             if paged_ids is not None:
@@ -297,6 +299,7 @@ class TaskTemplateRepository:
                     "task_max_attempts": row[9],  # task_max_attempts_col
                     "task_instance_id": row[12],  # task_instance_id_col
                     "workflow_run_id": row[13],  # workflow_run_id_col
+                    "task_resources_id": row[14],  # task_resources_id_col
                 }
                 item = self._convert_to_task_resource_detail_item(row_data)
                 if item:
@@ -360,6 +363,7 @@ class TaskTemplateRepository:
                 Task.max_attempts.label("task_max_attempts"),
                 TaskInstance.id.label("task_instance_id"),
                 TaskInstance.workflow_run_id,
+                TaskInstance.task_resources_id.label("task_resources_id"),
             )
             .select_from(TaskTemplateVersion)
             .join(
@@ -409,6 +413,7 @@ class TaskTemplateRepository:
             base_query.c.task_max_attempts,
             base_query.c.task_instance_id,
             base_query.c.workflow_run_id,
+            base_query.c.task_resources_id,
         ).select_from(base_query)
 
         for subquery in node_arg_subqueries:
@@ -444,6 +449,7 @@ class TaskTemplateRepository:
                 "task_max_attempts": row[11],  # task_max_attempts
                 "task_instance_id": row[12],  # task_instance_id
                 "workflow_run_id": row[13],  # workflow_run_id
+                "task_resources_id": row[14],  # task_resources_id
             }
             item = self._convert_to_task_resource_detail_item(row_data)
             if item:

--- a/jobmon_server/src/jobmon/server/web/repositories/workflow_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/workflow_repository.py
@@ -163,16 +163,22 @@ class WorkflowRepository:
         pre-launch. The Task Template Details task table (TI-indexed)
         uses ``/task_resources/batch`` for its lookup instead.
         """
-        # Group only on the two PKs — all other selected columns are
-        # functionally determined by them, so ``MAX(...)`` keeps MySQL
-        # ``ONLY_FULL_GROUP_BY`` (and SQLite) happy without grouping on
-        # the TEXT ``requested_resources`` column (which forces a
-        # temp-table filesort on large workflows).
+        # Group by every column whose identity must be preserved in
+        # the output row: ``TaskTemplateVersion.id`` isn't FD'd by
+        # ``(TaskTemplate.id, TaskResources.id)`` — a single
+        # (template, resources) pair can span versions — so it goes in
+        # the GROUP BY rather than being wrapped in ``MAX`` (which
+        # would arbitrarily pick one version). ``TaskTemplate.name``
+        # and ``Queue.name`` are FD'd by their own PKs and stay under
+        # ``MAX`` to avoid grouping on non-key columns. The TEXT
+        # ``requested_resources`` blob is FD'd by ``TaskResources.id``
+        # and also stays under ``MAX`` so MySQL doesn't temp-table
+        # filesort on it.
         rows = self.session.execute(
             select(
                 TaskTemplate.id,
                 func.max(TaskTemplate.name),
-                func.max(TaskTemplateVersion.id),
+                TaskTemplateVersion.id,
                 TaskResources.id,
                 func.max(Queue.name),
                 func.count(Task.id),
@@ -191,7 +197,7 @@ class WorkflowRepository:
             .join(TaskResources, Task.task_resources_id == TaskResources.id)
             .outerjoin(Queue, TaskResources.queue_id == Queue.id)
             .where(Task.workflow_id == workflow_id)
-            .group_by(TaskTemplate.id, TaskResources.id)
+            .group_by(TaskTemplate.id, TaskTemplateVersion.id, TaskResources.id)
             .order_by(TaskTemplate.id, TaskResources.id)
         ).all()
 

--- a/jobmon_server/src/jobmon/server/web/repositories/workflow_repository.py
+++ b/jobmon_server/src/jobmon/server/web/repositories/workflow_repository.py
@@ -28,12 +28,14 @@ from jobmon.server.web.models.workflow_attribute_type import (
 from jobmon.server.web.models.workflow_run import WorkflowRun
 from jobmon.server.web.models.workflow_status import WorkflowStatus
 from jobmon.server.web.schemas.workflow import (
+    RequestedResourceClusterItem,
     TaskTableItem,
     TaskTableResponse,
     WorkflowDetailsItem,
     WorkflowOverviewFilters,
     WorkflowOverviewItem,
     WorkflowOverviewResponse,
+    WorkflowRequestedResourcesResponse,
     WorkflowRunForResetResponse,
     WorkflowStatusResponse,
     WorkflowTasksResponse,
@@ -41,6 +43,7 @@ from jobmon.server.web.schemas.workflow import (
     WorkflowValidationResponse,
 )
 from jobmon.server.web.services.transition_service import TransitionService
+from jobmon.server.web.utils.json_compat import deserialize_requested_resources
 
 logger = structlog.get_logger(__name__)
 
@@ -150,6 +153,68 @@ class WorkflowRepository:
             df_json = df.to_json()
 
         return WorkflowTasksResponse(workflow_tasks=df_json)
+
+    def get_workflow_requested_resources(
+        self, workflow_id: int
+    ) -> WorkflowRequestedResourcesResponse:
+        """Return one cluster per unique ``(task_template, task_resources_id)``.
+
+        Sourced from ``Task.task_resources_id`` so the panel works
+        pre-launch. The Task Template Details task table (TI-indexed)
+        uses ``/task_resources/batch`` for its lookup instead.
+        """
+        # Group only on the two PKs — all other selected columns are
+        # functionally determined by them, so ``MAX(...)`` keeps MySQL
+        # ``ONLY_FULL_GROUP_BY`` (and SQLite) happy without grouping on
+        # the TEXT ``requested_resources`` column (which forces a
+        # temp-table filesort on large workflows).
+        rows = self.session.execute(
+            select(
+                TaskTemplate.id,
+                func.max(TaskTemplate.name),
+                func.max(TaskTemplateVersion.id),
+                TaskResources.id,
+                func.max(Queue.name),
+                func.count(Task.id),
+                func.max(TaskResources.requested_resources),
+            )
+            .select_from(Task)
+            .join(Node, Task.node_id == Node.id)
+            .join(
+                TaskTemplateVersion,
+                Node.task_template_version_id == TaskTemplateVersion.id,
+            )
+            .join(
+                TaskTemplate,
+                TaskTemplateVersion.task_template_id == TaskTemplate.id,
+            )
+            .join(TaskResources, Task.task_resources_id == TaskResources.id)
+            .outerjoin(Queue, TaskResources.queue_id == Queue.id)
+            .where(Task.workflow_id == workflow_id)
+            .group_by(TaskTemplate.id, TaskResources.id)
+            .order_by(TaskTemplate.id, TaskResources.id)
+        ).all()
+
+        clusters: List[RequestedResourceClusterItem] = []
+        for tt_id, tt_name, ttv_id, tr_id, q_name, n, raw_blob in rows:
+            try:
+                parsed = deserialize_requested_resources(raw_blob) or {}
+            except (ValueError, SyntaxError):
+                parsed = {"_raw": raw_blob}
+            if not isinstance(parsed, dict):
+                parsed = {"_raw": parsed}
+            clusters.append(
+                RequestedResourceClusterItem(
+                    task_template_id=int(tt_id),
+                    task_template_name=tt_name,
+                    task_template_version_id=int(ttv_id),
+                    task_resources_id=int(tr_id),
+                    queue_name=q_name,
+                    num_tasks=int(n),
+                    requested_resources=parsed,
+                )
+            )
+        return WorkflowRequestedResourcesResponse(clusters=clusters)
 
     def get_workflow_user_validation(
         self, workflow_id: int, username: str

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/task_template.py
@@ -175,6 +175,7 @@ async def get_task_template_resource_usage(
                         task_instance_id=detail_item.task_instance_id,
                         task_name=detail_item.task_name,
                         requested_resources=detail_item.requested_resources,
+                        task_resources_id=detail_item.task_resources_id,
                         attempt_number_of_instance=detail_item.attempt_number_of_instance,
                         status=detail_item.status,
                         task_status_date=detail_item.task_status_date,

--- a/jobmon_server/src/jobmon/server/web/routes/v3/cli/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/cli/workflow.py
@@ -19,6 +19,7 @@ from jobmon.server.web.schemas.workflow import (
     WorkflowDetailsItem,
     WorkflowOverviewFilters,
     WorkflowOverviewResponse,
+    WorkflowRequestedResourcesResponse,
     WorkflowRunForResetResponse,
     WorkflowStatusResponse,
     WorkflowTasksResponse,
@@ -103,6 +104,22 @@ def get_workflow_tasks(
     """Get the tasks for a given workflow."""
     workflow_repo = WorkflowRepository(db)
     return workflow_repo.get_workflow_tasks(workflow_id, limit, status)
+
+
+@api_v3_router.get("/workflow/{workflow_id}/requested_resources")
+def get_workflow_requested_resources(
+    workflow_id: int,
+    db: Session = Depends(get_db),
+) -> WorkflowRequestedResourcesResponse:
+    """Return the requested-resource clusters for a workflow.
+
+    One entry per unique ``(task_template, task_resources_id)``, with
+    ``num_tasks``, ``queue_name``, and the raw ``requested_resources``
+    JSON blob. Available as soon as the workflow is bound — no
+    TaskInstance required.
+    """
+    workflow_repo = WorkflowRepository(db)
+    return workflow_repo.get_workflow_requested_resources(workflow_id)
 
 
 @api_v3_router.get("/workflow/{workflow_id}/validate_username/{username}")

--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_resources.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/task_resources.py
@@ -1,12 +1,11 @@
 """Routes for Task Resources."""
 
-import ast
-import json
 from http import HTTPStatus as StatusCodes
-from typing import Any
+from typing import Any, List, Optional
 
 import structlog
-from fastapi import Depends
+from fastapi import Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
@@ -16,24 +15,82 @@ from jobmon.server.web.db.deps import get_db
 from jobmon.server.web.models.queue import Queue
 from jobmon.server.web.models.task_resources import TaskResources
 from jobmon.server.web.routes.v3.fsm import fsm_router as api_v3_router
+from jobmon.server.web.utils.json_compat import deserialize_requested_resources
 
 logger = structlog.get_logger(__name__)
 
-
-def _deserialize_requested_resources(raw: str) -> Any:
-    """Deserialize a requested_resources column value.
-
-    New rows are written via ``json.dumps`` by ``/task/bind_resources``, which
-    emits JSON (lowercase ``true``/``false``/``null``). Older rows may be
-    Python ``repr``-style (``True``/``False``/``None``) from pre-FastAPI
-    versions. Try JSON first, fall back to ``ast.literal_eval``.
-    """
-    try:
-        return json.loads(raw)
-    except (ValueError, TypeError):
-        return ast.literal_eval(raw)
+# Reject oversized batch requests — prevents a buggy/malicious client
+# from triggering a 100k-IN query.
+MAX_BATCH_IDS = 1000
 
 
+class TaskResourcesBatchRequest(BaseModel):
+    """Request body for ``/task_resources/batch``."""
+
+    task_resources_ids: List[int]
+
+
+class TaskResourcesBatchItem(BaseModel):
+    """One entry in the batch response."""
+
+    task_resources_id: int
+    requested_resources: Any = None
+    queue_name: Optional[str] = None
+
+
+class TaskResourcesBatchResponse(BaseModel):
+    """Response for ``/task_resources/batch``."""
+
+    resources: List[TaskResourcesBatchItem]
+
+
+@api_v3_router.post(
+    "/task_resources/batch",
+    response_model=TaskResourcesBatchResponse,
+)
+def get_task_resources_batch(
+    request_data: TaskResourcesBatchRequest,
+    db: Session = Depends(get_db),
+) -> TaskResourcesBatchResponse:
+    """Return ``requested_resources`` + ``queue_name`` for many ids in one query."""
+    ids = list(set(request_data.task_resources_ids))
+    if not ids:
+        return TaskResourcesBatchResponse(resources=[])
+    if len(ids) > MAX_BATCH_IDS:
+        raise HTTPException(
+            status_code=StatusCodes.BAD_REQUEST,
+            detail=f"task_resources_ids exceeds {MAX_BATCH_IDS}",
+        )
+
+    rows = db.execute(
+        select(
+            TaskResources.id,
+            TaskResources.requested_resources,
+            Queue.name,
+        )
+        .outerjoin(Queue, TaskResources.queue_id == Queue.id)
+        .where(TaskResources.id.in_(ids))
+    ).all()
+
+    items: List[TaskResourcesBatchItem] = []
+    for tr_id, raw, queue_name in rows:
+        try:
+            parsed: Any = deserialize_requested_resources(raw)
+        except (ValueError, SyntaxError):
+            parsed = None
+        items.append(
+            TaskResourcesBatchItem(
+                task_resources_id=int(tr_id),
+                requested_resources=parsed,
+                queue_name=queue_name,
+            )
+        )
+    return TaskResourcesBatchResponse(resources=items)
+
+
+# NOTE: keep this route below ``/task_resources/batch`` so FastAPI
+# matches the literal ``batch`` path before falling through to the
+# generic path-param route.
 @api_v3_router.post("/task_resources/{task_resources_id}")
 def get_task_resources(task_resources_id: int, db: Session = Depends(get_db)) -> Any:
     """Return an task_resources."""
@@ -47,7 +104,7 @@ def get_task_resources(task_resources_id: int, db: Session = Depends(get_db)) ->
     row = db.execute(select_stmt).fetchone()
     requested_resources_raw, queue_name = row if row else (None, None)
     requested_resources = (
-        _deserialize_requested_resources(requested_resources_raw)
+        deserialize_requested_resources(requested_resources_raw)
         if requested_resources_raw
         else None
     )

--- a/jobmon_server/src/jobmon/server/web/schemas/task_template.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/task_template.py
@@ -103,6 +103,7 @@ class TaskResourceDetailItem(BaseModel):
     task_instance_id: Optional[int] = None
     task_name: Optional[str] = None
     requested_resources: Optional[str] = None  # Raw JSON string from DB
+    task_resources_id: Optional[int] = None
     attempt_number_of_instance: Optional[int] = None  # Added field
     status: Optional[str] = None  # Added field: Will hold 'D', 'F', etc.
     task_status_date: Optional[datetime] = None
@@ -121,6 +122,7 @@ class TaskResourceVizItem(BaseModel):
     task_instance_id: Optional[int] = None
     task_name: Optional[str] = None
     requested_resources: Optional[str] = None
+    task_resources_id: Optional[int] = None
     attempt_number_of_instance: Optional[int] = None
     status: Optional[str] = None
     task_status_date: Optional[datetime] = None

--- a/jobmon_server/src/jobmon/server/web/schemas/workflow.py
+++ b/jobmon_server/src/jobmon/server/web/schemas/workflow.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict
 
@@ -142,3 +142,29 @@ class WorkflowDetailsResponse(BaseModel):
     """Response model for workflow details."""
 
     pass  # This will be a List[WorkflowDetailsItem] but FastAPI handles this automatically
+
+
+class RequestedResourceClusterItem(BaseModel):
+    """One (task_template, task_resources_id) cluster of requested resources.
+
+    Sourced from ``task_resources`` rows joined through ``task`` — so the
+    cluster is visible as soon as the workflow has been bound, even before
+    any TaskInstances have launched. ``requested_resources`` is the raw
+    JSON blob the user configured; fields are intentionally unrestricted
+    (``Dict[str, Any]``) because ``RequestedResourcesModel`` is only a
+    hint — users can stuff arbitrary keys into compute_resources.
+    """
+
+    task_template_id: int
+    task_template_name: str
+    task_template_version_id: int
+    task_resources_id: int
+    queue_name: Optional[str] = None
+    num_tasks: int
+    requested_resources: Dict[str, Any]
+
+
+class WorkflowRequestedResourcesResponse(BaseModel):
+    """Response for ``GET /workflow/{wfid}/requested_resources``."""
+
+    clusters: List[RequestedResourceClusterItem]

--- a/jobmon_server/src/jobmon/server/web/utils/json_compat.py
+++ b/jobmon_server/src/jobmon/server/web/utils/json_compat.py
@@ -1,7 +1,25 @@
 """Utility functions for JSON compatibility between old and new client versions."""
 
+import ast
 import json
 from typing import Any, List, Optional
+
+
+def deserialize_requested_resources(raw: Optional[str]) -> Any:
+    """Parse a ``task_resources.requested_resources`` column value.
+
+    New rows are ``json.dumps``'d by ``/task/bind_resources`` (lowercase
+    ``true``/``false``/``null``). Older rows are Python ``repr``-style
+    (``True``/``False``/``None``) from pre-FastAPI versions. Try JSON
+    first, fall back to ``ast.literal_eval``.
+    """
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return ast.literal_eval(raw)
+
 
 # Version cutoff for JSON compatibility
 # Clients <= this version expect quoted JSON strings (old format)

--- a/tests/integration/cli/test_cli_routes.py
+++ b/tests/integration/cli/test_cli_routes.py
@@ -368,6 +368,53 @@ def test_get_workflow_tasks(db_engine, tool):
     assert len(result) == 1
 
 
+def test_get_workflow_requested_resources(db_engine, tool):
+    """Two tasks with distinct compute_resources should produce two clusters.
+
+    Exercises the post-bind, pre-launch state — we never call ``wf.run()``
+    so no TaskInstance exists; the endpoint must still find the
+    task_resources rows via ``Task.task_resources_id``.
+    """
+    t = tool
+    wf = t.create_workflow(name="requested_resources_test")
+    tt = t.get_task_template(
+        template_name="tt_requested_resources",
+        command_template="echo {arg}",
+        node_args=["arg"],
+    )
+    t1 = tt.create_task(
+        arg=1,
+        cluster_name="sequential",
+        compute_resources={"queue": "null.q", "num_cores": 2},
+    )
+    t2 = tt.create_task(
+        arg=2,
+        cluster_name="sequential",
+        compute_resources={"queue": "null.q", "num_cores": 4},
+    )
+    wf.add_tasks([t1, t2])
+    wf.bind()
+    wf._bind_tasks()
+
+    app_route = f"/workflow/{wf.workflow_id}/requested_resources"
+    return_code, msg = wf.requester.send_request(
+        app_route=app_route,
+        message={},
+        request_type="get",
+    )
+    assert return_code == 200
+    clusters = msg["clusters"]
+    # Two distinct compute_resources → two task_resources rows → two clusters.
+    assert len(clusters) == 2
+    cluster_by_cores = {c["requested_resources"].get("num_cores"): c for c in clusters}
+    assert set(cluster_by_cores) == {2, 4}
+    for c in clusters:
+        assert c["num_tasks"] == 1
+        assert c["queue_name"] == "null.q"
+        assert c["task_template_name"] == "tt_requested_resources"
+        assert c["task_resources_id"] > 0
+
+
 def test_get_workflow_user_validation(db_engine, tool):
     t = tool
     wf = t.create_workflow(name="i_am_a_fake_wf")

--- a/tests/unit/server/test_task_resources_routes.py
+++ b/tests/unit/server/test_task_resources_routes.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from jobmon.server.web.routes.v3.fsm.task_resources import (
-    _deserialize_requested_resources,
+from jobmon.server.web.utils.json_compat import (
+    deserialize_requested_resources as _deserialize_requested_resources,
 )
 
 


### PR DESCRIPTION
## Summary

Surfaces the per-task ``requested_resources`` blob (what the workflow asked the scheduler for) on three surfaces so users can verify config — especially timeouts and memory — before or during a run.

- **Workflow page**: new left-panel ``Requested Resources`` tab (Tune icon in the summary bar). Clusters grouped by task template; each card shows the full blob including arbitrary user-defined keys (``project``, ``stdout``/``stderr`` dirs, ``working_dir``, etc.). Served by a new ``GET /workflow/{wfid}/requested_resources`` that groups by ``(task_template_id, task_resources_id)``.
- **Task Template Details**: new ``Requested`` column on the task table. Compact summary inline, full-blob tooltip on hover. Keyed on ``TaskInstance.task_resources_id`` (so scaled-retry rows show what that attempt actually ran with, not the initial bind value). Full blobs are hydrated via a new batched ``POST /task_resources/batch``, fired once after the three viz streams drain.
- **Task Details → attempts**: two-column ``Execution`` | ``Requested`` split, captured-log headings renamed to ``Captured Stderr`` / ``Captured Stdout`` so they don't conflict with the requested stdout/stderr paths. Captured-log modal simplified — compact header, "No output captured." stub for ``/dev/null`` and empty strings, error summary pinned to top when present.

## Backend details

- ``Task.task_resources_id`` is set at bind time and never updated by the scheduler; ``TaskInstance.task_resources_id`` tracks what each attempt actually ran with (updated by scaled retries / fallback queues). The workflow-level panel uses Task-level ids (pre-launch semantics); the TT table uses TI-level ids via the batch endpoint.
- Shared legacy-safe parser promoted to ``server/web/utils/json_compat.deserialize_requested_resources`` — handles both ``json.dumps``'d rows and pre-FastAPI Python-repr rows.
- Workflow endpoint SQL groups on ``(TaskTemplate.id, TaskResources.id)`` with ``MAX(...)`` on the FD'd columns, avoiding a temp-table filesort on the TEXT ``requested_resources`` column.
- Batch endpoint capped at 1000 ids and responds 400 above that.

## Test plan

- [x] ``uv run pytest tests/integration/cli/test_cli_routes.py::test_get_workflow_requested_resources`` (sqlite, post-bind pre-launch)
- [x] Manual verify against prod DB: workflow 568473 → Tune icon → full-blob cards
- [x] Manual verify: TT page task table Requested column tooltip shows full blob including custom keys
- [x] Manual verify: task 336399143 attempts view shows Execution/Requested split, captured-log modal compact
- [x] ``uv run nox -s format lint typecheck`` green
- [x] ``cd jobmon_gui && npm run build`` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new API endpoints and SQL queries plus new UI panels/tooltips driven by arbitrary `requested_resources` blobs; main risk is performance/compat issues from batch fetching and deserialization of legacy formats.
> 
> **Overview**
> Surfaces per-task `requested_resources` in the UI via a new Workflow Details left-panel **Requested Resources** view (Tune icon) that groups bound tasks into resource clusters and lets users expand to see the full blob.
> 
> Enhances Task Template Details with a new **Requested** table column showing a compact summary and a full-blob tooltip, backed by a new batched `POST /task_resources/batch` lookup keyed by `task_resources_id` (and exports a summarized value to CSV).
> 
> Updates Task Details attempt panels to split **Execution** vs **Requested** fields using a full-blob parser, and refactors captured stdout/stderr previews + modals for clearer labeling and empty-output handling. On the backend, introduces `GET /workflow/{id}/requested_resources`, propagates `task_resources_id` through task-template resource schemas/queries, and centralizes legacy-safe `requested_resources` deserialization in `json_compat` (with new tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494b5e2a37870937e8b1c68a75e0e6e4bde2bb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->