### PR TITLE
Re-gate inside queue_task_batch retry to survive NOWAIT rollback

### DIFF
--- a/jobmon_server/src/jobmon/server/web/routes/v3/fsm/array.py
+++ b/jobmon_server/src/jobmon/server/web/routes/v3/fsm/array.py
@@ -127,30 +127,39 @@ async def record_array_batch_num(
 
         # Process each batch with TransitionService
         for batch in task_batches:
-            # Use TransitionService for Task transition with audit logging
-            # Service has internal retries and handles SKIP LOCKED
-            result = TransitionService.gate_tasks_for_queueing(
-                session=db,
-                task_ids=batch,
-            )
-
-            gated_task_ids = result["gated"]
-
-            if result["locked"]:
-                logger.warning(
-                    f"Some tasks were locked during queueing, will retry: "
-                    f"{result['locked']}"
-                )
-
-            if not gated_task_ids:
-                # No tasks were gated in this batch
-                continue
-
             # Calculate array_batch_num and create TaskInstances
             # This still uses retry logic for the TI creation part
             max_retries = 5
             for attempt in range(max_retries):
                 try:
+                    # Gate Tasks (G/A -> Q) inside the retry loop. The OperationalError
+                    # handler below calls db.rollback(), which reverts both the gate
+                    # transitions and any partial TI work. If the gate ran only once
+                    # outside the loop, retries would issue a 0-row INSERT (the SELECT
+                    # filters Task.status == QUEUED, but the rollback put the tasks
+                    # back to REGISTERING) and the response would report all tasks
+                    # still at REGISTERING — even though the client had already
+                    # dequeued them. Re-gating on every attempt keeps the gate and
+                    # the TI insert in the same atomic unit.
+                    result = TransitionService.gate_tasks_for_queueing(
+                        session=db,
+                        task_ids=batch,
+                    )
+
+                    gated_task_ids = result["gated"]
+
+                    if result["locked"]:
+                        logger.warning(
+                            f"Some tasks were locked during queueing, will retry: "
+                            f"{result['locked']}"
+                        )
+
+                    if not gated_task_ids:
+                        # No tasks were gated in this batch. Commit any audit work
+                        # written by the gate (typically none) and move on.
+                        db.commit()
+                        break
+
                     # Calculate array_batch_num separately to avoid deadlock
                     # Use SELECT FOR UPDATE with NOWAIT to prevent waiting on locks
                     batch_num_result = db.execute(

--- a/tests/integration/server/test_queue_task_batch_retry.py
+++ b/tests/integration/server/test_queue_task_batch_retry.py
@@ -1,0 +1,327 @@
+"""Regression test for queue_task_batch rollback that wiped the gate.
+
+Bug: ``record_array_batch_num`` called ``gate_tasks_for_queueing`` outside the
+TI-creation retry loop. When the ``SELECT ... FOR UPDATE NOWAIT`` on
+``task_instance.array_batch_num`` raised ``OperationalError`` under concurrent
+load, the ``except`` branch's ``db.rollback()`` reverted both the partial TI
+work AND the gate's ``G->Q`` transitions. The retry then ran the
+``INSERT ... FROM SELECT`` filtered on ``Task.status == QUEUED``, which matched
+zero rows because the gate had been rolled back. The route committed nothing,
+returned 200 with all tasks reporting ``REGISTERING``. The client had already
+dequeued these tasks from ``ready_to_run``, so they evaporated and the
+orchestrator declared a premature exit.
+
+Fix: gate inside the retry loop so the gate and the TI insert stay in the
+same atomic unit; the rollback wipes both and the next attempt re-runs both.
+
+Observed in prod on Emu wfrs 386417 (85 stuck tasks) and 386675 (10,423 stuck
+tasks). Confirmed via the ``_dump_stuck_registering_tasks`` diagnostic
+showing ``num_upstreams_done == num_upstreams`` (counter fine, enqueue
+dropped) coincident with ``DB error during TI creation ... NOWAIT`` log lines.
+
+The test calls the route handler directly with a fresh ``Session`` bound to
+the test engine (not the wrapped ``dbsession`` fixture), because the route
+issues its own ``db.commit()``/``db.rollback()`` and those would fight with
+``dbsession``'s outer transactional wrap.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from jobmon.core.constants import TaskStatus
+from jobmon.server.web.models.array import Array
+from jobmon.server.web.models.cluster import Cluster
+from jobmon.server.web.models.cluster_type import ClusterType
+from jobmon.server.web.models.dag import Dag
+from jobmon.server.web.models.node import Node
+from jobmon.server.web.models.queue import Queue
+from jobmon.server.web.models.task import Task
+from jobmon.server.web.models.task_instance import TaskInstance
+from jobmon.server.web.models.task_resources import TaskResources
+from jobmon.server.web.models.task_resources_type import TaskResourcesType
+from jobmon.server.web.models.task_status_audit import TaskStatusAudit
+from jobmon.server.web.models.task_template import TaskTemplate
+from jobmon.server.web.models.task_template_version import TaskTemplateVersion
+from jobmon.server.web.models.tool import Tool
+from jobmon.server.web.models.tool_version import ToolVersion
+from jobmon.server.web.models.workflow import Workflow
+from jobmon.server.web.models.workflow_run import WorkflowRun
+from jobmon.server.web.routes.v3.fsm.array import record_array_batch_num
+from jobmon.server.web.services.transition_service import TransitionService
+
+
+@pytest.fixture
+def array_with_registering_tasks(db_engine):
+    """Build the minimum DB graph needed to call ``record_array_batch_num``.
+
+    Uses ``db_engine`` directly (not the ``dbsession`` fixture) so that
+    commits from the route under test land in the real test database and the
+    final ``SELECT`` for the response can see them. Cleans up rows it owns at
+    teardown so the suite remains isolated.
+    """
+    session = Session(bind=db_engine)
+
+    cluster_type = ClusterType(name="ct_queue_retry")
+    session.add(cluster_type)
+    session.flush()
+
+    cluster = Cluster(name="c_queue_retry", cluster_type_id=cluster_type.id)
+    session.add(cluster)
+    session.flush()
+
+    queue = Queue(name="q_queue_retry", cluster_id=cluster.id, parameters="{}")
+    session.add(queue)
+    session.flush()
+
+    task_resources_type = TaskResourcesType(id="O", label="ORIGINAL")
+    session.merge(task_resources_type)
+    session.flush()
+
+    tool = Tool(name="tool_queue_retry")
+    session.add(tool)
+    session.flush()
+
+    tool_version = ToolVersion(tool_id=tool.id)
+    session.add(tool_version)
+    session.flush()
+
+    task_template = TaskTemplate(tool_version_id=tool_version.id, name="tt_queue_retry")
+    session.add(task_template)
+    session.flush()
+
+    task_template_version = TaskTemplateVersion(
+        task_template_id=task_template.id,
+        command_template="echo {arg}",
+        arg_mapping_hash="arg_hash_queue_retry",
+    )
+    session.add(task_template_version)
+    session.flush()
+
+    node = Node(
+        task_template_version_id=task_template_version.id,
+        node_args_hash="node_hash_queue_retry",
+    )
+    session.add(node)
+    session.flush()
+
+    dag = Dag(hash="dag_hash_queue_retry")
+    session.add(dag)
+    session.flush()
+
+    workflow = Workflow(
+        tool_version_id=tool_version.id,
+        dag_id=dag.id,
+        name="wf_queue_retry",
+        workflow_args_hash="wf_hash_queue_retry",
+        task_hash="task_hash_queue_retry",
+        max_concurrently_running=10,
+        status="G",
+    )
+    session.add(workflow)
+    session.flush()
+
+    array = Array(
+        workflow_id=workflow.id,
+        task_template_version_id=task_template_version.id,
+        name="array_queue_retry",
+        max_concurrently_running=10,
+    )
+    session.add(array)
+    session.flush()
+
+    workflow_run = WorkflowRun(
+        workflow_id=workflow.id,
+        status="R",
+        user="test_user",
+    )
+    session.add(workflow_run)
+    session.flush()
+
+    task_resources = TaskResources(
+        queue_id=queue.id,
+        task_resources_type_id="O",
+        requested_resources="{}",
+    )
+    session.add(task_resources)
+    session.flush()
+
+    tasks = []
+    for i in range(3):
+        task = Task(
+            workflow_id=workflow.id,
+            node_id=node.id,
+            array_id=array.id,
+            task_args_hash=f"hash_queue_retry_{i}",
+            name=f"task_queue_retry_{i}",
+            command=f"echo task {i}",
+            status=TaskStatus.REGISTERING,
+            max_attempts=3,
+            task_resources_id=task_resources.id,
+        )
+        session.add(task)
+        tasks.append(task)
+    session.commit()
+
+    task_ids = [t.id for t in tasks]
+    array_id = array.id
+    workflow_id = workflow.id
+    workflow_run_id = workflow_run.id
+    task_resources_id = task_resources.id
+
+    yield {
+        "array_id": array_id,
+        "task_ids": task_ids,
+        "workflow_run_id": workflow_run_id,
+        "task_resources_id": task_resources_id,
+    }
+
+    # Teardown: roll back to the original REGISTERING state and delete owned
+    # rows. Order matters for FK integrity.
+    cleanup = Session(bind=db_engine)
+    cleanup.execute(
+        delete(TaskInstance).where(TaskInstance.workflow_run_id == workflow_run_id)
+    )
+    cleanup.execute(
+        delete(TaskStatusAudit).where(TaskStatusAudit.workflow_id == workflow_id)
+    )
+    cleanup.execute(delete(Task).where(Task.workflow_id == workflow_id))
+    cleanup.execute(delete(WorkflowRun).where(WorkflowRun.id == workflow_run_id))
+    cleanup.execute(delete(TaskResources).where(TaskResources.id == task_resources_id))
+    cleanup.execute(delete(Array).where(Array.id == array_id))
+    cleanup.execute(delete(Workflow).where(Workflow.id == workflow_id))
+    cleanup.commit()
+    cleanup.close()
+    session.close()
+
+
+def _build_fake_request(payload: dict):
+    """Build a Request-like object whose ``.json()`` returns ``payload``."""
+    request = MagicMock()
+    request.json = AsyncMock(return_value=payload)
+    return request
+
+
+@pytest.mark.asyncio
+async def test_queue_task_batch_re_gates_after_nowait_rollback(
+    db_engine, array_with_registering_tasks, monkeypatch
+):
+    """NOWAIT during TI creation must re-run the gate on retry.
+
+    Forces a NOWAIT OperationalError on the first SELECT FOR UPDATE call inside
+    the route's retry loop. The handler rolls back (which reverts the gate);
+    the next attempt must re-gate and successfully insert TaskInstances.
+    """
+    fixture = array_with_registering_tasks
+    array_id = fixture["array_id"]
+    task_ids = fixture["task_ids"]
+    workflow_run_id = fixture["workflow_run_id"]
+    task_resources_id = fixture["task_resources_id"]
+
+    # Run the route with its own session bound to the real engine, so its
+    # ``db.commit()`` / ``db.rollback()`` calls work normally.
+    db = Session(bind=db_engine)
+
+    # Spy on the gate so we can assert it was invoked twice (once per attempt).
+    # ``gate_tasks_for_queueing`` is a classmethod; the route calls it as
+    # ``TransitionService.gate_tasks_for_queueing(...)``, so we replace with a
+    # staticmethod wrapper to avoid double-binding ``cls``.
+    original_gate = TransitionService.gate_tasks_for_queueing
+    gate_calls = {"count": 0}
+
+    def spy_gate(*args, **kwargs):
+        gate_calls["count"] += 1
+        return original_gate(*args, **kwargs)
+
+    monkeypatch.setattr(
+        TransitionService, "gate_tasks_for_queueing", staticmethod(spy_gate)
+    )
+
+    # Fault-inject OperationalError("nowait") on the first SELECT FOR UPDATE
+    # call. SQLite's compiler silently drops the NOWAIT clause from compiled
+    # SQL, so detect via the Select object's ``_for_update_arg.nowait`` flag
+    # instead of substring-matching the compiled SQL.
+    original_execute = db.execute
+    nowait_calls = {"count": 0}
+
+    def faulty_execute(stmt, *args, **kwargs):
+        fua = getattr(stmt, "_for_update_arg", None)
+        if fua is not None and getattr(fua, "nowait", False):
+            nowait_calls["count"] += 1
+            if nowait_calls["count"] == 1:
+                raise OperationalError(
+                    "SELECT ... FOR UPDATE NOWAIT",
+                    {},
+                    Exception(
+                        "Statement aborted because lock(s) could not be "
+                        "acquired immediately and NOWAIT is set."
+                    ),
+                )
+        return original_execute(stmt, *args, **kwargs)
+
+    monkeypatch.setattr(db, "execute", faulty_execute)
+
+    request = _build_fake_request(
+        {
+            "task_ids": task_ids,
+            "task_resources_id": task_resources_id,
+            "workflow_run_id": workflow_run_id,
+        }
+    )
+
+    try:
+        response = await record_array_batch_num(
+            array_id=array_id, request=request, db=db
+        )
+    finally:
+        db.close()
+
+    # NOWAIT-style FOR UPDATE was attempted twice: once on the failed first
+    # attempt (we raise), once on the successful retry (we let it through).
+    assert nowait_calls["count"] == 2, (
+        f"Expected NOWAIT path to fire twice (1 failed + 1 retry); fired "
+        f"{nowait_calls['count']}"
+    )
+    # Gate must have been invoked twice: once on the failed attempt, once on
+    # the successful retry. With the bug (gate outside the loop), this would
+    # be 1.
+    assert gate_calls["count"] == 2, (
+        "Gate must be re-run inside the retry loop. With the pre-fix code "
+        "(gate outside the loop), the rollback wipes the gate and the retry "
+        "issues a 0-row INSERT, leaving tasks at REGISTERING and silently "
+        f"dropping them on the client side. gate_calls={gate_calls['count']}"
+    )
+
+    # The response status code must be 200 and report tasks at QUEUED.
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert (
+        TaskStatus.QUEUED in body["tasks_by_status"]
+    ), f"Expected QUEUED in response, got: {list(body['tasks_by_status'].keys())}"
+    assert set(body["tasks_by_status"][TaskStatus.QUEUED]) == set(task_ids)
+
+    # Verify the DB committed the gate + TI insert successfully. Read via a
+    # fresh session so we see the route's committed work.
+    verify = Session(bind=db_engine)
+    try:
+        for task_id in task_ids:
+            status = verify.execute(
+                select(Task.status).where(Task.id == task_id)
+            ).scalar()
+            assert (
+                status == TaskStatus.QUEUED
+            ), f"Task {task_id} should be QUEUED after retry, got {status}"
+
+        ti_count = verify.execute(
+            select(TaskInstance).where(TaskInstance.task_id.in_(task_ids))
+        ).all()
+        assert len(ti_count) == len(task_ids), (
+            f"Expected {len(task_ids)} TaskInstance rows after retry, "
+            f"got {len(ti_count)}"
+        )
+    finally:
+        verify.close()

--- a/tests/unit/swarm/test_main_loop_interleaving.py
+++ b/tests/unit/swarm/test_main_loop_interleaving.py
@@ -1,0 +1,321 @@
+"""Main-loop interleaving test: drive 5-upstream→1-downstream with
+realistic async background timing.
+
+Uses the REAL WorkflowRunOrchestrator with a mock gateway that flips
+upstream statuses to DONE in the background while the main loop runs.
+If propagation has any interleaving bug, the downstream's
+num_upstreams_done won't reach 5.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Dict, List, Set
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jobmon.client.swarm.gateway import (
+    HeartbeatResponse,
+    QueueResponse,
+    StatusUpdateResponse,
+    TaskStatusUpdatesResponse,
+)
+from jobmon.client.swarm.orchestrator import (
+    OrchestratorConfig,
+    WorkflowRunOrchestrator,
+)
+from jobmon.client.swarm.state import SwarmState
+from jobmon.core.constants import TaskStatus, WorkflowRunStatus
+
+
+class FakeSwarmTask:
+    def __init__(self, task_id: int, status: str) -> None:
+        self.task_id = task_id
+        self.array_id = 1
+        self.status = status
+        self.downstream_swarm_tasks: Set["FakeSwarmTask"] = set()
+        self.num_upstreams: int = 0
+        self.num_upstreams_done: int = 0
+        self.compute_resources_callable = None
+        self.resource_scales = {}
+        self.fallback_queues = []
+
+        self.current_task_resources = MagicMock()
+        self.current_task_resources.is_bound = True
+        self.current_task_resources.id = 1
+        self.current_task_resources.requested_resources = {}
+        self.current_task_resources.queue = MagicMock()
+        self.current_task_resources.coerce_resources = MagicMock(
+            return_value=self.current_task_resources
+        )
+        self.current_task_resources.adjust_resources = MagicMock(
+            return_value=self.current_task_resources
+        )
+
+        self.cluster = MagicMock()
+        self.cluster.id = 1
+
+    @property
+    def all_upstreams_done(self) -> bool:
+        if self.num_upstreams_done == self.num_upstreams:
+            return True
+        if self.num_upstreams_done > self.num_upstreams:
+            raise RuntimeError("More upstream tasks done than exist in DAG.")
+        return False
+
+    def __hash__(self) -> int:
+        return self.task_id
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, FakeSwarmTask) and self.task_id == other.task_id
+
+
+class FakeSwarmArray:
+    def __init__(self, array_id: int) -> None:
+        self.array_id = array_id
+        self.array_name = f"array_{array_id}"
+        self.max_concurrently_running = 100
+        self.tasks: Set[FakeSwarmTask] = set()
+
+    def add_task(self, task: FakeSwarmTask) -> None:
+        self.tasks.add(task)
+
+
+def build_state(
+    downstream_id: int, upstream_ids: List[int]
+) -> tuple[SwarmState, FakeSwarmTask, List[FakeSwarmTask]]:
+    downstream = FakeSwarmTask(downstream_id, TaskStatus.REGISTERING)
+    upstreams = [FakeSwarmTask(uid, TaskStatus.RUNNING) for uid in upstream_ids]
+    for up in upstreams:
+        up.downstream_swarm_tasks = {downstream}
+    downstream.num_upstreams = len(upstreams)
+
+    array = FakeSwarmArray(1)
+    for t in [downstream, *upstreams]:
+        array.add_task(t)
+
+    state = SwarmState(
+        workflow_id=1,
+        workflow_run_id=10,
+        dag_id=1,
+        max_concurrently_running=100,
+        status=WorkflowRunStatus.RUNNING,
+    )
+    for s in [
+        TaskStatus.REGISTERING,
+        TaskStatus.QUEUED,
+        TaskStatus.INSTANTIATING,
+        TaskStatus.LAUNCHED,
+        TaskStatus.RUNNING,
+        TaskStatus.DONE,
+        TaskStatus.ADJUSTING_RESOURCES,
+        TaskStatus.ERROR_FATAL,
+    ]:
+        state._task_status_map.setdefault(s, set())
+    for t in [downstream, *upstreams]:
+        state.tasks[t.task_id] = t  # type: ignore
+        state._task_status_map[t.status].add(t)  # type: ignore
+    state.arrays[1] = array  # type: ignore
+
+    return state, downstream, upstreams
+
+
+def make_gateway(server_state: Dict[int, str], clock: List[int]) -> MagicMock:
+    """Mock gateway whose sync response reflects server_state.
+
+    server_state: task_id -> current status (mutated externally to simulate progress)
+    clock: single-element list holding the server's logical timestamp
+    """
+    gateway = MagicMock()
+    last_snapshot: Dict[int, tuple[str, int]] = {}
+
+    def tick():
+        clock[0] += 1
+
+    async def get_task_status_updates(since=None):
+        tick()
+        # Return all tasks each time — simpler than implementing incremental
+        by_status: Dict[str, List[int]] = {}
+        for tid, st in server_state.items():
+            by_status.setdefault(st, []).append(tid)
+        return TaskStatusUpdatesResponse(time=str(clock[0]), tasks_by_status=by_status)
+
+    async def request_triage():
+        tick()
+
+    async def get_workflow_concurrency():
+        tick()
+        return 100
+
+    async def get_array_concurrency(array_id):
+        tick()
+        return 100
+
+    async def queue_task_batch(array_id, task_ids, task_resources_id, cluster_id):
+        tick()
+        # Transition each REGISTERING/ADJUSTING task to QUEUED
+        by_status: Dict[str, List[int]] = {}
+        for tid in task_ids:
+            cur = server_state.get(tid, TaskStatus.REGISTERING)
+            if cur in (TaskStatus.REGISTERING, TaskStatus.ADJUSTING_RESOURCES):
+                server_state[tid] = TaskStatus.QUEUED
+            by_status.setdefault(server_state[tid], []).append(tid)
+        return QueueResponse(tasks_by_status=by_status)
+
+    async def log_heartbeat(status, next_report_increment):
+        tick()
+        return HeartbeatResponse(status=WorkflowRunStatus.RUNNING)
+
+    async def update_status(status):
+        return StatusUpdateResponse(status=status)
+
+    gateway.get_task_status_updates = AsyncMock(side_effect=get_task_status_updates)
+    gateway.request_triage = AsyncMock(side_effect=request_triage)
+    gateway.get_workflow_concurrency = AsyncMock(side_effect=get_workflow_concurrency)
+    gateway.get_array_concurrency = AsyncMock(side_effect=get_array_concurrency)
+    gateway.queue_task_batch = AsyncMock(side_effect=queue_task_batch)
+    gateway.log_heartbeat = AsyncMock(side_effect=log_heartbeat)
+    gateway.update_status = AsyncMock(side_effect=update_status)
+    gateway.terminate_task_instances = AsyncMock()
+    gateway._ensure_session = AsyncMock(return_value=MagicMock())
+
+    return gateway
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("seed", range(30))
+async def test_main_loop_drives_5_upstreams_to_downstream(seed: int) -> None:
+    """Drive the real _main_loop. Upstreams transition DONE on staggered
+    timers; downstream's num_upstreams_done must reach 5.
+    """
+    random.seed(seed)
+
+    downstream_id = 100
+    upstream_ids = [1, 2, 3, 4, 5]
+    state, downstream, upstreams = build_state(downstream_id, upstream_ids)
+
+    # Mirror server-side status: all upstreams start in RUNNING (as in client)
+    server_state: Dict[int, str] = {
+        downstream_id: TaskStatus.REGISTERING,
+        **{uid: TaskStatus.RUNNING for uid in upstream_ids},
+    }
+    clock = [0]
+    gateway = make_gateway(server_state, clock)
+
+    config = OrchestratorConfig(
+        heartbeat_interval=0.01,
+        heartbeat_report_by_buffer=1.5,
+        wedged_workflow_sync_interval=0.05,
+        fail_fast=False,
+        timeout=30,
+    )
+
+    orch = WorkflowRunOrchestrator(
+        state=state,
+        gateway=gateway,
+        config=config,
+    )
+
+    # Mock TaskResources bind
+    for t in [downstream, *upstreams]:
+        t.current_task_resources.bind_async = AsyncMock(return_value=None)
+
+    # Random staggered DONE events
+    async def drive_done_events():
+        uids = list(upstream_ids)
+        random.shuffle(uids)
+        for uid in uids:
+            await asyncio.sleep(random.uniform(0.005, 0.03))
+            server_state[uid] = TaskStatus.DONE
+
+    distributor_alive = MagicMock(return_value=True)
+
+    driver = asyncio.create_task(drive_done_events())
+
+    async def run_until_stuck_or_done():
+        """Drive sync loops until all upstreams DONE or time runs out."""
+        # Minimal lifecycle setup (we're not calling run())
+        start = asyncio.get_event_loop().time()
+        while asyncio.get_event_loop().time() - start < 3.0:
+            try:
+                await orch._do_scheduling(timeout=0.01)
+            except Exception:
+                pass
+            await asyncio.sleep(0.005)
+            try:
+                await orch._do_sync(full_sync=False)
+            except Exception:
+                pass
+
+            all_up_done = all(
+                server_state[uid] == TaskStatus.DONE for uid in upstream_ids
+            )
+            if all_up_done and downstream.num_upstreams_done == 5:
+                return
+
+    try:
+        await run_until_stuck_or_done()
+    finally:
+        driver.cancel()
+        try:
+            await driver
+        except asyncio.CancelledError:
+            pass
+
+    # All upstreams should be DONE in server state
+    for uid in upstream_ids:
+        assert (
+            server_state[uid] == TaskStatus.DONE
+        ), f"seed={seed}: upstream {uid} not DONE: {server_state[uid]}"
+
+    assert downstream.num_upstreams_done == 5, (
+        f"seed={seed}: downstream stuck at "
+        f"{downstream.num_upstreams_done}/5. "
+        f"downstream.status={downstream.status}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_sync_recovers_missed_done() -> None:
+    """If an incremental sync somehow missed an upstream DONE,
+    the next full sync should catch it and propagate.
+    """
+    downstream_id = 100
+    upstream_ids = [1, 2, 3, 4, 5]
+    state, downstream, upstreams = build_state(downstream_id, upstream_ids)
+
+    # Server already has all 5 upstreams DONE
+    server_state: Dict[int, str] = {
+        downstream_id: TaskStatus.REGISTERING,
+        **{uid: TaskStatus.DONE for uid in upstream_ids},
+    }
+    clock = [0]
+    gateway = make_gateway(server_state, clock)
+
+    config = OrchestratorConfig(
+        heartbeat_interval=0.01,
+        heartbeat_report_by_buffer=1.5,
+        wedged_workflow_sync_interval=0.01,
+        fail_fast=False,
+        timeout=30,
+    )
+
+    orch = WorkflowRunOrchestrator(
+        state=state,
+        gateway=gateway,
+        config=config,
+    )
+
+    for t in [downstream, *upstreams]:
+        t.current_task_resources.bind_async = AsyncMock(return_value=None)
+
+    # One full sync should be enough: client cache has upstreams as R,
+    # server says D, apply_update sees the change, propagate fires
+    await orch._do_sync(full_sync=True)
+
+    assert downstream.num_upstreams_done == 5, (
+        f"Full sync didn't propagate all DONEs: counter="
+        f"{downstream.num_upstreams_done}/5"
+    )

--- a/tests/unit/swarm/test_propagation_interleaving.py
+++ b/tests/unit/swarm/test_propagation_interleaving.py
@@ -1,0 +1,423 @@
+"""Interleaving stress tests for swarm propagation logic.
+
+Targets the question: can any reachable sequence of apply_update /
+_process_changed_tasks / scheduler-tick calls leave a downstream task's
+num_upstreams_done below num_upstreams after all its upstreams reach DONE?
+
+Replicates the pattern seen in wf 566392 / wr 384312: a compute_scalars
+task with 5 compute_pafs upstreams, all transitioning DONE, but the
+downstream never entering ready_to_run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import random
+from typing import List, Set
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jobmon.client.swarm.gateway import (
+    HeartbeatResponse,
+    StatusUpdateResponse,
+    TaskStatusUpdatesResponse,
+)
+from jobmon.client.swarm.services.synchronizer import Synchronizer
+from jobmon.client.swarm.state import StateUpdate, SwarmState
+from jobmon.core.constants import TaskStatus, WorkflowRunStatus
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Lightweight SwarmTask stand-in
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class FakeSwarmTask:
+    """Mimics SwarmTask for state-level tests.
+
+    Uses the REAL all_upstreams_done semantics including the raise-on-overcount
+    path, so bugs that overshoot num_upstreams surface as exceptions.
+    """
+
+    def __init__(self, task_id: int, status: str = TaskStatus.REGISTERING) -> None:
+        self.task_id = task_id
+        self.array_id = 1
+        self.status = status
+        self.downstream_swarm_tasks: Set["FakeSwarmTask"] = set()
+        self.num_upstreams: int = 0
+        self.num_upstreams_done: int = 0
+        self.compute_resources_callable = None
+        self.resource_scales = {}
+        self.fallback_queues = []
+        self.current_task_resources = MagicMock()
+
+    @property
+    def all_upstreams_done(self) -> bool:
+        if self.num_upstreams_done == self.num_upstreams:
+            return True
+        if self.num_upstreams_done > self.num_upstreams:
+            raise RuntimeError("More upstream tasks done than exist in DAG.")
+        return False
+
+    def __hash__(self) -> int:
+        return self.task_id
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, FakeSwarmTask) and self.task_id == other.task_id
+
+    def __repr__(self) -> str:
+        return (
+            f"FakeSwarmTask(id={self.task_id}, status={self.status}, "
+            f"n_up_done={self.num_upstreams_done}/{self.num_upstreams})"
+        )
+
+
+def make_state(tasks: List[FakeSwarmTask]) -> SwarmState:
+    state = SwarmState(
+        workflow_id=1,
+        workflow_run_id=10,
+        dag_id=1,
+        max_concurrently_running=100,
+        status=WorkflowRunStatus.RUNNING,
+    )
+    # The state uses a status-bucket dict; populate it with our tasks.
+    for s in [
+        TaskStatus.REGISTERING,
+        TaskStatus.QUEUED,
+        TaskStatus.INSTANTIATING,
+        TaskStatus.LAUNCHED,
+        TaskStatus.RUNNING,
+        TaskStatus.DONE,
+        TaskStatus.ADJUSTING_RESOURCES,
+        TaskStatus.ERROR_FATAL,
+    ]:
+        state._task_status_map.setdefault(s, set())
+    for t in tasks:
+        state.tasks[t.task_id] = t  # type: ignore[assignment]
+        state._task_status_map[t.status].add(t)  # type: ignore[arg-type]
+    return state
+
+
+def build_stuck_scenario() -> tuple[SwarmState, FakeSwarmTask, List[FakeSwarmTask]]:
+    """Replicates wf 566392: 1 downstream (compute_scalars) + 5 upstreams."""
+    downstream = FakeSwarmTask(task_id=334020812, status=TaskStatus.REGISTERING)
+    upstreams = [
+        FakeSwarmTask(task_id=i, status=TaskStatus.RUNNING)
+        for i in (334020102, 334020103, 334020104, 334020105, 334020106)
+    ]
+    for up in upstreams:
+        up.downstream_swarm_tasks = {downstream}
+    downstream.num_upstreams = len(upstreams)
+    state = make_state([downstream, *upstreams])
+    return state, downstream, upstreams
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Baseline: one propagate_completions call per upstream
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSingleSyncPropagation:
+    """propagate_completions with multiple iteration orders, single sync cycle."""
+
+    @pytest.mark.parametrize("seed", range(50))
+    def test_random_order_all_upstreams_in_one_sync(self, seed: int) -> None:
+        """All 5 upstream DONEs arrive in one sync. Order shouldn't matter."""
+        random.seed(seed)
+        state, downstream, upstreams = build_stuck_scenario()
+
+        # Flip all upstreams to DONE status (simulating what apply_update did).
+        for up in upstreams:
+            state._task_status_map[TaskStatus.RUNNING].discard(up)
+            up.status = TaskStatus.DONE
+            state._task_status_map[TaskStatus.DONE].add(up)
+
+        # The real _process_changed_tasks calls propagate_completions({task})
+        # once per DONE task in changed_tasks, in SET iteration order.
+        order = list(upstreams)
+        random.shuffle(order)
+
+        newly_ready_union: List[FakeSwarmTask] = []
+        for up in order:
+            nr = state.propagate_completions({up})  # type: ignore[arg-type]
+            newly_ready_union.extend(nr)
+
+        assert (
+            downstream.num_upstreams_done == 5
+        ), f"counter={downstream.num_upstreams_done}, order={[u.task_id for u in order]}"
+        assert downstream in newly_ready_union
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Spread across multiple sync cycles (matches wf 566392 timing)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestMultiSyncPropagation:
+    """Upstream DONEs split across multiple sync cycles, in any partition."""
+
+    @pytest.mark.parametrize(
+        "partition",
+        [
+            # Each tuple is a sync cycle's batch of DONE upstreams by index.
+            [(0,), (1,), (2,), (3,), (4,)],  # one per cycle
+            [(0, 1), (2, 3), (4,)],  # observed in the ES data: ~3 syncs
+            [(0, 1, 2), (3, 4)],
+            [(0,), (1, 2), (3, 4)],
+            [(0, 1, 2, 3), (4,)],
+            [(0, 1, 2, 3, 4)],  # all in one full sync
+        ],
+    )
+    def test_partitioned_arrivals(self, partition: list[tuple]) -> None:
+        state, downstream, upstreams = build_stuck_scenario()
+
+        for batch_indices in partition:
+            # Simulate apply_update marking this batch DONE
+            for idx in batch_indices:
+                up = upstreams[idx]
+                state._task_status_map[TaskStatus.RUNNING].discard(up)
+                up.status = TaskStatus.DONE
+                state._task_status_map[TaskStatus.DONE].add(up)
+
+            # Simulate _process_changed_tasks iterating in this batch
+            for idx in batch_indices:
+                state.propagate_completions({upstreams[idx]})  # type: ignore[arg-type]
+
+        assert downstream.num_upstreams_done == 5
+        assert downstream.all_upstreams_done is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Duplicate sync response: same DONE reported twice
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestDuplicateObservations:
+    """What if a DONE is reported in two successive syncs?"""
+
+    def test_apply_update_dedups_when_cache_already_done(self) -> None:
+        """Second sync reporting DONE for a cached-DONE task does not re-propagate."""
+        state, downstream, upstreams = build_stuck_scenario()
+        up0 = upstreams[0]
+
+        # Sync 1: up0 transitions R → D
+        update1 = StateUpdate(task_statuses={up0.task_id: TaskStatus.DONE})
+        changed1 = state.apply_update(update1)
+        assert up0 in changed1
+        # Simulate _process_changed_tasks propagation
+        state.propagate_completions(set(changed1))
+        assert downstream.num_upstreams_done == 1
+
+        # Sync 2: same task reported D again (e.g., full sync)
+        update2 = StateUpdate(task_statuses={up0.task_id: TaskStatus.DONE})
+        changed2 = state.apply_update(update2)
+        assert up0 not in changed2, "apply_update should skip no-op status updates"
+        # No propagate call → counter stays 1
+        assert downstream.num_upstreams_done == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scheduler response + sync response interleaving
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestSchedulerSyncInterleaving:
+    """The scheduler's queue_task_batch response can carry DONE statuses when
+    a task transitioned between dequeue and server-side gating. Verify that
+    double-observation (scheduler + sync) does not over-count.
+    """
+
+    def test_scheduler_then_sync_same_done(self) -> None:
+        state, downstream, upstreams = build_stuck_scenario()
+        up0 = upstreams[0]
+
+        # Scheduler reports up0 as DONE (e.g., server raced ahead).
+        sched_update = StateUpdate(task_statuses={up0.task_id: TaskStatus.DONE})
+        changed = state.apply_update(sched_update)
+        state.propagate_completions(set(changed))
+        assert downstream.num_upstreams_done == 1
+
+        # Sync (incremental) reports same transition. Cache already D.
+        sync_update = StateUpdate(task_statuses={up0.task_id: TaskStatus.DONE})
+        changed_sync = state.apply_update(sync_update)
+        state.propagate_completions(set(changed_sync))
+        assert downstream.num_upstreams_done == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Heavy randomized stress: many DAGs, many interleavings
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestRandomizedStress:
+    """Random DAG topologies + random sync/scheduler interleavings."""
+
+    @pytest.mark.parametrize("seed", range(100))
+    def test_random_interleavings_never_undercount(self, seed: int) -> None:
+        random.seed(seed)
+
+        # Build a random bipartite DAG: N upstreams → 1 downstream
+        n_upstreams = random.randint(1, 10)
+        downstream = FakeSwarmTask(task_id=1000, status=TaskStatus.REGISTERING)
+        upstreams = [
+            FakeSwarmTask(task_id=i + 1, status=TaskStatus.RUNNING)
+            for i in range(n_upstreams)
+        ]
+        for up in upstreams:
+            up.downstream_swarm_tasks = {downstream}
+        downstream.num_upstreams = n_upstreams
+        state = make_state([downstream, *upstreams])
+
+        # Split upstreams into random sync-cycle batches.
+        indices = list(range(n_upstreams))
+        random.shuffle(indices)
+        batches: List[List[int]] = []
+        i = 0
+        while i < len(indices):
+            take = random.randint(1, len(indices) - i)
+            batches.append(indices[i : i + take])
+            i += take
+
+        # For each batch, apply_update → iterate changed set in random order.
+        for batch in batches:
+            update = StateUpdate(
+                task_statuses={upstreams[idx].task_id: TaskStatus.DONE for idx in batch}
+            )
+            changed = list(state.apply_update(update))
+            random.shuffle(changed)  # simulate set iteration order
+            for t in changed:
+                state.propagate_completions({t})
+
+        assert downstream.num_upstreams_done == n_upstreams, (
+            f"seed={seed}, batches={batches}, "
+            f"got counter={downstream.num_upstreams_done}/{n_upstreams}"
+        )
+        assert downstream.all_upstreams_done is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Async interleaving: heartbeat running during main-loop awaits
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestAsyncInterleaving:
+    """Run the real orchestrator _main_loop with concurrent heartbeat background
+    tasks and verify propagation still completes for a 5-upstream downstream.
+    """
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_does_not_clobber_propagation(self) -> None:
+        """Heartbeat background task runs concurrently; propagation must still
+        bump the downstream's num_upstreams_done to num_upstreams.
+
+        This replicates wf 566392's shape: 5 upstreams + 1 downstream, all
+        upstreams transitioning DONE over multiple sync cycles while heartbeat
+        ticks happen in-between.
+        """
+        state, downstream, upstreams = build_stuck_scenario()
+
+        # Sequence of sync responses — upstream DONEs arrive spread out.
+        sync_responses = [
+            # Cycle 1: 2 upstreams transition DONE
+            {
+                upstreams[0].task_id: TaskStatus.DONE,
+                upstreams[1].task_id: TaskStatus.DONE,
+            },
+            # Cycle 2: heartbeat only, no status changes
+            {},
+            # Cycle 3: 1 more DONE
+            {upstreams[2].task_id: TaskStatus.DONE},
+            # Cycle 4: last 2 DONE
+            {
+                upstreams[3].task_id: TaskStatus.DONE,
+                upstreams[4].task_id: TaskStatus.DONE,
+            },
+        ]
+        response_iter = iter(sync_responses)
+
+        async def fake_get_task_updates(since=None):
+            try:
+                payload = next(response_iter)
+            except StopIteration:
+                payload = {}
+            # Group task_ids by status
+            by_status: dict[str, list[int]] = {}
+            for tid, st in payload.items():
+                by_status.setdefault(st, []).append(tid)
+            return TaskStatusUpdatesResponse(
+                time="2026-04-17T05:22:30", tasks_by_status=by_status
+            )
+
+        gateway = MagicMock()
+        gateway.get_task_status_updates = AsyncMock(side_effect=fake_get_task_updates)
+        gateway.request_triage = AsyncMock()
+        gateway.get_workflow_concurrency = AsyncMock(return_value=100)
+        gateway.get_array_concurrency = AsyncMock(return_value=50)
+        gateway.log_heartbeat = AsyncMock(
+            return_value=HeartbeatResponse(status=WorkflowRunStatus.RUNNING)
+        )
+        gateway.update_status = AsyncMock(
+            side_effect=lambda s: StatusUpdateResponse(status=s)
+        )
+
+        sync = Synchronizer(
+            gateway=gateway,
+            task_ids=set(state.tasks.keys()),
+            array_ids=set(),
+        )
+
+        # Drive multiple sync ticks with a concurrent heartbeat coroutine
+        async def heartbeat_noise(n: int) -> None:
+            for _ in range(n):
+                await asyncio.sleep(0)
+                # Simulate heartbeat doing its thing - no state mutation
+                await gateway.log_heartbeat(
+                    status=WorkflowRunStatus.RUNNING, next_report_increment=45.0
+                )
+
+        # Run heartbeat noise + sync ticks concurrently.
+        async def drive_syncs() -> None:
+            for _ in sync_responses:
+                update = await sync.tick(full_sync=False, last_sync=None)
+                changed = state.apply_update(update)
+                for t in changed:
+                    if t.status == TaskStatus.DONE:
+                        state.propagate_completions({t})
+
+        # Stagger: heartbeat ticks during sync awaits
+        await asyncio.gather(drive_syncs(), heartbeat_noise(20))
+
+        assert (
+            downstream.num_upstreams_done == 5
+        ), f"counter={downstream.num_upstreams_done}, downstream={downstream}"
+        assert downstream.all_upstreams_done is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Exhaustive enumeration: all permutations of iteration order for 5-upstream
+# propagation partitioned every possible way. If a bug lurks in iteration-order
+# sensitivity this will find it.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestExhaustivePermutations:
+
+    def test_every_permutation_5_upstreams(self) -> None:
+        """For every iteration order of 5 upstream DONEs, counter reaches 5."""
+        failures = []
+        for order in itertools.permutations(range(5)):
+            state, downstream, upstreams = build_stuck_scenario()
+            # All 5 transition DONE "at once" (single apply_update)
+            update = StateUpdate(
+                task_statuses={u.task_id: TaskStatus.DONE for u in upstreams}
+            )
+            changed_set = state.apply_update(update)
+            # Iterate in the fixed permutation order rather than set order
+            by_id = {t.task_id: t for t in changed_set}
+            for idx in order:
+                tid = upstreams[idx].task_id
+                state.propagate_completions({by_id[tid]})
+            if downstream.num_upstreams_done != 5:
+                failures.append((order, downstream.num_upstreams_done))
+        assert not failures, f"Permutation failures: {failures}"


### PR DESCRIPTION
## Summary

- **Bug**: `record_array_batch_num` gated tasks (G→Q) once outside its TI-creation retry loop. When the `SELECT MAX(array_batch_num) FOR UPDATE NOWAIT` raised `OperationalError` under concurrent load, `db.rollback()` reverted both the partial TI insert AND the gate. The retry's `INSERT FROM SELECT` filtered on `Task.status == QUEUED`, matched 0 rows, and committed nothing — leaving the route to return HTTP 200 with tasks still at REGISTERING. The client had already dequeued them, so they silently disappeared and the orchestrator declared a premature exit.
- **Fix**: move `gate_tasks_for_queueing` inside the retry loop so the gate and TI insert stay in the same atomic unit. The rollback wipes both; the next attempt re-runs both. (`jobmon_server/.../array.py`)
- **Regression test**: `tests/integration/server/test_queue_task_batch_retry.py` fault-injects an `OperationalError` on the first `FOR UPDATE NOWAIT` call, asserts the gate runs twice (one failed + one retry), the response reports tasks at `QUEUED`, and `TaskInstance` rows are committed. Verified the test fails on the pre-fix code (`gate_calls=1`).
- **Bonus**: pre-existing client-side interleaving stress tests under `tests/unit/swarm/test_*_interleaving.py` — drive the real orchestrator with backgrounded upstream-DONE flips to verify propagation never leaves `num_upstreams_done` < `num_upstreams`. Cover the orthogonal client-side angle of the same stuck-downstream class.

Production evidence:
- Emu wfr 386417 — 85 stuck tasks (workflow eventually resumed and completed)
- Emu wfr 386675 — 10,423 of 16,917 tasks left REGISTERING at premature exit
- Both correlate exactly with `"DB error during TI creation ... NOWAIT"` warnings on the server side and the `_dump_stuck_registering_tasks` diagnostic in `client-3.7.7` reporting `num_upstreams_done == num_upstreams` (signature 2: counter fine, enqueue dropped).

## Test plan

- [x] `uv run nox -s tests` — full suite green (1168 passed) with fix + new test
- [x] Reverted fix locally, re-ran new regression test — fails with `gate_calls=1`, confirming it catches the bug
- [x] Pre-commit `format` / `lint` / `typecheck` pass on both commits
- [ ] Reviewer: spot-check that the gate now lives inside the retry loop and `db.rollback()` after `OperationalError` rewinds the gate cleanly for the next attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)