### PR TITLE
Eliminate task_status_audit gap-lock deadlock by rearranging bulk close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist
 .coverage
 .coverage.*
 .test_report.xml
+.test_report.mysql.xml
 jobmon.db
 jobmon_server/jobmon.db
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,55 @@
+name: jobmon-test
+
+# Throwaway MySQL for tests that require real InnoDB lock geometry
+# (e.g. tests/integration/server/test_audit_bulk_deadlock.py).
+#
+# The image is pinned to the same major version as prod
+# (Azure MySQL Flexible Server 8.0.x) so the gap-lock behavior under
+# REPEATABLE READ matches what we'd see in production. Bumping this
+# without verifying that production has moved invalidates the
+# regression test's assumptions.
+#
+# Bring up:
+#   docker compose -f docker-compose.test.yml up -d
+#   docker compose -f docker-compose.test.yml exec mysql_test mysqladmin ping -u root -ptest
+#
+# Run the gated tests:
+#   JOBMON_MYSQL_TEST_URI="mysql+mysqldb://root:test@127.0.0.1:3307/jobmon_test" \
+#     uv run nox -s mysql_tests
+#
+# Tear down:
+#   docker compose -f docker-compose.test.yml down -v
+
+services:
+  mysql_test:
+    image: mysql:8.0.44
+    container_name: jobmon-mysql-test
+    restart: "no"
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+      MYSQL_DATABASE: jobmon_test
+    ports:
+      # Distinct from the default 3306 so this can run alongside an
+      # operator's own MySQL without colliding.
+      - "127.0.0.1:3307:3306"
+    command:
+      - --default-authentication-plugin=mysql_native_password
+      # Match prod isolation level so the deadlock geometry the test
+      # targets reproduces faithfully.
+      - --transaction-isolation=REPEATABLE-READ
+      - --innodb-lock-wait-timeout=5
+      # Speeds up cold start; this DB is ephemeral.
+      - --innodb-flush-log-at-trx-commit=2
+      - --sync-binlog=0
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - mysqladmin ping -h 127.0.0.1 -u root -p$$MYSQL_ROOT_PASSWORD --silent
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+    tmpfs:
+      # InnoDB data on tmpfs — no on-disk persistence, faster, and
+      # forces a clean slate every `down`.
+      - /var/lib/mysql:rw,size=512m

--- a/jobmon_server/src/jobmon/server/web/services/transition_service.py
+++ b/jobmon_server/src/jobmon/server/web/services/transition_service.py
@@ -233,29 +233,74 @@ class TransitionService:
     ) -> None:
         """Bulk create audit records with proper exited_at handling.
 
-        Uses database func.now() for timestamps.
+        Closes any open audit rows for the supplied task_ids and inserts
+        a new open row per record. Runs as a three-phase sequence to
+        avoid the next-key gap-lock cycle the original
+        ``UPDATE … WHERE exited_at IS NULL`` would trigger on the
+        ``(task_id, exited_at)`` secondary index when two transactions
+        with interleaved task_ids ran the close-then-INSERT pair
+        concurrently (InnoDB errno 1213).
+
+        The ``exited_at`` column stays nullable. NULL continues to mean
+        "no observed exit yet" — currently open OR orphaned by workflow
+        death — and downstream consumers (``MAX(exited_at)`` ignoring
+        opens, ``COALESCE(exited_at, NOW())`` duration math, the GUI's
+        ``active = !exitedAt``) keep working unchanged.
 
         Args:
             session: Database session
-            records: List of dicts with task_id, workflow_id, previous_status, new_status
+            records: List of dicts with task_id, workflow_id,
+                previous_status, new_status
         """
         if not records:
             return
 
         task_ids = [r["task_id"] for r in records]
 
-        # Bulk close previous open records
-        session.execute(
-            update(TaskStatusAudit)
-            .where(
-                TaskStatusAudit.task_id.in_(task_ids),
-                TaskStatusAudit.exited_at.is_(None),
+        # Phase 1: non-locking MVCC read finds the PKs of the rows we
+        # want to close. The (task_id, exited_at) index still speeds
+        # this up — same lookup the original migration intended, but
+        # in a non-locking context, so it contributes no gap locks to
+        # any later cycle.
+        open_audit_ids = (
+            session.execute(
+                select(TaskStatusAudit.id).where(
+                    TaskStatusAudit.task_id.in_(task_ids),
+                    TaskStatusAudit.exited_at.is_(None),
+                )
             )
-            .values(exited_at=func.now())
-            .execution_options(synchronize_session=False)
+            .scalars()
+            .all()
         )
 
-        # Bulk insert new records (entered_at uses model default)
+        # Phase 2: close by primary key. MySQL plans this via the PK
+        # (PK list is more selective than the secondary index), so the
+        # WHERE clause takes record-level X locks on specific PK rows
+        # and does NOT scan ``(task_id, exited_at)`` with an IS NULL
+        # predicate — the scan that previously took next-key gap locks
+        # across every matched entry.
+        #
+        # The residual ``IS NULL`` predicate is kept to guard against
+        # TOCTOU: if a concurrent transaction closed one of the rows
+        # we found in Phase 1, our UPDATE on that row is a no-op
+        # instead of clobbering the other transaction's exited_at
+        # with our (later) NOW().
+        if open_audit_ids:
+            session.execute(
+                update(TaskStatusAudit)
+                .where(
+                    TaskStatusAudit.id.in_(open_audit_ids),
+                    TaskStatusAudit.exited_at.is_(None),
+                )
+                .values(exited_at=func.now())
+                .execution_options(synchronize_session=False)
+            )
+
+        # Phase 3: bulk insert new opens. Insert-intention locks in the
+        # ``(task_id, NULL)`` gap are mutually compatible across
+        # transactions; they only conflict with plain gap locks, which
+        # Phase 2 no longer takes. The cycle that produced the 1213s
+        # cannot form.
         session.execute(insert(TaskStatusAudit).values(records))
 
     @classmethod

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,6 +40,102 @@ def tests(session: Session) -> None:
 
 
 @nox.session(venv_backend="venv")
+def mysql_tests(session: Session) -> None:
+    """Run tests that require a real MySQL backend.
+
+    Brings up the throwaway MySQL container from ``docker-compose.test.yml``,
+    applies migrations against it, runs only the tests gated on
+    ``JOBMON_MYSQL_TEST_URI``, then tears the container down.
+
+    Use this for InnoDB-lock-geometry regressions (e.g. the
+    ``task_status_audit`` bulk-deadlock test) — SQLite cannot reproduce the
+    REPEATABLE READ gap-lock pathology, and you should never aim these at
+    a shared MySQL instance (least of all prod).
+    """
+    session.install("uv")
+    session.run("uv", "sync", "--active", "--group", "dev")
+
+    compose_file = "docker-compose.test.yml"
+    # Use pymysql (pure Python, in default deps) rather than mysqldb
+    # (C extension, optional ``mysql`` extra, requires system libmysql
+    # on macOS). The deadlock geometry the test exercises is server-side
+    # InnoDB behavior and is identical across drivers; we only need a
+    # MySQL connection.
+    uri = (
+        "mysql+pymysql://root:test@127.0.0.1:3307/jobmon_test"
+        "?charset=utf8mb4"
+    )
+
+    # Bring the container up and wait for the healthcheck.
+    # ``--wait`` blocks until each service's healthcheck passes, so we
+    # don't have to poll docker inspect ourselves.
+    session.run(
+        "docker",
+        "compose",
+        "-f",
+        compose_file,
+        "up",
+        "-d",
+        "--wait",
+        "--wait-timeout",
+        "90",
+        external=True,
+    )
+
+    try:
+        # Apply migrations against the fresh DB. We use jobmon's own
+        # ``init_db`` rather than alembic directly so seed metadata
+        # (workflow statuses, task statuses, etc.) lands too — same path
+        # the SQLite test fixture uses.
+        session.run(
+            "python",
+            "-c",
+            (
+                "import os; "
+                f"os.environ['JOBMON__DB__SQLALCHEMY_DATABASE_URI'] = "
+                f"'{uri}'; "
+                "os.environ['JOBMON__DB__SQLALCHEMY_CONNECT_ARGS'] = '{}'; "
+                "from jobmon.server.web.db import init_db; init_db()"
+            ),
+        )
+
+        # Run only the MySQL-gated tests. Anything else (the SQLite suite)
+        # should be run via `nox -s tests`.
+        args = session.posargs or [
+            "tests/integration/server/test_audit_bulk_deadlock.py",
+        ]
+        test_env = {
+            "JOBMON_MYSQL_TEST_URI": uri,
+            "SQLALCHEMY_WARN_20": "1",
+        }
+        if sys.platform == "darwin":
+            test_env["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
+
+        session.run(
+            "coverage",
+            "run",
+            "-m",
+            "pytest",
+            "--junitxml=.test_report.mysql.xml",
+            "-v",
+            *args,
+            env=test_env,
+        )
+    finally:
+        # Tear down even on failure so re-running starts clean. `-v`
+        # removes the tmpfs volume too.
+        session.run(
+            "docker",
+            "compose",
+            "-f",
+            compose_file,
+            "down",
+            "-v",
+            external=True,
+        )
+
+
+@nox.session(venv_backend="venv")
 def lint(session: Session) -> None:
     """Lint code using various plugins.
 

--- a/tests/integration/server/test_audit_bulk_deadlock.py
+++ b/tests/integration/server/test_audit_bulk_deadlock.py
@@ -1,0 +1,486 @@
+"""Regression tests for ``TransitionService.create_audit_records_bulk``.
+
+The bulk close-then-open pattern on ``task_status_audit`` previously took the
+form ``UPDATE … WHERE task_id IN (…) AND exited_at IS NULL`` followed by an
+``INSERT`` of new open rows. Under MySQL default ``REPEATABLE READ`` against
+the ``(task_id, exited_at)`` secondary index added by migration
+``b2c3d4e5f6a7``, two transactions with interleaved ``task_id`` lists would
+deadlock: their UPDATE-stage next-key locks blocked each other's follow-on
+INSERT insert-intention locks. Production logged ~240 of these per 24 h on
+the ``INSERT INTO task_status_audit`` statement.
+
+The fix splits the close into a non-locking SELECT for primary keys followed
+by an UPDATE keyed by those PKs, with a residual ``IS NULL`` predicate to
+prevent clobbering a concurrent closer. The tests below check:
+
+  * behaviour parity — one open row closed, one new open inserted
+  * TOCTOU safety — a concurrent closer between Phase 1 and Phase 2 cannot
+    have its ``exited_at`` overwritten
+  * deadlock-free under MySQL concurrency — two threads with interleaved
+    task_id lists both commit without raising 1213. Gated on
+    ``JOBMON_MYSQL_URI`` since SQLite cannot reproduce the lock geometry.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from datetime import datetime
+from typing import List
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from jobmon.core.constants import TaskStatus
+from jobmon.server.web.models.array import Array
+from jobmon.server.web.models.cluster import Cluster
+from jobmon.server.web.models.cluster_type import ClusterType
+from jobmon.server.web.models.dag import Dag
+from jobmon.server.web.models.node import Node
+from jobmon.server.web.models.queue import Queue
+from jobmon.server.web.models.task import Task
+from jobmon.server.web.models.task_resources import TaskResources
+from jobmon.server.web.models.task_resources_type import TaskResourcesType
+from jobmon.server.web.models.task_status_audit import TaskStatusAudit
+from jobmon.server.web.models.task_template import TaskTemplate
+from jobmon.server.web.models.task_template_version import TaskTemplateVersion
+from jobmon.server.web.models.tool import Tool
+from jobmon.server.web.models.tool_version import ToolVersion
+from jobmon.server.web.models.workflow import Workflow
+from jobmon.server.web.models.workflow_run import WorkflowRun
+from jobmon.server.web.services.transition_service import TransitionService
+
+# ---------------------------------------------------------------------------
+# Local fixture — keeps this file independent of test_transition_service.py
+# (whose fixture is module-local, not in conftest, so not shareable).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workflow_with_tasks(dbsession: Session):
+    """Minimal workflow + 5 tasks for exercising the audit bulk path."""
+    cluster_type = ClusterType(name="ct_audit_bulk")
+    dbsession.add(cluster_type)
+    dbsession.flush()
+
+    cluster = Cluster(name="c_audit_bulk", cluster_type_id=cluster_type.id)
+    dbsession.add(cluster)
+    dbsession.flush()
+
+    queue = Queue(name="q_audit_bulk", cluster_id=cluster.id, parameters="{}")
+    dbsession.add(queue)
+    dbsession.flush()
+
+    task_resources_type = TaskResourcesType(id="O", label="ORIGINAL")
+    dbsession.merge(task_resources_type)
+    dbsession.flush()
+
+    tool = Tool(name="tool_audit_bulk")
+    dbsession.add(tool)
+    dbsession.flush()
+
+    tool_version = ToolVersion(tool_id=tool.id)
+    dbsession.add(tool_version)
+    dbsession.flush()
+
+    task_template = TaskTemplate(tool_version_id=tool_version.id, name="tt_audit_bulk")
+    dbsession.add(task_template)
+    dbsession.flush()
+
+    task_template_version = TaskTemplateVersion(
+        task_template_id=task_template.id,
+        command_template="echo {arg}",
+        arg_mapping_hash="arg_hash_audit_bulk",
+    )
+    dbsession.add(task_template_version)
+    dbsession.flush()
+
+    node = Node(
+        task_template_version_id=task_template_version.id,
+        node_args_hash="node_hash_audit_bulk",
+    )
+    dbsession.add(node)
+    dbsession.flush()
+
+    dag = Dag(hash="dag_hash_audit_bulk")
+    dbsession.add(dag)
+    dbsession.flush()
+
+    workflow = Workflow(
+        tool_version_id=tool_version.id,
+        dag_id=dag.id,
+        name="wf_audit_bulk",
+        workflow_args_hash="wf_hash_audit_bulk",
+        task_hash="task_hash_audit_bulk",
+        max_concurrently_running=10,
+        status="G",
+    )
+    dbsession.add(workflow)
+    dbsession.flush()
+
+    array = Array(
+        workflow_id=workflow.id,
+        task_template_version_id=task_template_version.id,
+        name="array_audit_bulk",
+        max_concurrently_running=10,
+    )
+    dbsession.add(array)
+    dbsession.flush()
+
+    workflow_run = WorkflowRun(workflow_id=workflow.id, status="R", user="test_user")
+    dbsession.add(workflow_run)
+    dbsession.flush()
+
+    task_resources = TaskResources(
+        queue_id=queue.id,
+        task_resources_type_id="O",
+        requested_resources="{}",
+    )
+    dbsession.add(task_resources)
+    dbsession.flush()
+
+    tasks = []
+    for i in range(5):
+        task = Task(
+            workflow_id=workflow.id,
+            node_id=node.id,
+            array_id=array.id,
+            task_args_hash=f"hash_audit_bulk_{i}",
+            name=f"task_audit_bulk_{i}",
+            command=f"echo task {i}",
+            status=TaskStatus.REGISTERING,
+            max_attempts=3,
+            task_resources_id=task_resources.id,
+        )
+        dbsession.add(task)
+        tasks.append(task)
+    dbsession.flush()
+
+    return {"workflow": workflow, "tasks": tasks}
+
+
+# ---------------------------------------------------------------------------
+# Behaviour parity
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAuditRecordsBulkParity:
+    """The rearranged implementation must preserve the close+insert contract."""
+
+    def test_closes_existing_open_and_inserts_new_open(
+        self, dbsession: Session, workflow_with_tasks
+    ):
+        """One open audit row → close it; new record → insert it open."""
+        tasks = workflow_with_tasks["tasks"]
+        workflow = workflow_with_tasks["workflow"]
+        task = tasks[0]
+
+        # Seed an existing open row (entered_at < now, exited_at NULL).
+        existing = TaskStatusAudit(
+            task_id=task.id,
+            workflow_id=workflow.id,
+            previous_status=None,
+            new_status=TaskStatus.REGISTERING,
+            exited_at=None,
+        )
+        dbsession.add(existing)
+        dbsession.flush()
+        existing_id = existing.id
+
+        # Trigger the bulk path with a single record for the same task.
+        TransitionService.create_audit_records_bulk(
+            session=dbsession,
+            records=[
+                {
+                    "task_id": task.id,
+                    "workflow_id": workflow.id,
+                    "previous_status": TaskStatus.REGISTERING,
+                    "new_status": TaskStatus.QUEUED,
+                }
+            ],
+        )
+        dbsession.flush()
+        # The Phase 2 UPDATE runs with synchronize_session=False (Core
+        # bulk update); the ORM identity map still has the original
+        # ``existing`` object with exited_at=None. Expire so the next
+        # read pulls fresh column values from the DB.
+        dbsession.expire_all()
+
+        rows = (
+            dbsession.execute(
+                select(TaskStatusAudit)
+                .where(TaskStatusAudit.task_id == task.id)
+                .order_by(TaskStatusAudit.id)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2, "expected the original row plus one new open row"
+
+        closed, opened = rows
+        assert closed.id == existing_id
+        assert closed.exited_at is not None, "Phase 2 must close the existing row"
+        assert opened.exited_at is None, "Phase 3 inserts the new row open"
+        assert opened.new_status == TaskStatus.QUEUED
+        assert opened.previous_status == TaskStatus.REGISTERING
+
+    def test_no_open_row_just_inserts(self, dbsession: Session, workflow_with_tasks):
+        """When no prior open row exists, Phase 2 is skipped, Phase 3 still runs."""
+        tasks = workflow_with_tasks["tasks"]
+        workflow = workflow_with_tasks["workflow"]
+        task = tasks[0]
+
+        TransitionService.create_audit_records_bulk(
+            session=dbsession,
+            records=[
+                {
+                    "task_id": task.id,
+                    "workflow_id": workflow.id,
+                    "previous_status": None,
+                    "new_status": TaskStatus.REGISTERING,
+                }
+            ],
+        )
+        dbsession.flush()
+
+        rows = (
+            dbsession.execute(
+                select(TaskStatusAudit).where(TaskStatusAudit.task_id == task.id)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].exited_at is None
+        assert rows[0].new_status == TaskStatus.REGISTERING
+
+    def test_empty_records_is_noop(self, dbsession: Session):
+        """Empty input must early-return without issuing SQL."""
+        # Just verify no exception. If a degenerate UPDATE or INSERT slipped
+        # through with an empty IN-list, SQLAlchemy would raise.
+        TransitionService.create_audit_records_bulk(session=dbsession, records=[])
+
+
+# ---------------------------------------------------------------------------
+# TOCTOU
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAuditRecordsBulkTOCTOU:
+    """A concurrent closer between Phase 1 and Phase 2 must not be clobbered."""
+
+    def test_residual_is_null_predicate_prevents_clobber(
+        self, dbsession: Session, workflow_with_tasks
+    ):
+        """Simulates the race directly: Phase 1's SELECT returns the PK of a
+        row that is already closed (as it would under MVCC if another writer
+        committed between snapshot time and our UPDATE). Phase 2's residual
+        ``IS NULL`` predicate must make the UPDATE a no-op so the existing
+        ``exited_at`` is not clobbered with ``NOW()``.
+        """
+        tasks = workflow_with_tasks["tasks"]
+        workflow = workflow_with_tasks["workflow"]
+        task = tasks[0]
+
+        # Seed a row that is ALREADY closed (the "other writer" already won).
+        pre_existing_exit = datetime(2026, 1, 1, 0, 0, 0)
+        closed = TaskStatusAudit(
+            task_id=task.id,
+            workflow_id=workflow.id,
+            previous_status=None,
+            new_status=TaskStatus.REGISTERING,
+            exited_at=pre_existing_exit,
+        )
+        dbsession.add(closed)
+        dbsession.flush()
+        closed_id = closed.id
+
+        # Force Phase 1's SELECT to return [closed_id] as if the snapshot
+        # had still shown the row as open. The Phase 2 UPDATE then targets
+        # that PK with an ``exited_at IS NULL`` residual; the actual row
+        # state is "closed", so the predicate should filter out the row.
+        real_execute = dbsession.execute
+
+        def execute_with_stale_select(stmt, *args, **kwargs):
+            sql = str(stmt).lower()
+            is_phase_1_select = (
+                "select" in sql
+                and "task_status_audit.id" in sql
+                and "exited_at is null" in sql
+            )
+            if is_phase_1_select:
+
+                class _FakeScalars:
+                    def all(self_inner):
+                        return [closed_id]
+
+                class _FakeResult:
+                    def scalars(self_inner):
+                        return _FakeScalars()
+
+                return _FakeResult()
+            return real_execute(stmt, *args, **kwargs)
+
+        with patch.object(dbsession, "execute", side_effect=execute_with_stale_select):
+            TransitionService.create_audit_records_bulk(
+                session=dbsession,
+                records=[
+                    {
+                        "task_id": task.id,
+                        "workflow_id": workflow.id,
+                        "previous_status": TaskStatus.REGISTERING,
+                        "new_status": TaskStatus.QUEUED,
+                    }
+                ],
+            )
+        dbsession.flush()
+
+        # The closed row's exited_at must STILL be the pre-existing
+        # timestamp. If the residual IS NULL filter were absent, Phase 2
+        # would have set it to NOW().
+        dbsession.expire_all()
+        refreshed = dbsession.execute(
+            select(TaskStatusAudit).where(TaskStatusAudit.id == closed_id)
+        ).scalar_one()
+        assert refreshed.exited_at == pre_existing_exit, (
+            "Phase 2's residual IS NULL predicate failed to prevent "
+            "clobbering an already-closed row"
+        )
+
+        # Phase 3 should still have inserted a new open row.
+        new_open = dbsession.execute(
+            select(TaskStatusAudit).where(
+                TaskStatusAudit.task_id == task.id,
+                TaskStatusAudit.id != closed_id,
+            )
+        ).scalar_one()
+        assert new_open.exited_at is None
+        assert new_open.new_status == TaskStatus.QUEUED
+
+
+# ---------------------------------------------------------------------------
+# MySQL deadlock-free integration
+# ---------------------------------------------------------------------------
+
+
+_MYSQL_URI = os.environ.get("JOBMON_MYSQL_TEST_URI")
+
+
+@pytest.mark.skipif(
+    not _MYSQL_URI,
+    reason=(
+        "Requires JOBMON_MYSQL_TEST_URI pointing at a MySQL 8.x instance. "
+        "SQLite cannot reproduce the (task_id, exited_at) gap-lock geometry "
+        "the fix targets, so this test is mysql-only."
+    ),
+)
+class TestCreateAuditRecordsBulkMySQLNoDeadlock:
+    """Two concurrent bulk close-then-open calls with interleaved task_ids
+    must commit cleanly across many iterations. Pre-fix code reliably
+    raises ``1213 Deadlock found`` within tens of iterations because the
+    next-key gap locks the close-UPDATE takes on
+    ``ix_task_status_audit_task_exited`` block the follow-on INSERT's
+    insert-intention locks (and vice versa for the peer transaction).
+    """
+
+    # Each thread runs N close-then-open iterations. The geometry doesn't
+    # fire on every iteration — production sees ~240/24h across the full
+    # transition fleet — so we have to make the test run many times to
+    # converge on a stable signal. With 100 iterations and interleaved
+    # task_ids, the pre-fix code reproducibly raises 1213 within a few
+    # seconds on MySQL 8.0.
+    ITERATIONS = 100
+    TASKS_PER_THREAD = 25
+
+    def _seed_audit_rows(self, engine, workflow_id: int, task_ids: List[int]) -> None:
+        """Ensure one open audit row per task_id."""
+        with Session(bind=engine) as s:
+            for tid in task_ids:
+                s.add(
+                    TaskStatusAudit(
+                        task_id=tid,
+                        workflow_id=workflow_id,
+                        previous_status=None,
+                        new_status=TaskStatus.REGISTERING,
+                        exited_at=None,
+                    )
+                )
+            s.commit()
+
+    def _reset_audit_rows(self, engine, workflow_id: int, task_ids: List[int]) -> None:
+        """Drop all audit rows for these task_ids, then reseed one open row
+        each — so the next iteration starts in a known state.
+        """
+        from sqlalchemy import delete
+
+        with Session(bind=engine) as s:
+            s.execute(
+                delete(TaskStatusAudit).where(TaskStatusAudit.task_id.in_(task_ids))
+            )
+            s.commit()
+        self._seed_audit_rows(engine, workflow_id, task_ids)
+
+    def test_interleaved_bulk_closes_do_not_deadlock(self):
+        engine = create_engine(_MYSQL_URI, future=True)
+        workflow_id = int(os.environ.get("JOBMON_TEST_WORKFLOW_ID", "999000000"))
+
+        # Interleave the two threads' task_id lists so each pair of
+        # adjacent index entries belongs to different transactions.
+        # This is the geometry that produces the cycle under the
+        # pre-fix ``UPDATE … exited_at IS NULL`` scan.
+        a_ids = [workflow_id + (2 * i + 1) for i in range(self.TASKS_PER_THREAD)]
+        b_ids = [workflow_id + (2 * i + 2) for i in range(self.TASKS_PER_THREAD)]
+        all_ids = a_ids + b_ids
+        try:
+            self._seed_audit_rows(engine, workflow_id, all_ids)
+
+            errors: list[BaseException] = []
+            barrier = threading.Barrier(2)
+
+            def run(task_ids: List[int]):
+                try:
+                    for _ in range(self.ITERATIONS):
+                        with Session(bind=engine) as s:
+                            barrier.wait(timeout=30)
+                            TransitionService.create_audit_records_bulk(
+                                session=s,
+                                records=[
+                                    {
+                                        "task_id": tid,
+                                        "workflow_id": workflow_id,
+                                        "previous_status": (TaskStatus.REGISTERING),
+                                        "new_status": TaskStatus.QUEUED,
+                                    }
+                                    for tid in task_ids
+                                ],
+                            )
+                            s.commit()
+                except BaseException as e:  # noqa: BLE001
+                    # On first error, abort the barrier so the peer
+                    # doesn't block forever.
+                    errors.append(e)
+                    barrier.abort()
+
+            t1 = threading.Thread(target=run, args=(a_ids,))
+            t2 = threading.Thread(target=run, args=(b_ids,))
+            t1.start()
+            t2.start()
+            t1.join(timeout=120)
+            t2.join(timeout=120)
+
+            assert not errors, (
+                f"Concurrent bulk-close raised across {self.ITERATIONS} "
+                "iterations — the rearrangement is not eliminating the "
+                f"deadlock on this MySQL version. First error: {errors[0]!r}"
+            )
+        finally:
+            # Always cleanup so the test is re-runnable.
+            from sqlalchemy import delete
+
+            with Session(bind=engine) as s:
+                s.execute(
+                    delete(TaskStatusAudit).where(TaskStatusAudit.task_id.in_(all_ids))
+                )
+                s.commit()


### PR DESCRIPTION
## Summary

Fixes the ~240/24h ``1213 Deadlock found`` errors on
``INSERT INTO task_status_audit`` that became chronic after migration ``b2c3d4e5f6a7`` added the ``(task_id, exited_at)`` secondary index. The retry inside ``transition_tasks`` was masking deadlocks on the bulk-transition path, but the bind/reset callers (``task.py:132,167,475``, ``task_repository.py:168``, ``workflow_repository.py:311``) have no surrounding retry — their deadlocks surface as **HTTP 423** to clients (353 such in the same 24h window).

## Mechanism

Two concurrent ``create_audit_records_bulk`` calls with interleaved ``task_id`` lists, under MySQL default ``REPEATABLE READ``:

1. ``UPDATE … WHERE task_id IN (…) AND exited_at IS NULL`` scans the ``(task_id, exited_at)`` secondary index with an ``IS NULL`` predicate. InnoDB takes **next-key locks** (record + gap before) on every matched entry.
2. The follow-on ``INSERT`` wants an **insert-intention lock** in the ``(task_id, NULL)`` gap where the new row will live.
3. A plain gap lock blocks an insert-intention lock in the same gap — the one asymmetric blocking case in InnoDB's gap-lock rules. A waits for B; B waits for A. 1213 fires.

## Fix

Split the close into three phases:

```
Phase 1: SELECT id WHERE task_id IN (…) AND exited_at IS NULL
         — plain MVCC read, no locks
Phase 2: UPDATE WHERE id IN (pks) AND exited_at IS NULL
         — PK-driven, no secondary-index scan ⇒ no next-key gap locks.
         Residual IS NULL keeps TOCTOU safety: if a peer closed the
         row first, our UPDATE is a no-op (same as today's WHERE).
Phase 3: INSERT new opens
         — insert-intention locks in the (task_id, NULL) gap are
         mutually compatible across transactions.
```

The cycle can't form because the only thing that produced it — plain gap locks from Phase 1's IS NULL scan — is gone.

**NULL semantics preserved.** ``exited_at`` stays nullable. NULL still distinguishes *currently open* from *orphaned by workflow death*. ``MAX(exited_at)``, ``COALESCE(exited_at, NOW())``, the GUI's ``active = !exitedAt`` all behave unchanged. No schema migration. No API contract change.

Net production diff: **+25 LoC** in one method in ``transition_service.py``.

## Verification

Pre/post-fix run against MySQL 8.0.44 (pinned to prod's exact version):

| State | Result |
|---|---|
| Pre-fix code + new test | **FAILS** with ``(1213, 'Deadlock found when trying to get lock; try restarting transaction')`` within <1s |
| Post-fix code + new test | **PASSES** across 200 bulk operations (2 threads × 100 iterations) |
| Full SQLite suite (``nox -s tests``) | 1175 passed, 7 skipped |

## What's in the PR

- **Production fix** (``transition_service.py``): single method rewrite, +25 net LoC.
- **Tests** (``tests/integration/server/test_audit_bulk_deadlock.py``):
  - Behaviour parity (close+open semantics preserved)
  - TOCTOU (Phase 1 returns a stale PK → Phase 2 IS-NULL residual no-ops, doesn't clobber)
  - Empty input / no-prior-open edge cases
  - **MySQL-only deadlock-free integration** (gated on ``JOBMON_MYSQL_TEST_URI`` since SQLite can't reproduce the gap-lock geometry)
- **Tooling**:
  - ``docker-compose.test.yml``: pinned ``mysql:8.0.44``, ``REPEATABLE-READ``, tmpfs-backed (no disk state)
  - ``nox -s mysql_tests``: brings the container up with ``--wait``, applies migrations, runs the gated tests, tears it down with ``-v`` in a ``finally``
  - Uses ``mysql+pymysql`` (pure-Python, already in default deps) rather than ``mysqldb`` (C extension, optional ``mysql`` extra requiring system libs) — the deadlock geometry is server-side InnoDB behavior, identical across drivers.

## Test plan

- [x] ``nox -s tests`` — full SQLite suite green (1175 passed)
- [x] ``nox -s mysql_tests`` with fix — passes
- [x] ``nox -s mysql_tests`` with fix reverted — fails with exact 1213 expected
- [x] ``nox -s format`` / ``lint`` / ``typecheck`` — green (verified by pre-commit hooks)
- [ ] Reviewer: skim the design rationale in the commit message and the test docstrings; verify the residual ``IS NULL`` in Phase 2 is intentional (it is — TOCTOU safety)

## What this PR does NOT fix

Two pre-existing races that are unchanged from today's code and out of scope here:

1. **Multi-caller race on the same task** — ``create_audit_records_bulk`` doesn't enforce single-open-row uniqueness, so two bind/reset callers racing on the same task can produce two open audit rows. Fixing this needs a partial unique index (MySQL doesn't support; Postgres does) or a per-task lock at the audit layer. Tracked separately if it bites.
2. **Server-side load-induced timeouts** — orthogonal class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the SQL write pattern for `task_status_audit` bulk updates to avoid InnoDB deadlocks; correctness depends on subtle concurrency/locking behavior (now covered by new MySQL-only regression tests and tooling).
> 
> **Overview**
> Prevents MySQL `1213 Deadlock found` errors during bulk task transitions by restructuring `TransitionService.create_audit_records_bulk` into a **three-phase** sequence: MVCC `SELECT` open audit row PKs, PK-targeted `UPDATE` to close them (with a residual `exited_at IS NULL` guard), then `INSERT` new open rows—avoiding the prior `UPDATE ... exited_at IS NULL` secondary-index scan that induced gap locks.
> 
> Adds a MySQL-only integration regression suite (`tests/integration/server/test_audit_bulk_deadlock.py`) covering behavior parity, TOCTOU safety, and concurrent interleaved bulk calls, plus a `docker-compose.test.yml` MySQL 8.0.44 fixture and a new `nox -s mysql_tests` session to spin up the container, run migrations, execute the gated tests, and tear down. Also ignores the new `.test_report.mysql.xml` artifact in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77ea96a64ff6356d49fb1784bfbeed6c109c124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->