### PR TITLE
Emit startup-phase breadcrumbs from the distributor process

### DIFF
--- a/jobmon_core/src/jobmon/distributor/cli.py
+++ b/jobmon_core/src/jobmon/distributor/cli.py
@@ -1,6 +1,7 @@
 """Command line interface for Execution."""
 
 import argparse
+import sys
 from typing import Optional
 
 import structlog
@@ -11,6 +12,25 @@ from jobmon.core.logging import set_jobmon_context
 from jobmon.distributor.api import DistributorService
 
 logger = structlog.get_logger(__name__)
+
+
+def _phase(name: str) -> None:
+    """Emit a startup-phase breadcrumb on stderr.
+
+    The orchestrator's ``DistributorContext.wait_for_startup_signal`` watches
+    stderr for the ``ALIVE`` token and, on timeout, captures the full stderr
+    buffer into the ``DistributorStartupTimeout`` exception body. These
+    breadcrumbs land in that buffer and identify which startup step the
+    distributor reached before hanging — invaluable when OTLP context isn't
+    bound yet (e.g. shared-filesystem stalls during Python imports or
+    ``shutil.which`` in the cluster plugin constructor) so the failure is
+    invisible to ES.
+
+    Carefully avoids the substring ``ALIVE`` so the orchestrator's signal
+    detector cannot be fooled into thinking startup succeeded prematurely.
+    """
+    sys.stderr.write(f"JOBMON_PHASE: {name}\n")
+    sys.stderr.flush()
 
 
 class DistributorCLI(CLI):
@@ -31,16 +51,30 @@ class DistributorCLI(CLI):
     @staticmethod
     def run_distributor(args: argparse.Namespace) -> None:
         """Start the distributor service for a workflow run."""
+        _phase("cli_entered")
+
         # Bind global context for this distributor instance
         set_jobmon_context(workflow_run_id=args.workflow_run_id)
+        _phase("context_bound")
 
         logger.info("Distributor starting")
 
+        # First HTTP roundtrip to the jobmon server — fetches cluster
+        # metadata. If this hangs the distributor is blocked on network or
+        # on Cluster construction (notably ``shutil.which`` over PATH, which
+        # can stall on a slow shared filesystem).
         cluster = Cluster.get_cluster(args.cluster_name)
+        _phase("cluster_bound")
+
         cluster_interface = cluster.get_distributor()
+        _phase("cluster_interface_built")
 
         distributor_service = DistributorService(cluster_interface)
+        # Second HTTP roundtrip: transition_to_instantiated (workflow_run
+        # B -> I). Hangs here implicate the server-side WFR transition path.
         distributor_service.set_workflow_run(args.workflow_run_id)
+        _phase("workflow_run_set")
+
         distributor_service.run()
 
     def _add_distributor_parser(self) -> None:

--- a/jobmon_core/src/jobmon/distributor/distributor_service.py
+++ b/jobmon_core/src/jobmon/distributor/distributor_service.py
@@ -139,8 +139,19 @@ class DistributorService:
         # start the cluster
         try:
             self._initialize_signal_handlers()
+            # Phase breadcrumbs land in the stderr buffer the orchestrator
+            # surfaces in DistributorStartupTimeout.  See
+            # ``jobmon.distributor.cli._phase`` for the protocol; carefully
+            # avoid the ``ALIVE`` substring so the orchestrator's signal
+            # detector isn't fooled.
+            sys.stderr.write("JOBMON_PHASE: signal_handlers_set\n")
+            sys.stderr.flush()
             self.cluster_interface.start()
+            sys.stderr.write("JOBMON_PHASE: cluster_started\n")
+            sys.stderr.flush()
             self.workflow_run.transition_to_launched()
+            sys.stderr.write("JOBMON_PHASE: transitioned_to_launched\n")
+            sys.stderr.flush()
 
             # Send simple startup signal
             sys.stderr.write("ALIVE")

--- a/tests/unit/core/test_distributor_startup_breadcrumbs.py
+++ b/tests/unit/core/test_distributor_startup_breadcrumbs.py
@@ -1,0 +1,91 @@
+"""Locks down the distributor's stderr breadcrumb protocol.
+
+The orchestrator's ``DistributorContext.wait_for_startup_signal``:
+
+  - watches stderr for the literal substring ``ALIVE`` (success) or
+    ``SHUTDOWN`` (clean teardown);
+  - on a ``DistributorStartupTimeout``, captures the full stderr buffer into
+    the exception body so the user sees what the distributor was doing.
+
+Adding any breadcrumb that contains either token would cause the orchestrator
+to treat startup as succeeded prematurely or misinterpret shutdown — both
+silent regressions that this test exists to catch. The test also checks the
+emit order matches the public order documented in ``cli.run_distributor`` /
+``DistributorService.run`` so consumers grepping the timeout payload don't
+have to guess.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from jobmon.distributor import cli as cli_mod
+from jobmon.distributor import distributor_service as svc_mod
+
+
+def _phase_tokens_in(source: str) -> list[str]:
+    """Return phase names from breadcrumb emissions in ``source``.
+
+    Matches both literal ``sys.stderr.write("JOBMON_PHASE: foo\\n")`` calls
+    and the ``_phase("foo")`` helper call sites used in ``cli.py`` (the
+    helper expands to the same literal at runtime, but at the source level
+    it's a function call rather than a string). The ``_phase`` helper
+    definition itself contains the f-string ``"JOBMON_PHASE: {name}\\n"``;
+    exclude any match containing ``{`` so the helper's own format string
+    doesn't show up as a phase named ``{name}``.
+    """
+
+    def _is_real_name(name: str) -> bool:
+        return "{" not in name
+
+    literals = [
+        m
+        for m in re.findall(r'"JOBMON_PHASE: ([^"\n]+)\\n"', source)
+        if _is_real_name(m)
+    ]
+    helpers = re.findall(r'_phase\("([^"]+)"\)', source)
+    return literals + helpers
+
+
+def test_no_breadcrumb_contains_alive_or_shutdown_tokens():
+    """Breadcrumbs must not collide with the orchestrator's signal tokens.
+
+    A breadcrumb containing ``ALIVE`` would make the orchestrator skip the
+    timeout wait and treat the distributor as ready before any real work
+    has happened; a breadcrumb containing ``SHUTDOWN`` would let
+    ``DistributorContext._shutdown`` short-circuit and miss a true shutdown.
+    """
+    cli_src = inspect.getsource(cli_mod)
+    svc_src = inspect.getsource(svc_mod)
+    for name in _phase_tokens_in(cli_src) + _phase_tokens_in(svc_src):
+        assert (
+            "ALIVE" not in name
+        ), f"Breadcrumb {name!r} contains the orchestrator's success token"
+        assert (
+            "SHUTDOWN" not in name
+        ), f"Breadcrumb {name!r} contains the orchestrator's shutdown token"
+
+
+def test_breadcrumb_order_matches_documented_startup_sequence():
+    """Locks down the public ordering of startup phases.
+
+    Updating this list when you legitimately change the startup sequence is
+    fine — but every change of the sequence is a contract change for
+    anyone parsing ``DistributorStartupTimeout`` payloads, so it should be
+    intentional.
+    """
+    cli_src = inspect.getsource(cli_mod)
+    svc_src = inspect.getsource(svc_mod)
+    assert _phase_tokens_in(cli_src) == [
+        "cli_entered",
+        "context_bound",
+        "cluster_bound",
+        "cluster_interface_built",
+        "workflow_run_set",
+    ]
+    assert _phase_tokens_in(svc_src) == [
+        "signal_handlers_set",
+        "cluster_started",
+        "transitioned_to_launched",
+    ]


### PR DESCRIPTION
## Summary

When a distributor subprocess hangs during startup, the orchestrator's ``DistributorContext.wait_for_startup_signal`` times out at 180s and raises ``DistributorStartupTimeout`` with the buffered stderr as the payload. Until now the distributor only emitted ``ALIVE`` (success) and ``SHUTDOWN`` (teardown), so the payload was empty and we couldn't tell *which* step had hung.

This adds eight ``JOBMON_PHASE: <name>\n`` breadcrumbs on stderr — one before each network roundtrip and each filesystem-touching step in the distributor's startup path:

| Where | Phase | Meaning |
|---|---|---|
| ``cli.run_distributor`` | ``cli_entered`` | process is alive, args parsed |
|   | ``context_bound`` | structlog/OTLP context bound |
|   | ``cluster_bound`` | first HTTP (``GET /cluster/{name}``) returned |
|   | ``cluster_interface_built`` | ``SlurmDistributor`` constructor (``shutil.which``) done |
|   | ``workflow_run_set`` | second HTTP (``PUT update_status`` B→I) returned |
| ``DistributorService.run`` | ``signal_handlers_set`` | SIGTERM/SIGINT handlers installed |
|   | ``cluster_started`` | ``cluster_interface.start()`` returned |
|   | ``transitioned_to_launched`` | third HTTP (``PUT update_status`` I→O) returned |
|   | ``ALIVE`` | (unchanged) startup complete |

Next time someone hits this, their ``DistributorStartupTimeout`` body identifies the last phase the distributor reached — which directly distinguishes the major suspects:

- **No breadcrumbs at all** → process never started or died before any Python ran.
- **``cli_entered`` only** → blocked in imports (NFS / Qumulo / venus-fs metadata stall on conda env, of the kind 406ac661 + eb8ec5b3 addressed on the worker side).
- **``cluster_interface_built`` without ``cluster_bound``** → ``SlurmDistributor.__init__`` is slow (probably ``shutil.which`` walking PATH on a slow FS).
- **``cluster_bound`` without ``workflow_run_set``** → B→I HTTP hung (server-side).
- **``transitioned_to_launched`` without ``ALIVE``** → final write/flush failure between the I→O response and the literal write.

## Why stderr (not OTLP / structlog)

Breadcrumbs need to survive even when the thing that's hung is the OTLP exporter init or ``configure_component_logging``. Stderr is one of the few things the orchestrator can reliably read regardless — and it already captures the full buffer into the timeout exception body.

## Signal-token collision

Carefully avoids the ``ALIVE`` and ``SHUTDOWN`` substrings — the orchestrator does a literal ``in buffer`` check, so a breadcrumb containing either token would either fool the orchestrator into thinking startup succeeded (skip the timeout) or short-circuit the shutdown path. The included unit test locks this invariant down along with the documented emit order.

## Test plan

- [x] ``uv run nox -s tests`` — 977 passed, 6 skipped, full suite green
- [x] Pre-commit ``format`` / ``lint`` / ``typecheck`` pass
- [x] New unit test ``tests/unit/core/test_distributor_startup_breadcrumbs.py`` lock down (1) no ``ALIVE`` / ``SHUTDOWN`` in breadcrumb names and (2) documented emit order
- [ ] Reviewer: spot-check that no breadcrumb literal contains the ``ALIVE`` or ``SHUTDOWN`` substrings (the test enforces this; just sanity-check the names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)