### PR TITLE
Surface distributor startup breadcrumbs on DistributorStartupTimeout

### DIFF
--- a/jobmon_client/src/jobmon/client/workflow.py
+++ b/jobmon_client/src/jobmon/client/workflow.py
@@ -55,10 +55,14 @@ class DistributorContext:
         self._cluster_name = cluster_name
         self._workflow_run_id = workflow_run_id
         self._timeout = timeout
+        # Everything the distributor wrote to stderr while we waited for the
+        # ALIVE signal. Holds the JOBMON_PHASE startup breadcrumbs so a startup
+        # timeout can report which phase the distributor reached before hanging.
+        self._startup_stderr = ""
 
     def wait_for_startup_signal(self, timeout: int = 180) -> bool:
         """Wait for startup signal with non-blocking reads to handle timing issues."""
-        buffer = ""
+        self._startup_stderr = ""
         start_time = time.time()
 
         assert self.process.stderr is not None  # keep mypy happy
@@ -71,14 +75,8 @@ class DistributorContext:
         while time.time() - start_time < timeout:
             try:
                 chunk = self.process.stderr.read(100)
-                if chunk:
-                    buffer += chunk
-                    # Look for startup signal (handles package warnings naturally)
-                    if "ALIVE" in buffer:
-                        logger.info("Received startup signal")
-                        return True
             except BlockingIOError:
-                # No data available, check if process died
+                # No data available right now; bail out if the process died.
                 if self.process.poll() is not None:
                     logger.error(
                         f"Distributor process exited with code: "
@@ -86,8 +84,31 @@ class DistributorContext:
                     )
                     return False
                 time.sleep(0.1)
+                continue
             except Exception as e:
                 logger.warning(f"Error reading stderr: {e}")
+                time.sleep(0.1)
+                continue
+
+            if chunk:
+                # Accumulate on self so a timeout can surface the breadcrumbs.
+                self._startup_stderr += chunk
+                # Look for startup signal (handles package warnings naturally)
+                if "ALIVE" in self._startup_stderr:
+                    logger.info("Received startup signal")
+                    return True
+            elif self.process.poll() is not None:
+                # EOF: the distributor closed stderr and exited before
+                # signalling. Without this branch read() returns "" forever and
+                # we busy-spin to the full timeout instead of failing fast and
+                # surfacing the breadcrumbs captured so far.
+                logger.error(
+                    f"Distributor process exited with code: "
+                    f"{self.process.returncode}"
+                )
+                return False
+            else:
+                # No data but process still alive; avoid a hot spin loop.
                 time.sleep(0.1)
 
         return False
@@ -122,17 +143,54 @@ class DistributorContext:
 
         # Use simple non-blocking startup detection
         if not self.wait_for_startup_signal(self._timeout):
-            stderr_all = ""
+            # wait_for_startup_signal consumes the distributor's stderr as it
+            # polls for ALIVE, so the JOBMON_PHASE breadcrumbs already live in
+            # self._startup_stderr. Drain anything still buffered and append it.
+            startup_stderr = self._startup_stderr
             try:
-                _, stderr_all = self.process.communicate(timeout=5)
+                _, remaining = self.process.communicate(timeout=5)
             except TimeoutExpired:
-                pass
+                remaining = ""
             err = self._shutdown()
+            full_stderr = "".join(
+                part for part in (startup_stderr, remaining, err) if part
+            )
+            last_phase = self._last_startup_phase(full_stderr)
+            # The raised exception is invisible in ES for non-interactive runs
+            # (e.g. svc_* nightly batches), but the jobmon.client.workflow
+            # logger exports reliably. Log the captured breadcrumbs here so the
+            # stalled startup phase is diagnosable from telemetry alone.
+            logger.error(
+                "Distributor failed to emit startup signal before timeout",
+                workflow_run_id=self._workflow_run_id,
+                timeout_s=self._timeout,
+                last_startup_phase=last_phase,
+                distributor_stderr=full_stderr,
+            )
             raise DistributorStartupTimeout(
-                f"Distributor process did not start within {self._timeout}s, "
-                f"stderr='{err}'\n\nFull stderr: {stderr_all}"
+                f"Distributor process did not start within {self._timeout}s "
+                f"(last startup phase reached: {last_phase}).\n"
+                f"Full stderr:\n{full_stderr}"
             )
         return self
+
+    @staticmethod
+    def _last_startup_phase(stderr: str) -> str:
+        """Return the last ``JOBMON_PHASE`` breadcrumb seen in captured stderr.
+
+        Distinguishes where the distributor hung: e.g. ``cluster_bound``
+        (reached but no ``cluster_interface_built``) implicates the
+        SlurmDistributor constructor's ``shutil.which`` over a slow shared
+        filesystem, while ``cli_entered`` / ``context_bound`` point at Python
+        import or interpreter startup. ``"none"`` means no breadcrumb was
+        captured at all (process never produced output).
+        """
+        last_phase = "none"
+        for line in stderr.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("JOBMON_PHASE:"):
+                last_phase = stripped.split(":", 1)[1].strip()
+        return last_phase
 
     def __exit__(
         self,

--- a/tests/integration/client/test_distributor_context.py
+++ b/tests/integration/client/test_distributor_context.py
@@ -125,7 +125,7 @@ sys.stderr.write("Starting up...\\n")
 sys.stderr.flush()
 time.sleep(0.5)
 
-sys.stderr.write("Still starting...\\n") 
+sys.stderr.write("Still starting...\\n")
 sys.stderr.flush()
 time.sleep(0.5)
 
@@ -169,6 +169,79 @@ time.sleep(2)  # This should cause timeout
                     test_process.communicate(timeout=2)
                 except subprocess.TimeoutExpired:
                     test_process.kill()
+
+        finally:
+            os.unlink(script_path)
+
+    def test_timeout_surfaces_startup_breadcrumbs(self):
+        """A startup timeout must surface the captured JOBMON_PHASE breadcrumbs.
+
+        wait_for_startup_signal consumes the distributor's stderr while polling
+        for ALIVE; if that buffer is discarded the breadcrumbs never reach the
+        DistributorStartupTimeout body or the log, leaving startup hangs
+        undiagnosable in production. This locks in that the last reached phase
+        is reported both in the exception body and via the logger (the channel
+        that reaches telemetry for non-interactive svc_* runs).
+        """
+        test_script = """#!/usr/bin/env python3
+import sys
+import time
+
+# Emit breadcrumbs up to cluster_bound, then hang without ALIVE -- the
+# signature of a shutil.which / cluster-interface stall.
+sys.stderr.write("JOBMON_PHASE: cli_entered\\n")
+sys.stderr.flush()
+sys.stderr.write("JOBMON_PHASE: context_bound\\n")
+sys.stderr.flush()
+sys.stderr.write("JOBMON_PHASE: cluster_bound\\n")
+sys.stderr.flush()
+time.sleep(30)  # hang past the timeout
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(test_script)
+            script_path = f.name
+
+        try:
+            os.chmod(script_path, 0o755)
+
+            with patch("jobmon.client.workflow.Popen") as mock_popen, patch(
+                "jobmon.client.workflow.logger"
+            ) as mock_logger:
+                test_process = subprocess.Popen(
+                    [sys.executable, script_path],
+                    stderr=subprocess.PIPE,
+                    universal_newlines=True,
+                )
+                mock_popen.return_value = test_process
+
+                distributor_context = DistributorContext("sequential", 12345, 2)
+
+                try:
+                    with distributor_context:
+                        assert False, "Should have timed out"
+                except DistributorStartupTimeout as exc:
+                    # Last reached phase is reported in the exception body...
+                    assert "last startup phase reached: cluster_bound" in str(exc)
+                    # ...and the full breadcrumb trail is preserved.
+                    assert "context_bound" in str(exc)
+
+                # ...and logged with the phase as structured context so the
+                # stall is diagnosable from telemetry alone.
+                error_calls = [
+                    c
+                    for c in mock_logger.error.call_args_list
+                    if c.kwargs.get("last_startup_phase") == "cluster_bound"
+                ]
+                assert error_calls, "timeout phase was not logged"
+                assert "cluster_bound" in error_calls[0].kwargs["distributor_stderr"]
+
+                if test_process.poll() is None:
+                    test_process.terminate()
+                    try:
+                        test_process.communicate(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        test_process.kill()
 
         finally:
             os.unlink(script_path)


### PR DESCRIPTION
## Why

FHS (and other) production controllers are dying at the bind/launch phase: the
workflow binds (G→L→B in <1s), the orchestrator spawns the distributor
subprocess and blocks in `wait_for_startup_signal`, the distributor never emits
`ALIVE` within `distributor_startup_timeout` (default 180s), and the orchestrator
raises `DistributorStartupTimeout` and dies — leaving the run stranded at BOUND.
This scales with concurrent launches (nightly `svc_fhs` golden batch stalled 9
mortality workflows on one node in ~40s).

Investigation confirmed the failure end-to-end from the orchestrator's own logs
(every stuck golden-batch run: `Starting Distributor Process` → 185s of silence →
`No shutdown confirmation received`). But we **cannot tell which startup phase
hangs**, because the `JOBMON_PHASE` breadcrumbs added in a17a552d were being lost
two ways:

1. `wait_for_startup_signal` accumulated the distributor's stderr into a **local
   `buffer` that it discarded** on timeout, so the follow-up `communicate()` found
   nothing left to read and the exception body still showed `stderr=''`.
2. The exception was **raised but never logged**, so it never reached ES — fatal
   for non-interactive `svc_*` nightly runs whose only durable trace is the
   orchestrator's `jobmon.client.workflow` logs.

## What

- **Persist** the consumed stderr on `self._startup_stderr` so the breadcrumbs
  survive the wait loop.
- On timeout, **log at ERROR** via the orchestrator logger (confirmed to export
  reliably) with a parsed `last_startup_phase` label + full stderr, and embed the
  same in the exception body.
- **Fail fast on EOF:** when the distributor closes stderr and exits, `read()`
  returns `""` (not `BlockingIOError`), so the dead-process `poll()` check was
  skipped and the loop spun to the full 180s. Detect EOF and return immediately.

After deploy, a stuck run logs `last_startup_phase=<phase>`, queryable in ES:
`cluster_bound` ⇒ the `SlurmDistributor` ctor's `shutil.which` over a slow shared
filesystem; `cli_entered`/`context_bound` ⇒ import/interpreter startup;
`workflow_run_set` reached ⇒ the B→I HTTP call.

This is the **observability gate** for confirming the root cause; it does not by
itself fix the startup hang or reap pre-RUNNING stranded runs (follow-ups).

## Tests

- New `test_timeout_surfaces_startup_breadcrumbs`: a distributor that emits
  breadcrumbs up to `cluster_bound` then hangs must report `cluster_bound` in
  both the exception body and the structured log.
- Existing startup/pollution/timeout and breadcrumb-protocol tests still pass.
- `nox -s format / lint / typecheck` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)